### PR TITLE
Allow specifying author for revisions and tags

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -5,4 +5,5 @@ pytest-isort==0.*
 pytest-mypy==0.*; python_version > '3.5'
 pytest-env==0.*
 pytest-cov==2.*
+pytest-vcr==1.*
 sphinx-autodoc-typehints[type_comments]==1.10.*; python_version >= '3.5'

--- a/dev-requirements.py2.txt
+++ b/dev-requirements.py2.txt
@@ -9,16 +9,17 @@ attrs==19.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via isort
 click==7.1.2              # via pip-tools
 configparser==4.0.2       # via flake8, importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, vcrpy, zipp
 coverage==5.1             # via pytest-cov
 enum34==1.1.10            # via flake8
 flake8==3.8.2             # via pytest-flake8
-funcsigs==1.0.2           # via pytest
+funcsigs==1.0.2           # via mock, pytest
 functools32==3.2.3.post2  # via flake8
 futures==3.3.0            # via isort
 importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 isort==4.3.21             # via pytest-isort
 mccabe==0.6.1             # via flake8
+mock==3.0.5               # via vcrpy
 more-itertools==5.0.0     # via pytest
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via importlib-metadata, pytest
@@ -32,11 +33,15 @@ pytest-cov==2.9.0         # via -r dev-requirements.in
 pytest-env==0.6.2         # via -r dev-requirements.in
 pytest-flake8==1.0.6      # via -r dev-requirements.in
 pytest-isort==0.3.1       # via -r dev-requirements.in
-pytest==4.6.10            # via -r dev-requirements.in, pytest-cov, pytest-env, pytest-flake8, pytest-isort
+pytest-vcr==1.0.2         # via -r dev-requirements.in
+pytest==4.6.10            # via -r dev-requirements.in, pytest-cov, pytest-env, pytest-flake8, pytest-isort, pytest-vcr
+pyyaml==5.3.1             # via vcrpy
 scandir==1.10.0           # via pathlib2
-six==1.15.0               # via more-itertools, packaging, pathlib2, pip-tools, pytest
+six==1.15.0               # via mock, more-itertools, packaging, pathlib2, pip-tools, pytest, vcrpy
 typing==3.7.4.1           # via flake8
+vcrpy==3.0.0              # via pytest-vcr
 wcwidth==0.1.9            # via pytest
+wrapt==1.12.1             # via vcrpy
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev-requirements.py3.txt
+++ b/dev-requirements.py3.txt
@@ -15,7 +15,7 @@ coverage==5.1             # via pytest-cov
 docutils==0.16            # via sphinx
 filelock==3.0.12          # via pytest-mypy
 flake8==3.8.2             # via pytest-flake8
-idna==2.9                 # via requests
+idna==2.9                 # via requests, yarl
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 isort==4.3.21             # via pytest-isort
@@ -23,6 +23,7 @@ jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==8.3.0     # via pytest
+multidict==4.7.6          # via yarl
 mypy-extensions==0.4.3    # via mypy
 mypy==0.770               # via pytest-mypy
 packaging==20.4           # via pytest, sphinx
@@ -38,10 +39,12 @@ pytest-env==0.6.2         # via -r dev-requirements.in
 pytest-flake8==1.0.6      # via -r dev-requirements.in
 pytest-isort==0.3.1       # via -r dev-requirements.in
 pytest-mypy==0.6.2 ; python_version > "3.5"  # via -r dev-requirements.in
-pytest==4.6.10            # via -r dev-requirements.in, pytest-cov, pytest-env, pytest-flake8, pytest-isort, pytest-mypy
+pytest-vcr==1.0.2         # via -r dev-requirements.in
+pytest==4.6.10            # via -r dev-requirements.in, pytest-cov, pytest-env, pytest-flake8, pytest-isort, pytest-mypy, pytest-vcr
 pytz==2020.1              # via babel
+pyyaml==5.3.1             # via vcrpy
 requests==2.23.0          # via sphinx
-six==1.15.0               # via packaging, pip-tools, pytest
+six==1.15.0               # via packaging, pip-tools, pytest, vcrpy
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autodoc-typehints[type_comments]==1.10.3 ; python_version >= "3.5"  # via -r dev-requirements.in
 sphinx==3.0.4             # via sphinx-autodoc-typehints
@@ -54,7 +57,10 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 typed-ast==1.4.1          # via mypy, sphinx-autodoc-typehints
 typing-extensions==3.7.4.2  # via mypy
 urllib3==1.25.9           # via requests
+vcrpy==4.0.2              # via pytest-vcr
 wcwidth==0.1.9            # via pytest
+wrapt==1.12.1             # via vcrpy
+yarl==1.4.2               # via vcrpy
 zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/metastore/backend/__init__.py
+++ b/metastore/backend/__init__.py
@@ -2,7 +2,7 @@
 """
 from typing import Any, Dict, List, Optional
 
-from metastore.types import DataPackageType, PackageRevisionInfo, TagInfo
+from metastore.types import Author, DataPackageType, PackageRevisionInfo, TagInfo
 from metastore.util import get_callable
 
 BACKEND_CLASSES = {'github': 'metastore.backend.gh:GitHubStorage',
@@ -12,8 +12,8 @@ BACKEND_CLASSES = {'github': 'metastore.backend.gh:GitHubStorage',
 class StorageBackend(object):
     """Abstract interface for storage backend classes
     """
-    def create(self, package_id, metadata, change_desc=None):
-        # type: (str, DataPackageType, Optional[str]) -> PackageRevisionInfo
+    def create(self, package_id, metadata, author=None, message=None):
+        # type: (str, DataPackageType, Optional[Author], Optional[str]) -> PackageRevisionInfo
         """Create a new data package
         """
         raise NotImplementedError("This method is not implemented for this backend")
@@ -21,11 +21,13 @@ class StorageBackend(object):
     def fetch(self, package_id, revision_ref=None):
         # type: (str, Optional[str]) -> PackageRevisionInfo
         """Fetch a data package, potentially at a given revision / tag
+
+        :raises metastore.backend.exc.NotFound: Raised if the package or referenced revision do not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
-    def update(self, package_id, metadata, partial=False, base_revision_ref=None, update_description=None):
-        # type: (str, DataPackageType, bool, Optional[str], Optional[str]) -> PackageRevisionInfo
+    def update(self, package_id, metadata, author=None, partial=False, message=None, base_revision_ref=None):
+        # type: (str, DataPackageType, Optional[Author], bool, Optional[str], Optional[str]) -> PackageRevisionInfo
         """Update or partial update (patch) a data package
         """
         raise NotImplementedError("This method is not implemented for this backend")
@@ -33,6 +35,8 @@ class StorageBackend(object):
     def delete(self, package_id):
         # type: (str) -> None
         """Delete a data package
+
+        :raises metastore.backend.exc.NotFound: Raised if the package does not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
@@ -44,6 +48,8 @@ class StorageBackend(object):
         will not be set in the return value. If you need to access the actual package
         metadata and not just revision information, fetch the package data by calling
         :meth:`fetch`.
+
+        :raises metastore.backend.exc.NotFound: Raised if the package does not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
@@ -52,18 +58,24 @@ class StorageBackend(object):
         """Get info about a specific revision of a data package
 
         NOTE: this does not fetch the data package metadata itself, just info about a revision of it
+
+        :raises metastore.backend.exc.NotFound: Raised if the package or revision do not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
-    def tag_create(self, package_id, revision_ref, name, description=None):
-        # type: (str, str, str, Optional[str]) -> TagInfo
+    def tag_create(self, package_id, revision_ref, name, author=None, description=None):
+        # type: (str, str, str, Optional[Author], Optional[str]) -> TagInfo
         """Create a tag (named reference to a revision of a data package)
+
+        :raises metastore.backend.exc.NotFound: Raised if the package or referenced revision do not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
     def tag_list(self, package_id):
         # type: (str) -> List[TagInfo]
         """Get list of tags for a package
+
+        :raises metastore.backend.exc.NotFound: Raised if the package does not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
@@ -72,18 +84,25 @@ class StorageBackend(object):
         """Get info about a specific tag of a data package
 
         NOTE: this does not fetch the data package metadata itself, just info about a revision of it
+
+        :raises metastore.backend.exc.NotFound: Raised if the package or tag do not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
-    def tag_update(self, package_id, tag, new_name=None, new_description=None):
-        # type: (str, str, Optional[str], Optional[str]) -> TagInfo
+    def tag_update(self, package_id, tag, author=None, new_name=None, new_description=None):
+        # type: (str, str, Optional[Author], Optional[str], Optional[str]) -> TagInfo
         """Modify existing tag name or description
+
+        :raises metastore.backend.exc.NotFound: Raised if the package or tag do not exist
+        :raises metastore.backend.exc.Conflict: Raised if the tag name is already in use by another tag
         """
         raise NotImplementedError("This method is not implemented for this backend")
 
     def tag_delete(self, package_id, tag):
         # type: (str, str) -> None
-        """Delete an existing tag
+        """Delete an existing
+
+        :raises metastore.backend.exc.NotFound: Raised if the package or tag do not exist
         """
         raise NotImplementedError("This method is not implemented for this backend")
 

--- a/metastore/backend/filesystem.py
+++ b/metastore/backend/filesystem.py
@@ -170,7 +170,7 @@ class FilesystemStorage(StorageBackend):
 
         with self._fs.open(db_file, 'ab') as f:
             line = [revision, now, message, author.name, author.email]
-            f.write('{}\n'.format(json.dumps(line)))
+            f.write('{}\n'.format(json.dumps(line)).encode('utf8'))
         return PackageRevisionInfo(package_id, revision, now, author, message)
 
     def _get_revisions(self, package_id):
@@ -217,7 +217,7 @@ class FilesystemStorage(StorageBackend):
 
             with tags_dir.open(tag_name, 'wb') as f:
                 line = [now.isoformat(), revision.revision, tag_description, author.name, author.email]
-                json.dump(line, f)
+                f.write(json.dumps(line).encode('utf8'))
         return TagInfo(revision.package_id, tag_name, now, revision.revision, author, revision,
                        description=tag_description)
 

--- a/metastore/backend/filesystem.py
+++ b/metastore/backend/filesystem.py
@@ -180,7 +180,7 @@ class FilesystemStorage(StorageBackend):
         db_file = u'{}/{}'.format(_get_package_path(package_id), self.REVISION_DB_FILE)
         with self._fs.open(db_file, 'r') as f:
             lines = [json.loads(line) for line in f]
-            revisions = [_parse_rev_log(package_id, l) for l in reversed(lines)]
+            revisions = [_parse_rev_log(package_id, line) for line in reversed(lines)]
         return revisions
 
     def _get_revision(self, package_id, revision):

--- a/metastore/backend/filesystem.py
+++ b/metastore/backend/filesystem.py
@@ -17,7 +17,7 @@ from dateutil.parser import isoparse
 from fs import open_fs
 from fs.errors import DirectoryExists, ResourceNotFound
 
-from ..types import PackageRevisionInfo, TagInfo
+from ..types import Author, PackageRevisionInfo, TagInfo
 from . import StorageBackend, exc
 
 
@@ -32,15 +32,16 @@ class FilesystemStorage(StorageBackend):
 
     See the PyFilesystem documentation for types of supported file systems.
     """
-    REVISION_DB_FILE = 'revisions.csv'
+    REVISION_DB_FILE = 'revisions.jsonl'
 
     TAG_NAME_RE = re.compile(r'^[\w\-+.,]+\Z')
 
-    def __init__(self, uri):
-        # type: (str) -> None
+    def __init__(self, uri, default_author=None):
+        # type: (str, Optional[Author]) -> None
         self._fs = open_fs(uri)
+        self._default_author = default_author
 
-    def create(self, package_id, metadata, revision_desc=None):
+    def create(self, package_id, metadata, author=None, message=None):
         try:
             package_dir = self._fs.makedirs(_get_package_path(package_id))
         except DirectoryExists:
@@ -50,7 +51,7 @@ class FilesystemStorage(StorageBackend):
         with self._fs.lock():
             with package_dir.open(revision, 'wb') as f:
                 f.write(json.dumps(metadata).encode('utf8'))
-            rev_info = self._log_revision(package_id, revision, revision_desc)
+            rev_info = self._log_revision(package_id, revision, author, message)
         rev_info.package = metadata
         return rev_info
 
@@ -75,7 +76,7 @@ class FilesystemStorage(StorageBackend):
 
         return revision
 
-    def update(self, package_id, metadata, partial=False, base_revision_ref=None, update_description=None):
+    def update(self, package_id, metadata, author=None, partial=False, base_revision_ref=None, message=None):
         current = self.fetch(package_id, base_revision_ref)
 
         if partial:
@@ -86,7 +87,7 @@ class FilesystemStorage(StorageBackend):
             revision = _make_revision_id()
             with self._fs.open(u'{}/{}'.format(_get_package_path(package_id), revision), 'wb') as f:
                 f.write(json.dumps(metadata).encode('utf8'))
-            rev_info = self._log_revision(package_id, revision, update_description)
+            rev_info = self._log_revision(package_id, revision, author, message)
         rev_info.package = metadata
         return rev_info
 
@@ -113,11 +114,11 @@ class FilesystemStorage(StorageBackend):
             raise exc.NotFound('Could not find package {}@{}', package_id, revision_ref)
         return revision
 
-    def tag_create(self, package_id, revision_ref, name, description=None):
+    def tag_create(self, package_id, revision_ref, name, author=None, description=None):
         if not self._validate_tag_name(name):
             raise ValueError("Invalid tag name: {}".format(name))
         revision = self.revision_fetch(package_id, revision_ref)
-        return self._log_tag(revision, name, description)
+        return self._log_tag(revision, name, author, description)
 
     def tag_list(self, package_id):
         return self._get_tags(package_id)
@@ -133,7 +134,7 @@ class FilesystemStorage(StorageBackend):
         tag_info.revision = self.revision_fetch(package_id, tag_info.revision_ref)
         return tag_info
 
-    def tag_update(self, package_id, tag, new_name=None, new_description=None):
+    def tag_update(self, package_id, tag, author=None, new_name=None, new_description=None):
         if new_name is None and new_description is None:
             raise ValueError("Expecting at least one of new_name or new_description to be specified")
         elif new_name and not self._validate_tag_name(new_name):
@@ -145,7 +146,7 @@ class FilesystemStorage(StorageBackend):
         overwrite = tag_info.name == name
 
         with self._fs.lock():
-            tag_info = self._log_tag(tag_info.revision, name, description, allow_overwrite=overwrite)
+            tag_info = self._log_tag(tag_info.revision, name, author, description, allow_overwrite=overwrite)
             if not overwrite:
                 self.tag_delete(package_id, tag)
 
@@ -159,17 +160,18 @@ class FilesystemStorage(StorageBackend):
             except ResourceNotFound:
                 raise exc.NotFound('Could not find tag {} for package {}', tag, package_id)
 
-    def _log_revision(self, package_id, revision, revision_desc=None):
-        # type: (str, str, Optional[str]) -> PackageRevisionInfo
+    def _log_revision(self, package_id, revision, author, message=None):
+        # type: (str, str, Optional[Author], Optional[str]) -> PackageRevisionInfo
         """Log a revision
         """
         db_file = u'{}/{}'.format(_get_package_path(package_id), self.REVISION_DB_FILE)
         now = datetime.now(tz=pytz.utc).isoformat()
+        author = self._verify_author(author)
+
         with self._fs.open(db_file, 'ab') as f:
-            encoded_desc = base64.b64encode(revision_desc.encode('utf8')) if revision_desc else b''
-            line = '{},{},{}\n'.format(revision, now, encoded_desc.decode('utf8'))
-            f.write(line.encode('utf8'))
-        return PackageRevisionInfo(package_id, revision, now, revision_desc)
+            line = [revision, now, message, author.name, author.email]
+            f.write('{}\n'.format(json.dumps(line)))
+        return PackageRevisionInfo(package_id, revision, now, author, message)
 
     def _get_revisions(self, package_id):
         # type: (str) -> List[PackageRevisionInfo]
@@ -177,8 +179,9 @@ class FilesystemStorage(StorageBackend):
         """
         db_file = u'{}/{}'.format(_get_package_path(package_id), self.REVISION_DB_FILE)
         with self._fs.open(db_file, 'r') as f:
-            rev_data = [line.split(',', 2) for line in f]
-        return [_parse_rev_log(package_id, r) for r in reversed(rev_data)]
+            lines = [json.loads(line) for line in f]
+            revisions = [_parse_rev_log(package_id, l) for l in reversed(lines)]
+        return revisions
 
     def _get_revision(self, package_id, revision):
         # type: (str, str) -> PackageRevisionInfo
@@ -189,7 +192,7 @@ class FilesystemStorage(StorageBackend):
         db_file = u'{}/{}'.format(_get_package_path(package_id), self.REVISION_DB_FILE)
         with self._fs.open(db_file, 'r') as f:
             for line in f:
-                rev_data = line.split(',', 2)
+                rev_data = json.loads(line)
                 if rev_data[0] == revision:
                     return _parse_rev_log(package_id, rev_data)
 
@@ -199,23 +202,24 @@ class FilesystemStorage(StorageBackend):
         """
         return bool(self.TAG_NAME_RE.match(name))
 
-    def _log_tag(self, revision, tag_name, tag_description, allow_overwrite=False):
-        # type: (PackageRevisionInfo, str, str) -> TagInfo
+    def _log_tag(self, revision, tag_name, author, tag_description, allow_overwrite=False):
+        # type: (PackageRevisionInfo, str, Optional[Author], str, bool) -> TagInfo
         """Log a new tag for an existing revision
         """
         tags_path = u'{}/{}'.format(_get_package_path(revision.package_id), 'tags')
         now = datetime.now(tz=pytz.utc)
         tags_dir = self._fs.makedirs(tags_path, recreate=True)
+        author = self._verify_author(author)
 
         with tags_dir.lock():
             if not allow_overwrite and tags_dir.exists(tag_name):
                 raise exc.Conflict('Tag already exists: {}'.format(tag_name))
 
             with tags_dir.open(tag_name, 'wb') as f:
-                f.write('{},{},'.format(now.isoformat(), revision.revision).encode('utf8'))
-                if tag_description:
-                    f.write(base64.b64encode(tag_description.encode('utf8')))
-        return TagInfo(revision.package_id, tag_name, now, revision.revision, revision, description=tag_description)
+                line = [now.isoformat(), revision.revision, tag_description, author.name, author.email]
+                json.dump(line, f)
+        return TagInfo(revision.package_id, tag_name, now, revision.revision, author, revision,
+                       description=tag_description)
 
     def _get_tag(self, package_id, tag_name):
         # type: (str, str) -> Optional[TagInfo]
@@ -228,11 +232,11 @@ class FilesystemStorage(StorageBackend):
             if not tag_dir:
                 return None
             with tag_dir.open(tag_name, 'r') as f:
-                line = f.read()
+                line = json.load(f)
         except ResourceNotFound:
             return None
 
-        return _parse_tag_file_content(package_id, tag_name, line)
+        return _tag_file_to_taginfo(package_id, tag_name, line)
 
     def _get_tags(self, package_id):
         # type: (str) -> List[TagInfo]
@@ -245,8 +249,8 @@ class FilesystemStorage(StorageBackend):
 
         for tag_name in tag_dir.listdir('.'):
             with tag_dir.open(tag_name, 'r') as f:
-                tag_line = f.read()
-            tags.append(_parse_tag_file_content(package_id, tag_name, tag_line))
+                tag_line = json.load(f)
+            tags.append(_tag_file_to_taginfo(package_id, tag_name, tag_line))
 
         return sorted(tags, key=attrgetter('created'))
 
@@ -262,6 +266,16 @@ class FilesystemStorage(StorageBackend):
             return package_dir.opendir('tags')
         except ResourceNotFound:
             return None
+
+    def _verify_author(self, author):
+        # type: (Optional[Author]) -> Author
+        """Verify that we have a valid author object
+        """
+        if author:
+            return author
+        if self._default_author:
+            return self._default_author
+        return Author(None, None)
 
 
 def _get_package_path(package_id):
@@ -297,15 +311,33 @@ def _parse_rev_log(package_id, rev_data):
     # type: (str, List[str]) -> PackageRevisionInfo
     """Parse a line from the revision log and return a RevisionInfo object
     """
-    return PackageRevisionInfo(package_id, rev_data[0], isoparse(rev_data[1]),
-                               description=_decode_text_blob(rev_data[2]))
+    if rev_data[3] or rev_data[4]:
+        author = Author(name=rev_data[3] or None,
+                        email=rev_data[4] or None)
+    else:
+        author = None
+
+    return PackageRevisionInfo(package_id=package_id,
+                               revision=rev_data[0],
+                               created=isoparse(rev_data[1]),
+                               author=author,
+                               description=rev_data[2])
 
 
-def _parse_tag_file_content(package_id, tag_name, tag_line):
+def _tag_file_to_taginfo(package_id, tag_name, tag_data):
     # type: (str, str, str) -> TagInfo
-    tag_data = tag_line.split(',', 2)
-    return TagInfo(package_id, tag_name, isoparse(tag_data[0]), tag_data[1],
-                   description=_decode_text_blob(tag_data[2]))
+    if tag_data[3] or tag_data[4]:
+        author = Author(name=tag_data[3] or None,
+                        email=tag_data[4] or None)
+    else:
+        author = None
+
+    return TagInfo(package_id=package_id,
+                   name=tag_name,
+                   created=isoparse(tag_data[0]),
+                   revision_ref=tag_data[1],
+                   description=tag_data[2],
+                   author=author)
 
 
 def _decode_text_blob(encoded_desc):

--- a/metastore/backend/gh.py
+++ b/metastore/backend/gh.py
@@ -304,6 +304,27 @@ def _is_sha(ref, chars=40):
         return False
     return True
 
+
+def _get_git_matching_refs(repo, ref):
+    """This is backported from PyGithub 1.51 to support Python 2.7 which is no
+    longer supported for that version.
+
+    If we ever drop Python 2.7 support, this code is no longer needed and
+    :meth:``github.Repository.Repository.get_git_matching_refs`` can be called
+    directly.
+    """
+    if hasattr(repo, 'get_git_matching_refs'):
+        return repo.get_git_matching_refs(ref)
+
+    assert isinstance(ref, str), ref
+    return PaginatedList.PaginatedList(
+        GitRef.GitRef,
+        repo._requester,
+        repo.url + "/git/matching-refs/" + ref,
+        None,
+    )
+
+
 # class CKANGitClient(object):
 #
 #     def __init__(self, token, pkg_dict):
@@ -441,23 +462,3 @@ def _is_sha(ref, chars=40):
 #
 #         except Exception as e:
 #             return False
-
-
-def _get_git_matching_refs(repo, ref):
-    """This is backported from PyGithub 1.51 to support Python 2.7 which is no
-    longer supported for that version.
-
-    If we ever drop Python 2.7 support, this code is no longer needed and
-    :meth:``github.Repository.Repository.get_git_matching_refs`` can be called
-    directly.
-    """
-    if hasattr(repo, 'get_git_matching_refs'):
-        return repo.get_git_matching_refs(ref)
-
-    assert isinstance(ref, str), ref
-    return PaginatedList.PaginatedList(
-        GitRef.GitRef,
-        repo._requester,
-        repo.url + "/git/matching-refs/" + ref,
-        None,
-    )

--- a/metastore/backend/gh.py
+++ b/metastore/backend/gh.py
@@ -6,12 +6,14 @@ revisions and tags. This implementation is based on GitHub's Web API, and will
 not support other Git hosting services.
 """
 import json
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from github import (AuthenticatedUser, Commit, GitCommit, Github, GithubException, GitRef, GitTag, InputGitTreeElement,
                     Organization, PaginatedList, Repository, UnknownObjectException)
+from github.GithubObject import NotSet
+from github.InputGitAuthor import InputGitAuthor
 
-from ..types import PackageRevisionInfo, TagInfo
+from ..types import Author, PackageRevisionInfo, TagInfo
 from . import StorageBackend, exc
 
 
@@ -28,15 +30,16 @@ class GitHubStorage(StorageBackend):
     DEFAULT_COMMIT_MESSAGE = 'Datapackage updated'
     DEFAULT_TAG_MESSAGE = 'Tagging revision'
 
-    def __init__(self, github_options, default_owner=None, default_branch=DEFAULT_BRANCH,
+    def __init__(self, github_options, default_owner=None, default_author=None, default_branch=DEFAULT_BRANCH,
                  default_commit_message=DEFAULT_COMMIT_MESSAGE):
         self.gh = Github(**github_options)
         self._default_owner = default_owner
+        self._default_author = default_author
         self._default_branch = default_branch
         self._default_commit_message = default_commit_message
         self._user = None
 
-    def create(self, package_id, metadata, change_desc=None):
+    def create(self, package_id, metadata, author=None, message=None):
         owner, repo_name = self._parse_id(package_id)
 
         try:
@@ -46,8 +49,8 @@ class GitHubStorage(StorageBackend):
                 raise exc.Conflict("Datapackage with the same ID already exists")
             raise
 
-        if change_desc is None:
-            change_desc = 'Initial datapackage commit'
+        if message is None:
+            message = 'Initial datapackage commit'
 
         try:
             datapackage = self._create_file('datapackage.json', json.dumps(metadata, indent=2))
@@ -55,7 +58,7 @@ class GitHubStorage(StorageBackend):
             # Create an initial README.md file so we can start using the low-level Git API
             repo.create_file('README.md', 'Initialize data repository', self.DEFAULT_README)
             head = repo.get_branch(self._default_branch)
-            commit = self._create_commit(repo, [datapackage], head.commit, change_desc)
+            commit = self._create_commit(repo, [datapackage], head.commit, author, message)
 
             # TODO: handle resources / Git LFS config and pointer files
 
@@ -63,7 +66,8 @@ class GitHubStorage(StorageBackend):
             self.delete(package_id)
             raise
 
-        return PackageRevisionInfo(package_id, commit.sha, commit.author.date, change_desc, metadata)
+        c_author = Author(commit.author.name, commit.author.email)
+        return PackageRevisionInfo(package_id, commit.sha, commit.author.date, c_author, message, metadata)
 
     def fetch(self, package_id, revision_ref=None):
         repo = self._get_repo(package_id)
@@ -91,14 +95,15 @@ class GitHubStorage(StorageBackend):
         except ValueError:
             raise ValueError("Unable to parse datapackage.json file in {}@{}".format(package_id, revision_ref))
 
-        return PackageRevisionInfo(package_id, commit.sha, commit.author.date, commit.message, datapackage)
+        author = Author(commit.author.name, commit.author.email)
+        return PackageRevisionInfo(package_id, commit.sha, commit.author.date, author, commit.message, datapackage)
 
-    def update(self, package_id, metadata, partial=False, base_revision_ref=None, update_description=None):
+    def update(self, package_id, metadata, author=None, partial=False, base_revision_ref=None, message=None):
         parent = self.fetch(package_id, base_revision_ref)
         owner, repo_name = self._parse_id(package_id)
 
-        if update_description is None:
-            update_description = self._default_commit_message
+        if message is None:
+            message = self._default_commit_message
 
         if partial:
             parent.package.update(metadata)
@@ -108,8 +113,9 @@ class GitHubStorage(StorageBackend):
         datapackage = self._create_file('datapackage.json', json.dumps(metadata, indent=2))
         repo = self._get_owner(owner).get_repo(repo_name)
         head = repo.get_branch(self._default_branch)
-        commit = self._create_commit(repo, [datapackage], head.commit, update_description)
-        return PackageRevisionInfo(package_id, commit.sha, commit.author.date, update_description, metadata)
+        commit = self._create_commit(repo, [datapackage], head.commit, author, message)
+        c_author = Author(commit.author.name, commit.author.email)
+        return PackageRevisionInfo(package_id, commit.sha, commit.author.date, c_author, message, metadata)
 
     def delete(self, package_id):
         repo = self._get_repo(package_id)
@@ -124,14 +130,15 @@ class GitHubStorage(StorageBackend):
     def revision_fetch(self, package_id, revision_ref):
         return self.fetch(package_id, revision_ref)
 
-    def tag_create(self, package_id, revision_ref, name, description=None):
+    def tag_create(self, package_id, revision_ref, name, author=None, description=None):
         repo = self._get_repo(package_id)
         revision = self.revision_fetch(package_id, revision_ref)
         if description is None:
             description = self.DEFAULT_TAG_MESSAGE
 
-        git_tag = self._create_tag(repo, name, description, revision_ref)
-        return TagInfo(package_id, name, git_tag.tagger.date, revision_ref, revision, description)
+        git_tag = self._create_tag(repo, name, description, revision_ref, author)
+        t_author = Author(git_tag.tagger.name, git_tag.tagger.email)
+        return TagInfo(package_id, name, git_tag.tagger.date, revision_ref, t_author, revision, description)
 
     def tag_list(self, package_id):
         repo = self._get_repo(package_id)
@@ -149,7 +156,7 @@ class GitHubStorage(StorageBackend):
             raise exc.NotFound('Could not find tag {} for package {}', tag, package_id)
         return self._tag_ref_to_taginfo(package_id, repo, ref)
 
-    def tag_update(self, package_id, tag, new_name=None, new_description=None):
+    def tag_update(self, package_id, tag, author=None, new_name=None, new_description=None):
         if new_name is None and new_description is None:
             raise ValueError("Expecting at least one of new_name or new_description to be specified")
 
@@ -162,13 +169,15 @@ class GitHubStorage(StorageBackend):
             # Nothing to change here
             return tag_info
         elif name != tag_info.name:
-            git_tag = self._create_tag(repo, name, description, tag_info.revision_ref)
+            git_tag = self._create_tag(repo, name, description, tag_info.revision_ref, author)
             repo.get_git_ref('tags/{}'.format(tag_info.name)).delete()
         else:
             git_tag = repo.create_git_tag(name, description, tag_info.revision_ref, 'commit')
             repo.get_git_ref('tags/{}'.format(name)).edit(git_tag.sha)
 
-        return TagInfo(package_id, name, git_tag.tagger.date, tag_info.revision_ref, tag_info.revision, description)
+        t_author = Author(git_tag.tagger.name, git_tag.tagger.email)
+        return TagInfo(package_id, name, git_tag.tagger.date, tag_info.revision_ref, t_author, tag_info.revision,
+                       description)
 
     def tag_delete(self, package_id, tag):
         repo = self._get_repo(package_id)
@@ -210,26 +219,28 @@ class GitHubStorage(StorageBackend):
         except UnknownObjectException:
             raise exc.NotFound('Could not find package {}', package_id)
 
-    def _create_commit(self, repo, files, parent_commit, message):
-        # type: (Repository, List[InputGitTreeElement], Commit, str) -> GitCommit
+    def _create_commit(self, repo, files, parent_commit, author, message):
+        # type: (Repository, List[InputGitTreeElement], Commit, Optional[Author], str) -> GitCommit
         """Create a git Commit
         """
         # Create tree
         tree = repo.create_git_tree(files, parent_commit.commit.tree)
         # Create commit
-        commit = repo.create_git_commit(message, tree, [parent_commit.commit])
+        author = self._verify_author(author)
+        commit = repo.create_git_commit(message, tree, [parent_commit.commit], author=author)
         # Update refs
         ref = repo.get_git_ref('heads/{}'.format(self._default_branch))
         ref.edit(commit.sha)
 
         return commit
 
-    def _create_tag(self, repo, name, description, revision_ref):
-        # type: (Repository.Repository, str, str, str) -> GitTag.GitTag
+    def _create_tag(self, repo, name, description, revision_ref, author):
+        # type: (Repository.Repository, str, str, str, Optional[Author]) -> GitTag.GitTag
         """Low level operations for creating a git tag
         """
+        author = self._verify_author(author)
         try:
-            git_tag = repo.create_git_tag(name, description, revision_ref, 'commit')
+            git_tag = repo.create_git_tag(name, description, revision_ref, 'commit', tagger=author)
             repo.create_git_ref('refs/tags/{}'.format(name), git_tag.sha)
         except GithubException as e:
             if e.status == 422:
@@ -241,13 +252,26 @@ class GitHubStorage(StorageBackend):
 
         return git_tag
 
+    def _verify_author(self, author):
+        # type: (Optional[Author]) -> Union[InputGitAuthor, NotSet]
+        """Check we have an author and return something Git can use to set commit / tag author
+        """
+        if author and (author.name or author.email):
+            return InputGitAuthor(author.name, author.email)
+        elif self._default_author:
+            return InputGitAuthor(self._default_author.name, self._default_author.email)
+        else:
+            return NotSet
+
     def _tag_ref_to_taginfo(self, package_id, repo, ref):
         # type: (str, Repository.Repository, GitRef.GitRef) -> TagInfo
         """Convert a GitRef for a tag into a TagInfo object
         """
         tag_obj = repo.get_git_tag(ref.object.sha)
         revision = self.revision_fetch(package_id, tag_obj.object.sha)
-        return TagInfo(package_id, tag_obj.tag, tag_obj.tagger.date, tag_obj.object.sha, revision, tag_obj.message)
+        author = Author(tag_obj.tagger.name, tag_obj.tagger.email)
+        return TagInfo(package_id, tag_obj.tag, tag_obj.tagger.date, tag_obj.object.sha, author, revision,
+                       tag_obj.message)
 
     @staticmethod
     def _create_file(path, content):
@@ -263,6 +287,7 @@ def _commit_to_revinfo(package_id, commit):
     return PackageRevisionInfo(package_id,
                                commit.sha,
                                commit.commit.author.date,
+                               Author(commit.commit.author.name, commit.commit.author.email),
                                commit.commit.message)
 
 

--- a/metastore/types.py
+++ b/metastore/types.py
@@ -8,19 +8,40 @@ from typing import Any, Dict, Optional
 DataPackageType = Dict[str, Any]
 
 
+# Data classes. If this was Python 3.7+, we could have used dataclasses here ;)
+class Author(object):
+    """Revision / tag author information
+    """
+    name = None  # type: Optional[str]
+    email = None  # type: Optional[str]
+
+    def __init__(self, name=None, email=None):
+        self.name = name
+        self.email = email
+
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.name == other.name and self.email == other.email
+
+    def __repr__(self):
+        return '<Author {}>'.format(self.email)
+
+
 class PackageRevisionInfo(object):
     """Revision information
     """
     package_id = None  # type: str
     revision = None  # type: str
     created = None  # type: datetime
+    author = None  # type: Optional[Author]
     description = None  # type: Optional[str]
     package = None  # type: Optional[DataPackageType]
 
-    def __init__(self, package_id, revision, created, description=None, package=None):
+    def __init__(self, package_id, revision, created, author=None, description=None, package=None):
         self.package_id = package_id
         self.revision = revision
         self.created = created
+        self.author = author
         self.description = description
         self.package = package
 
@@ -37,14 +58,16 @@ class TagInfo(object):
     name = None  # type: str
     created = None  # type: datetime
     revision_ref = None  # type: str
+    author = None  # type: Optional[Author]
     revision = None  # type: Optional[PackageRevisionInfo]
     description = None  # type: Optional[str]
 
-    def __init__(self, package_id, name, created, revision_ref, revision=None, description=None):
+    def __init__(self, package_id, name, created, revision_ref, author=None, revision=None, description=None):
         self.package_id = package_id
         self.name = name
         self.created = created
         self.revision_ref = revision_ref
+        self.author = author
         self.revision = revision
         self.description = description
 

--- a/tests/backend/__init__.py
+++ b/tests/backend/__init__.py
@@ -96,9 +96,9 @@ class CommonBackendTestSuite(object):
     def test_revision_list_multiple_revisions(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
         p2 = backend.update(self.dataset_id('mydataset'), {"type": "csv"}, partial=True,
-                            update_description="Set type to csv")
+                            message="Set type to csv")
         p3 = backend.update(self.dataset_id('mydataset'), {"type": "xls"}, partial=True,
-                            update_description="Set type to xls")
+                            message="Set type to xls")
 
         revs = backend.revision_list(self.dataset_id('mydataset'))
         assert len(revs) == 3
@@ -112,9 +112,9 @@ class CommonBackendTestSuite(object):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
         p2 = backend.create(self.dataset_id('otherdataset'), create_test_datapackage('otherdataset'))
         p3 = backend.update(self.dataset_id('mydataset'), {"type": "csv"}, partial=True,
-                            update_description="Set type to csv")
+                            message="Set type to csv")
         p4 = backend.update(self.dataset_id('otherdataset'), {"type": "xls"}, partial=True,
-                            update_description="Set type to xls")
+                            message="Set type to xls")
 
         revs = backend.revision_list(self.dataset_id('mydataset'))
         assert len(revs) == 2
@@ -131,7 +131,7 @@ class CommonBackendTestSuite(object):
     def test_revision_fetch(self, backend):
         backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
         p2 = backend.update(self.dataset_id('mydataset'), {"type": "csv"}, partial=True,
-                            update_description="Set type to csv")
+                            message="Set type to csv")
 
         rev = backend.revision_fetch(p2.package_id, p2.revision)
         assert p2.revision == rev.revision
@@ -150,11 +150,11 @@ class CommonBackendTestSuite(object):
 
     def test_tag_create_fetch(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        r1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', 'My nice little tag')
-        t1 = backend.tag_fetch(p1.package_id, 'version-1.0')
-        assert t1.revision == r1.revision
-        assert t1.name == 'version-1.0'
-        assert t1.description == 'My nice little tag'
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description='My nice little tag')
+        t2 = backend.tag_fetch(p1.package_id, 'version-1.0')
+        assert t2.revision == t1.revision
+        assert t2.name == 'version-1.0'
+        assert t2.description == 'My nice little tag'
 
     @pytest.mark.parametrize('name', [
         'with space',
@@ -170,8 +170,8 @@ class CommonBackendTestSuite(object):
 
     def test_tag_create_fetch_substring_names(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        r1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
-        r2 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0.0', "This is a different tag")
+        r1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
+        r2 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0.0', description="This is a different tag")
         t1 = backend.tag_fetch(p1.package_id, 'version-1.0')
         assert t1.revision == r1.revision
         assert t1.name == 'version-1.0'
@@ -181,10 +181,10 @@ class CommonBackendTestSuite(object):
 
     def test_tag_create_existing_name(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         p2 = backend.update(self.dataset_id('mydataset'), create_test_datapackage('mydataset', type='csv'))
         with pytest.raises(exc.Conflict):
-            backend.tag_create(p1.package_id, p2.revision, 'version-1.0', "Next Tag with Same Name")
+            backend.tag_create(p1.package_id, p2.revision, 'version-1.0', description="Next Tag with Same Name")
 
     def test_tag_fetch_no_tag(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
@@ -193,17 +193,17 @@ class CommonBackendTestSuite(object):
 
     def test_tag_fetch_no_package(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         with pytest.raises(exc.NotFound):
             backend.tag_fetch(self.dataset_id('otherdataset'), 'version-1.0')
 
     def test_tag_list(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "First version")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="First version")
         p2 = backend.update(self.dataset_id('mydataset'), create_test_datapackage('mydataset', type='csv'))
-        backend.tag_create(p1.package_id, p2.revision, 'version-1.1', "Second version")
+        backend.tag_create(p1.package_id, p2.revision, 'version-1.1', description="Second version")
         p3 = backend.create(self.dataset_id('otherdataset'), create_test_datapackage('otherdataset'))
-        backend.tag_create(p3.package_id, p3.revision, 'version-1.0', "First version")
+        backend.tag_create(p3.package_id, p3.revision, 'version-1.0', description="First version")
 
         tags = backend.tag_list(self.dataset_id('mydataset'))
         assert len(tags) == 2
@@ -214,7 +214,7 @@ class CommonBackendTestSuite(object):
 
     def test_tag_list_no_tags(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "First version")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="First version")
         backend.create(self.dataset_id('otherdataset'), create_test_datapackage('otherdataset'))
 
         tags = backend.tag_list(self.dataset_id('otherdataset'))
@@ -226,7 +226,7 @@ class CommonBackendTestSuite(object):
 
     def test_tag_update(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         t2 = backend.tag_update(p1.package_id, t1.name, new_name='v-1.0', new_description='My newer better tag')
 
         with pytest.raises(exc.NotFound):
@@ -241,7 +241,7 @@ class CommonBackendTestSuite(object):
 
     def test_tag_update_desc_only(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         backend.tag_update(p1.package_id, t1.name, new_description='My newer better tag')
 
         p2 = backend.fetch(p1.package_id, revision_ref=t1.name)
@@ -253,7 +253,7 @@ class CommonBackendTestSuite(object):
 
     def test_tag_update_name_only(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         t2 = backend.tag_update(p1.package_id, t1.name, new_name='v-1.0')
 
         with pytest.raises(exc.NotFound):
@@ -269,15 +269,15 @@ class CommonBackendTestSuite(object):
 
     def test_tag_update_no_chance(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         with pytest.raises(ValueError):
             backend.tag_update(p1.package_id, t1.name)
 
     def test_tag_update_existing_name(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
         p2 = backend.update(self.dataset_id('mydataset'), create_test_datapackage('mydataset', type='csv'))
-        t2 = backend.tag_create(p1.package_id, p2.revision, 'version-1.1', "My next version tag")
+        t2 = backend.tag_create(p1.package_id, p2.revision, 'version-1.1', description="My next version tag")
 
         with pytest.raises(exc.Conflict):
             backend.tag_update(p1.package_id, t1.name, new_name=t2.name)
@@ -296,18 +296,18 @@ class CommonBackendTestSuite(object):
 
     def test_tag_update_invalid_name(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "My nice little tag")
+        t1 = backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="My nice little tag")
 
         with pytest.raises(ValueError):
             backend.tag_update(p1.package_id, t1.name, new_name='ver 1.0')
 
     def test_tag_delete(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "First version")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="First version")
         p2 = backend.update(self.dataset_id('mydataset'), create_test_datapackage('mydataset', type='csv'))
-        backend.tag_create(p1.package_id, p2.revision, 'version-1.1', "Second version")
+        backend.tag_create(p1.package_id, p2.revision, 'version-1.1', description="Second version")
         p3 = backend.create(self.dataset_id('otherdataset'), create_test_datapackage('otherdataset'))
-        backend.tag_create(p3.package_id, p3.revision, 'version-1.0', "First version")
+        backend.tag_create(p3.package_id, p3.revision, 'version-1.0', description="First version")
 
         tags = backend.tag_list(self.dataset_id('mydataset'))
         assert len(tags) == 2
@@ -321,14 +321,14 @@ class CommonBackendTestSuite(object):
 
     def test_tag_delete_no_tag(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "First version")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="First version")
 
         with pytest.raises(exc.NotFound):
             backend.tag_delete(p1.package_id, 'version-1.1')
 
     def test_tag_delete_no_package(self, backend):
         p1 = backend.create(self.dataset_id('mydataset'), create_test_datapackage('mydataset'))
-        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', "First version")
+        backend.tag_create(p1.package_id, p1.revision, 'version-1.0', description="First version")
 
         with pytest.raises(exc.NotFound):
             backend.tag_delete(self.dataset_id('otherdataset'), 'version-1.0')

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_create_fetch.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_create_fetch.yaml
@@ -1,0 +1,1520 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:27 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D0461:3ADA62E:5ED65FB3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3897'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:28 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D0495:3ADA660:5ED65FB3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3896'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268820973,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjA5NzM=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:18:28Z","updated_at":"2020-06-02T14:18:28Z","pushed_at":"2020-06-02T14:18:29Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:29 GMT
+      etag:
+      - '"a29db355737a78e7a85d4986cb5c3c47"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D04CD:3ADA69F:5ED65FB4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3895'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"4dc8712104ecdfb4392b79bef27c14f9764b59f1","node_id":"MDY6Q29tbWl0MjY4ODIwOTczOjRkYzg3MTIxMDRlY2RmYjQzOTJiNzliZWYyN2MxNGY5NzY0YjU5ZjE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/4dc8712104ecdfb4392b79bef27c14f9764b59f1","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/4dc8712104ecdfb4392b79bef27c14f9764b59f1","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:30Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:30Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:30 GMT
+      etag:
+      - '"c0a5423ce34f0569c4bee67af9c5563e"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D060C:3ADA81B:5ED65FB5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3894'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aMBT+K1WeaXMhEECatodWUydB1Y5d0mlCjnOSmDl2Zju0gPrfdxzStfDQ
+        NVX31heU2Pk+f+fqw9YRpARn4pREG1BOz6GyLJlxJltHFwQ3wpSOIj/wvRBomiVhfxwk0TiBLIio
+        H2bjaBgmg3HmI1TIFBYsRdD0NB5eBmOTfOPedBmHF6fnNxdzurlYXv2KN3l/Oj+/nZ5e8Ti4KuPl
+        5eZi/onNNpxdf4vXs2B6O/sYD2ab2IuXXwbXy7N3e7pIbQqprMJW++eCFEQdna2UFPgllIRxFIH6
+        cfkE7PKH3C6eoHH4QUqMNTnwAu/YGx57wdwPJ/5o0veunbt7D1hv/LcjStCa5FbEuWCGEc42cISy
+        yJGCSmpmpFqjUKMAv7mPhJ954zQL+lE0CsLIDwcjSINgTKIkCUc0wp1RGvXBQ2CtrAMKYyo9cV1S
+        sZOcmaJOrAPc5gi3BIMhlwqOOUuODWijXfu7WJRrq0SDcRHkWg3affbZ6L9XPHyXjNrtkIQWAsIs
+        qKwFprHXc1agWMYoMQzTA725ewfM04xwDT1HAdF2y6mFZrnAnZ5jH4ipFfpf1Jz3nIqsuSQIsq93
+        r2fmC0wsTMkX+15+FN7nBHZ36Avcqg/OfXFqdTXbbeOqMTYPDYDLnNnA6aKpctyz7Wc4GAz7++3o
+        cvj1+4zTZezP5vHGcqwwx9WhNc2iDtpqqTUoKoXBdGoKp3Yb5verdyEy5KrlaDrev4rOcmn3QefT
+        MXz4LpOcyxvEHkrdr+k9evcvCFXtnpnIuxMgaOtKUwD6CeXfWaMZ9okuTA1gi50EOwtLLYVGFytI
+        u5C0EBRzI1DHtmlhDVedaKpYZUu7k6w9IBJJlRPBNk2P6ESEQJuSTU/tYlIDQCCsMLs6IXeIrVsp
+        tiJ0bd2ggAJboU+7sx1AkcysK3sxfcGIWw8zAwuSlrbMmnZ5eEG+lWB7rb6VYLfKeSvB3aWFzWyv
+        ep9VghVRtm84kx8/sSAXnIlf+IKTIvDsNSa/RBFBCxz8/v4vsBfWI+aOA4edIu+5UHClpAFqHs1g
+        7Uo7ooEgCd+b0H7XzF4aeBOYWi9QGt0ZDCKTikIz8nFsf1ajzDJ0YnNz37Y+ejgTT3i6Tz9/PD5w
+        Enbkxiprw90fzQ59clkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:30 GMT
+      etag:
+      - W/"16384fec87a6649e56a6f2f71a4c3ec4"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D06BE:3ADA90B:5ED65FB6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3893'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:31 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D06E3:3ADA93D:5ED65FB6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3892'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/4dc8712104ecdfb4392b79bef27c14f9764b59f1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPJIBxwodUqYesqlQi0aZZrUhVRQYGMDUQ2Wa7Icp/77jpob3t
+        Su3FwvOYeW/ejK9EN5wkhJVFFPrU9xgUZZWzIKZ5GOdQ0bDwWRWHK5Yv48onDumHEk6ixKR0na0e
+        aWzyZ+mlbcZ2682P3aGYdu3+ezbVQXrYvKbrvczovsvax2l3+Cy2kxTH5+yypenr9lO23E6Zl7VP
+        y2P78AGLj0pi4caYs05cl5/FohamGfNFMXSugvOg3Q4M12ZQMJcinxvQRrv2PJ26S8kRA+NikosZ
+        nUDsHa01ppOnvyX8Qf8W4jvpezj5aJpBkeRKet4BNv+l4Q1Xs4cXNfToCHRcWE9wThhegA1/rG3Q
+        eoI/YM82jXrUm3uruUcPPkv8KAm8I7k55K7IwH+kMApQwfX3KvmVF5cVDcIwoiz02TKCktKYh3nO
+        oiJEJCrDALx/O22rQbtv5kZjOtCa19a6TS+M4FJMMLMLNPu1ZwJX7IIaz1xBbzRJvn5zyAsoUYmC
+        G4GzwY7vd8DHUHGpwSEKuLYQGXst6h4Rh9gPbkaFVP0opS15kQPHJHu93X4C5Zws5IQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:31 GMT
+      etag:
+      - W/"24542ce1de498f046a38a652c0061a66"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:30 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D0727:3ADA98A:5ED65FB7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3891'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["4dc8712104ecdfb4392b79bef27c14f9764b59f1"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"7efd80774d7979dd26d2446cdf093c5f42123a62","node_id":"MDY6Q29tbWl0MjY4ODIwOTczOjdlZmQ4MDc3NGQ3OTc5ZGQyNmQyNDQ2Y2RmMDkzYzVmNDIxMjNhNjI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7efd80774d7979dd26d2446cdf093c5f42123a62","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/7efd80774d7979dd26d2446cdf093c5f42123a62","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:31Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:31Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"4dc8712104ecdfb4392b79bef27c14f9764b59f1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/4dc8712104ecdfb4392b79bef27c14f9764b59f1","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/4dc8712104ecdfb4392b79bef27c14f9764b59f1"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:32 GMT
+      etag:
+      - '"320364bbc131c24c8f855c2fa317c33d"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7efd80774d7979dd26d2446cdf093c5f42123a62
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D074C:3ADA9BF:5ED65FB7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3890'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBRF/4tnWpNgGpK5orSSlQWC6BL54xm7ipMofi1Kq/53XsXIwsByl/vO
+        u+fCJnCsumXiHpRNPKqEMLE71g8W2mCplWu5eotNlIcPUa+3X/WrOdf9rtv38qQ2jd+/yJN+fz7b
+        TTMTeJw6gjzimCrO1RiWnwH9US/NEPkE40AjgDQzTLDogl4gJEz8lm0bZ6uoA+QE0fVvr0EfwCCr
+        Lix5RUPCmqciy7N7AcY6LR7KXBelBpcXJhOuLFZCP5YuIzOcRyCCPGLA/zX9+Zn4n22u12+9sof6
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:32 GMT
+      etag:
+      - W/"1c22d23a686b24a918ea4cc671fe4b4d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:30 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D07C8:3ADAA45:5ED65FB8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3889'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "7efd80774d7979dd26d2446cdf093c5f42123a62"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWpfUJCRz1QKSlQWC6BI5uQt2FcdRfC1Kq/53rmJkYWB5y7vv
+        3ncRE3aiuGWUFg1E6U0knMSdGAJg7YBbvdHpm6+8PnyocvP8Vb6253J46feDPpldZfdP+tS8b8+w
+        q2YGj1PPkCUaYyGlGd3y05E9Nss2eDnhGHgEiWfChIveNQvCSFHesq79DIY7JMkQX//2Cs0BWxLF
+        RURreCjDDh5XWaYgy7McIEkhUSptoVvl6/ahU8l9sjZpwmY0j8gEe3hH/2v68zPKP9tcr9/hGhmK
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:33 GMT
+      etag:
+      - W/"11470890effa4922e01d255f22fa9881"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D07F4:3ADAA8A:5ED65FB8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3888'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:33 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D087D:3ADAB1A:5ED65FB9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3887'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjpNnEwGJbYNsFCmQDFD1s9yJQEi0xkUSVpOw6Qt69/5CS
+        JbvexHF4zCWxafKb4XBmOJx2ItPJfHZ1fT2b3ny4OJlUKhURjU1uP/+2uiv+KJIvN4/825/LpHpY
+        f73PLm/vf/356+Ptxwkm81JgphXGRlG5TrnlRlj8sGiKIup+LQVGrdLitJDxKc017P8rai2X3IK2
+        4IURJxO1qoSezNtJoTJZQcgeDASRpldX0w+z2fX5jvLru4eb9ffZ7w3/Vufpl2IZ3/89u/2crG/v
+        s3+xlEMe11GjC9Bza2szZ8wPmouzTNq8iRsjdKIqKyp7lqiSNawX9mn58RKQTHcYZzIM7OBq2ZH8
+        cuAM27+T3JbFjjJeB7dy/5qFKgq1AnN3FweKZRsAnZmDySp7GwyAlimbC5gW230iI0mc+bFUt7hl
+        9A9+STiDY9MiPRbYLYeS5GJPLdOiVo7bxCbRsrZSVUeruwUBVOmMV/KRvwkKiAGLFD1aMbcYELGE
+        Mx9N8atb5sI1WZPZtEiEXOI83kbewQBs1zVll7uRBemUpBURT0tKCi5XPJ0gel8ZO3sSUCo2hz+Z
+        V8hfFBH6YZOQng1sZ9x9QbpHEFFfsP/BOAQwYLDKg1gHYxKrZfjbxVuCxMBjpTmSeDAhW9CWjb+S
+        U1nBy2CyHAzQXKlwlncwQKUxjTjI9w8/Vcc0rA+2qiljn0kPCbHDxXga9sCNkVklRDCLb4At6y+B
+        WPMqycOJ6Hkt85+c1/As2BaIBWRcqDgYExc6c8CWmZz7q9FGIbUmCcTbEqDFIugWiLcRYHVAv3Hq
+        E3CDx21t4ULB9O95rO1OoOBV1vAsnIQNkC4rlCoZf3yxQjs8Zgci8FSaahk3YRPzwKQd+KII+Sfc
+        EQzIQYCrup4v6V5hpFEl58xUlvKlmudweofbCrHAIigOdsXQ95dLt9dtg3gtG+4Xf5l1kkKdRneb
+        9fqP5XVvq2Cu1fNY+1PNbU4ZFmJrrkWozXQ41sZ46j6dnZ21ueDuWVIKHTCLeBqwXCc5yutQ+rc9
+        D5Vjya17/ixI/RTPoULxNNhZbICAexcItQdPG/tRjXo9mOIONqaXskDXQlXh7oiBOJZTKSsXMjnk
+        rXh4mG9B209GVok44XjeICqsTCTiBE928gAU+SKcFT0N20OPyD8TC4GQCXZKWnhey3xXIBV1odZB
+        M+QISYlECzSo0ohbPEpn09n0dHp1Op39dX45P7+ez66/Y05Towf2wzkXFzSnbkz+whSk/y5W8Ald
+        qecbQbtvTOo4QY4x+QD5ZUDM9/SSfoBICjj9TtQep8ty925/HQbbyVUpatRp/ePcyEd8nm7VWIlq
+        KpwOBlfc4rGBmmUY6uuyHpBzE/lMMplb3aDnSCO1VvcisWY8NmSy0cSVfJBbC6mG3HQL/CN/EF5K
+        rVXXbPTNhS4Po23YdTxTaXhciGFA1aLqNBxvQyaiMhsz+AYAbXk0fcsE7ksqFrwpbOTfStRORU8W
+        DVa4o9AlzEA9L2q3dp0VbxBy1X6PlBX9ZzRcrCjryHuHVQ+C+rNAIauoVWT+aThcz11g/WL/ixvC
+        Vqga2/5FC7pOt9ekCHC0erzGEYrDjtg3iMdtofc+cRO/94nf+8TvfWLfaafrb0+fuBJ2hYbpKJuO
+        n7d9tn76D23yk0QVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:34 GMT
+      etag:
+      - W/"67edcba8eed123760b9c1a2d911e11ce"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D08AC:3ADAB61:5ED65FB9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3886'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWpfUJCRz1QKSlQWC6BI5uQt2FcdRfC1Kq/53rmJkYWB5y7vv
+        3ncRE3aiuGWUFg1E6U0knMSdGAJg7YBbvdHpm6+8PnyocvP8Vb6253J46feDPpldZfdP+tS8b8+w
+        q2YGj1PPkCUaYyGlGd3y05E9Nss2eDnhGHgEiWfChIveNQvCSFHesq79DIY7JMkQX//2Cs0BWxLF
+        RURreCjDDh5XWaYgy7McIEkhUSptoVvl6/ahU8l9sjZpwmY0j8gEe3hH/2v68zPKP9tcr9/hGhmK
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:34 GMT
+      etag:
+      - W/"11470890effa4922e01d255f22fa9881"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D090D:3ADABE6:5ED65FBA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3885'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7efd80774d7979dd26d2446cdf093c5f42123a62
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUwY7aMBD9FeQzkMQxMYlUqYdUKw6AaFetoKqQ44yJ2ThBsbMtIP59x0JI7Q0k
+        eogVz/j5zbx5yZnYSpCMcFDlNOSclTzlaVnSpKSMJbJUYRrLiWI0orFIKBmSpi1hq0sEzfN1sqKp
+        K37U4Xy/Zst89nv5Kk/LfVlvzIrNcxkvXlYxxiabl9VxYfDJV3RNv5p5/nZan76bRT77M98vqsV+
+        9gkv77saL66cO9gsCMRBj3faVX0xlq0JOji0NjDghHVtB6NaFyMH1tnAr9utOZYCc+ACBAWIMBpz
+        D7RWOVNv/y3hL/p7iK+kj3CK3lVtR7IzaYQBbP5bJSrRDb68d22DioAR2muCc8LwGHz4884HvSZ4
+        AHv2MBrScBQmo5C+RiyLplkcbchlSK4VOfiPFK4DrOB8sxKHaRIzxeIijKVSSVoyziYyLIADqJgW
+        IEWRTJ47bV8DzvpebhTGgLVi56WbNdppUQ+8ew5CvmF0cJUNazyIDhpnSfbz1iAr5ZRHNAoZ4PdR
+        sDilBU8LUJTLiKmUJ6yYpCp6boM3Oz/A/jQ73815+TUk79BppaVwGv2LrrjuAX8YStQWhqQDYX2K
+        9I3VuwYzQ+JfhOs7HEfT17WX/Vi3AkF+e7l8ANTmesCoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:34 GMT
+      etag:
+      - W/"320364bbc131c24c8f855c2fa317c33d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:31 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D0937:3ADAC17:5ED65FBA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3884'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=7efd80774d7979dd26d2446cdf093c5f42123a62
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hxbMkOjNKYrTjQlnUPdUIhyNbZVipLxlIastLvvnMbaJfu
+        IevG2IPEoZPu/+N/p0dP8xa8qSe44x0v73kNo7U12jvxOu6aX2dswzERA4tLkXDBEkiCYFL4MY3G
+        jEZCAAUW+YmfxAX1sZSV31EkoSfeplf4tHGus1NCeCdHtXTNphiVpiU9dMaSFhy3zvRwqmRx6sA6
+        S4Z9tWp3A6YFR0qjHWhMHHKf9VB9YlCJ2GcsRDSWCBFQEYQhLUXlJ5MyqsJgHEw4DZCsca1a/Qz1
+        BugYlEKZghyr+I4XEVDvgODDtmApMvBY8hvNEWarleHiAKLn231vNhb6veHPbTrGlT8xxO26YSQr
+        qQDt2SvjAWxNnaXzzeJ2rLI1xu04Wl588Rf5lRJpZrPz5/xumV89iHy+XuaX8lrOilSe13c6S2ds
+        iLJ0WPPtIr8xL1VuGnHx+aHI1evLb9G6nCzky/1ZcqeHKP/aYYRIoEsjpK6RqcBxpCGerZTU99ab
+        PnoWVPVfzThOxd/g+dBwDf/rjfi//VtPTz8A5w6nreAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:34 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:31 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D0963:3ADAC4F:5ED65FBA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3883'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:34 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D0988:3ADAC7F:5ED65FBA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3882'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjpNnEwGJbYNsFCmQDFD1s9yJQEi0xkUSVpOw6Qt69/5CS
+        JbvexHF4zCWxafKb4XBmOJx2ItPJfHZ1fT2b3ny4OJlUKhURjU1uP/+2uiv+KJIvN4/825/LpHpY
+        f73PLm/vf/356+Ptxwkm81JgphXGRlG5TrnlRlj8sGiKIup+LQVGrdLitJDxKc017P8rai2X3IK2
+        4IURJxO1qoSezNtJoTJZQcgeDASRpldX0w+z2fX5jvLru4eb9ffZ7w3/Vufpl2IZ3/89u/2crG/v
+        s3+xlEMe11GjC9Bza2szZ8wPmouzTNq8iRsjdKIqKyp7lqiSNawX9mn58RKQTHcYZzIM7OBq2ZH8
+        cuAM27+T3JbFjjJeB7dy/5qFKgq1AnN3FweKZRsAnZmDySp7GwyAlimbC5gW230iI0mc+bFUt7hl
+        9A9+STiDY9MiPRbYLYeS5GJPLdOiVo7bxCbRsrZSVUeruwUBVOmMV/KRvwkKiAGLFD1aMbcYELGE
+        Mx9N8atb5sI1WZPZtEiEXOI83kbewQBs1zVll7uRBemUpBURT0tKCi5XPJ0gel8ZO3sSUCo2hz+Z
+        V8hfFBH6YZOQng1sZ9x9QbpHEFFfsP/BOAQwYLDKg1gHYxKrZfjbxVuCxMBjpTmSeDAhW9CWjb+S
+        U1nBy2CyHAzQXKlwlncwQKUxjTjI9w8/Vcc0rA+2qiljn0kPCbHDxXga9sCNkVklRDCLb4At6y+B
+        WPMqycOJ6Hkt85+c1/As2BaIBWRcqDgYExc6c8CWmZz7q9FGIbUmCcTbEqDFIugWiLcRYHVAv3Hq
+        E3CDx21t4ULB9O95rO1OoOBV1vAsnIQNkC4rlCoZf3yxQjs8Zgci8FSaahk3YRPzwKQd+KII+Sfc
+        EQzIQYCrup4v6V5hpFEl58xUlvKlmudweofbCrHAIigOdsXQ95dLt9dtg3gtG+4Xf5l1kkKdRneb
+        9fqP5XVvq2Cu1fNY+1PNbU4ZFmJrrkWozXQ41sZ46j6dnZ21ueDuWVIKHTCLeBqwXCc5yutQ+rc9
+        D5Vjya17/ixI/RTPoULxNNhZbICAexcItQdPG/tRjXo9mOIONqaXskDXQlXh7oiBOJZTKSsXMjnk
+        rXh4mG9B209GVok44XjeICqsTCTiBE928gAU+SKcFT0N20OPyD8TC4GQCXZKWnhey3xXIBV1odZB
+        M+QISYlECzSo0ohbPEpn09n0dHp1Op39dX45P7+ez66/Y05Towf2wzkXFzSnbkz+whSk/y5W8Ald
+        qecbQbtvTOo4QY4x+QD5ZUDM9/SSfoBICjj9TtQep8ty925/HQbbyVUpatRp/ePcyEd8nm7VWIlq
+        KpwOBlfc4rGBmmUY6uuyHpBzE/lMMplb3aDnSCO1VvcisWY8NmSy0cSVfJBbC6mG3HQL/CN/EF5K
+        rVXXbPTNhS4Po23YdTxTaXhciGFA1aLqNBxvQyaiMhsz+AYAbXk0fcsE7ksqFrwpbOTfStRORU8W
+        DVa4o9AlzEA9L2q3dp0VbxBy1X6PlBX9ZzRcrCjryHuHVQ+C+rNAIauoVWT+aThcz11g/WL/ixvC
+        Vqga2/5FC7pOt9ekCHC0erzGEYrDjtg3iMdtofc+cRO/94nf+8TvfWLfaafrb0+fuBJ2hYbpKJuO
+        n7d9tn76D23yk0QVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:35 GMT
+      etag:
+      - W/"67edcba8eed123760b9c1a2d911e11ce"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D09B5:3ADACB0:5ED65FBA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3881'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:18:35 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90A:160FD:31D09E4:3ADACE3:5ED65FBB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3880'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_create_name_conflict.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_create_name_conflict.yaml
@@ -1,0 +1,1240 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:36 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8314972:9BEEF8B:5ED65FBB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3879'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:36 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:83149CB:9BEEFCD:5ED65FBC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3878'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821003,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEwMDM=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:18:36Z","updated_at":"2020-06-02T14:18:36Z","pushed_at":"2020-06-02T14:18:37Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:38 GMT
+      etag:
+      - '"5a41e2c6a42492d1c5ae23925a008ab0"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8314A4C:9BEF072:5ED65FBC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3877'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79","node_id":"MDY6Q29tbWl0MjY4ODIxMDAzOmViNWY1OWQ5ZTFmOGM3YmNhNmY5MTY4YWMyYmRmOGJjZmU2ZTdkNzk=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:38Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:38Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:39 GMT
+      etag:
+      - '"219612fc6f731ebf8bd5fe970a221cec"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8314D0E:9BEF3C9:5ED65FBE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3876'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X207bQBD9FeTngBPnHgm1lWgrKiWINkCdqorW9jheWO+6u+tAEuXfO+OYi/NA
+        MaJvvET2rs/smTOXnWwcyVJwRk7KjAXtNJxQpSm3zmjjmIThBgTduDuMhtCKB2E/CFkvHrZ6AxZ6
+        QRQPgjCGHvSj/hChUkUw5xGCxid+79wb2uBKNMfXfufs5PRufPJpfZZe8smV3zq7Ou/Opl/Ss6/j
+        tp9Okknqd8dTv+NfjVd++h3Xv13P0gtvNo1uJuub4wovlttEaWJYcv+RsITpg89LrSR+CSnjAkkg
+        f1w+Alr+uKDFI3QOP4iYJZe9ptc8bPYOm9601Rm1BqP2YOZs7xUgNf7bESkYwxZE4lRyy5ngazhA
+        WuxAQ6YMt0qvkKjVgN/cR6IVN4dR7LX7/YHX6bc63QFEnjdk/SDoYGhwZxD129BEYK5JgMTazIxc
+        l2X8aMFtkgckgFsc4aZgMeRKw6HgwaEFY41Lv/N5uiImBqyLIJc4GPfFZ6N+b3j4LhmNWyMJCQLS
+        zkOVS0zjZsNZguYxD5nlmB6o5u4dME9jJgw0HA3M0JaTS8MXEncaDj0wm2vUX+ZCNJyMrYRiCKLX
+        7du5+QoXE5uKeVXlJ+F9SWB3h75CVrN37qtTq67bbhlXg7F5bABCLTgFziRFleMetZ9et9trV9vR
+        ee/y50SE135rMvXXZGOJOa73vSkWjVdWS25Ah0paTKeicHK3sPxhedxBCwtd2ig63r+KjmwZ95Hn
+        8zF8/C5WQqhbxO5TrdZ0xbz7AEJWu2cuF/UNIGjjKpsA6oT0t+Q0xz5Rx1IB2GAnwc7CIzJhUGIN
+        UR0jJQTJ3ErksSlaWGErD0yoeUalXYtWBYiGlF4wyddFj6hlCIGUkkVPreNSAUAgLDG7aiF3iI2b
+        ab5k4Ypk0BACX6Km9a3tQdGYXWV0MV1gxElhbmHOopTKrGiX+xfkewmW1+p7CdarnPcS3F1a2Mwq
+        1fuiEsyYpr7hjH79xoKcCy5v8AUnRRDxW0x+gWYyTHDwe/hfQBfWE8s1Bw6aIu9tIeFMKwuhfTKD
+        lSvliAaSBaIyof3JOV0aeBPY3MyRWrhzGGSsdAjFyCew/RFHFccoYnFz35UaPZ6JJzzfp18+Hu+J
+        hB258Ip82P4FYcUCWFkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:39 GMT
+      etag:
+      - W/"279864418c835db23b64e013630096cf"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8314EE8:9BEF617:5ED65FBF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3875'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:39 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8314F53:9BEF69F:5ED65FBF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3874'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTXYvbMBD8K0HPSWwr/oZCC2nLFZxwvbTBKSWsrXWsO8sOknw0CfnvXTV9aN/u
+        oH0R1o53Z3Z3dGGmBZYzrKImykSGQZPWSVVD3GRBnELNK9GkVd1gjIlIMjZl/SBwLwUlFcsyvueZ
+        rbadXzyW4Xp596NYvjuv1Ve52pbBensf7TYf1PpjsSjVql2pMio2ZVhui1OpPlP80+NOfeG7jXha
+        nZ/eUPFRd1S4tfZocs+Do5wfpG3Hal4PytN4HIyn0IKxg8ZZJ6uZRWON5879Xp0EEIbWoySPMpQk
+        7BWttVZ1+78l/EH/EuIb6Ws4YbTtoFl+YT0opOYfWmhBT94/66GniaAC6WZCe6LwHF347cEF3Uzo
+        B+rZpXGf+zM/nvl8E4R5kOaLdMeuU3ZTZPE/UliNpODy20pB42ei4YskSXmYBGGUouA8g6SqQvIW
+        IalIFuj/2207DcZ7MTcNRqExcHCju+ulldDJM06cgSa/fCbJYifSeASNvTUs//Z9yp5Ry0bWYCXt
+        hjq+3ZEeQwOdwSnTCMZBbOyNPPSETJn7ADtqourHrnMlT90AlOSu1+tPC8uTvYQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:40 GMT
+      etag:
+      - W/"fcd9155aa1f84adf1b624f149bc0d18e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8315000:9BEF76E:5ED65FBF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3873'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"741138ed26f2f12323669ddff9012dd1426ac3ce","node_id":"MDY6Q29tbWl0MjY4ODIxMDAzOjc0MTEzOGVkMjZmMmYxMjMyMzY2OWRkZmY5MDEyZGQxNDI2YWMzY2U=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/741138ed26f2f12323669ddff9012dd1426ac3ce","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/741138ed26f2f12323669ddff9012dd1426ac3ce","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:40Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:40Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/eb5f59d9e1f8c7bca6f9168ac2bdf8bcfe6e7d79"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:40 GMT
+      etag:
+      - '"51bda16ed5d6f34a3b32588acec31498"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/741138ed26f2f12323669ddff9012dd1426ac3ce
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8315055:9BEF7D0:5ED65FC0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3872'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Ou24CMRBF/8V1wCIK++oirUJAsqiyUWhWfoxjo/V6ZQ8oC+LfMyhlmhRpbnPn
+        zD1XlsCy5p6ZO5Am8yAzQmIPbIwGem+oFa0o3kIXxPHjad9uv0T7fNmPu+EwirPcdO7wKs7q/eVi
+        Nt1M4CkNBDnEKTecy8kvPz26k1rqGHiCKdIIIM3EBIvBqwVCxszv2fdhNpI6QE4QXf/2iuoIGllz
+        ZdlJGgK1tuva1LCylS6VloWtV0Ul9aMytlLaQgGlKWsyw3kCIsgjePxf05+fmf/Z5nb7BhKxKkp9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:40 GMT
+      etag:
+      - W/"52221a036a63e5021e67de23b210ab3c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:83150FF:9BEF89B:5ED65FC0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3871'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "741138ed26f2f12323669ddff9012dd1426ac3ce"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWmMnMjRbpYi2SFYngugSOfEFp4rjyL5WpFX/O1cxsjCwvOXd
+        d++7sggdK+6ZuANjE/cmIUT2wMZgoe4ttbrU6s1XXh8/8n25+9Ll+rIfX4fDqM9mU7nDVp+b95eL
+        3VQzgac4EOQQp1RwbqZ++dmjOzXLNngeYQo0AkgzIcJi6JsFQsLE71nXfraGOkBOEF3/9grNEVpk
+        xZUlZ2joKRciewYrVSc7ITOZKbWytutWj0JaK3KpTJu1QGY4T0AEefge/9f052fif7a53b4B8eKH
+        en0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:41 GMT
+      etag:
+      - W/"59ed9f691862e6e5a5029a96698afed8"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8315159:9BEF916:5ED65FC0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3870'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:42 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:83152D7:9BEFAE3:5ED65FC1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3869'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"message":"Repository creation failed.","errors":[{"resource":"Repository","code":"custom","field":"name","message":"name
+        already exists on this account"}],"documentation_url":"https://developer.github.com/v3/repos/#create"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '225'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:83153F1:9BEFC18:5ED65FC2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3868'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:42 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8315457:9BEFCA2:5ED65FC2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3867'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBGnWwGJ7yHaBAu4CRQ/bvQiUREuMJVElKbuOkHfvP6Rk
+        yV5v4iQ85pLYNPnNcDgzHE47kelkPru5vZ1dTqdXZ5NKpSKiscni7vPma/FHkXz58MC//bVOqtX2
+        z/vsenH/ebO4W3ycYDIvBWZaYWwUlduUW26ExQ/Lpiii7tdSYNQqLc4LGZ/TXMN+XFFrueYWtCUv
+        jDibqE0l9GTeTgqVyQpCjmAgiDS9uZn+OpvdXh4ov/26+rD9Pvu94d/qPP1SrOP7f2aLu2S7uM/+
+        w1IOeVxHjS5Az62tzZwxP2iuLjJp8yZujNCJqqyo7EWiStawXtin9cdrQDLdYZzJMHCAq2VH8suB
+        M+z4TnJbFgfKeB3cyuNrlqoo1AbMw12cKJbtAHRmDiar7G0wAFqmbC5gWmz3kYwkceavpbrFLaN/
+        8EvCGRybFulrgd1yKEku9tgyLWrluE1sEi1rK1X1anX3IIAqnfFKPvA3QQExYJGir1bMLQZErOHM
+        r6b41S1z4ZpsyWxaJEKucR5vIx9gALbbmrLL15EF6ZSkFRFPS0oKLlc8niF6Xxg7RxJQKnaHP5lX
+        yF8UEXq1S0hPBrYz7rEgPSKIqM/Y/2QcAhgwWGUltsGYxGoZ/nbxliAx8FhpjiQeTMgetGXjr+RU
+        VvAymCwHAzRXKpzlHQxQaUwjTvL900/VMQ3rg61qythn0lNC7HQxnoY9cGNkVgkRzOI7YMv6SyDW
+        vErycCJ6Xsv8J+c1PAu2BWIBGRcqDsbEhc4csGUm5/5qtFFIrUkC8fYEaLEMugXi7QRYHdBvnPoE
+        3OFxW1u4UDD9ex5ruxMoeJU1PAsnYQekywqlSsYfnq3QTo/ZgQg8laZaxk3YxDwwaQe+KEL+CXcE
+        A3IQ4Kqup0u6FxhpVMk5M5WlfK7mOZ3e4fZCLLAIioNDMfT9+dLtZdsgXsuG+8VfZp2kUKfR3Wa9
+        /mN53dsqmGv1PNb+UnObU4aF2JprEWozHY61MZ66jxcXF20uuHuWlEIHzCKeBizXSY7yOpT+bc9D
+        5Vhy654/S1I/xXOoUDwNdhY7IODeBULtwdPGflSjXg+muION6aUs0LVQVbg7YiCO5VTKyqVMTnkr
+        nh7me9D2k5FVIs44njeICisTiTjBk508AEW+CGdFT8P20CPyz8RCIGSCnZIWntcy3xVIRV2obdAM
+        OUJSItECDao04haP0tl0Nj2f3pxPZ39fXs8vb+dXN98xp6nRA/vpnOtLmlM3Jn9mCtJ/Fyv4hK7U
+        042gwzcmdZwgx5h8gPw2IOZHekk/QSQFnP4gal+ny/rwbn8ZBtvJVSlq1Gn949zIB3ye7tVYiWoq
+        nA4GN9zisYGaZRjq67IekHMT+UwymVvdoOdII7VW9yKxZjw2ZLLRxI1cyb2FVEPuugX+kT8IL6XW
+        qms2+uZCl4fRNuw6nqk0PC7EMKBqUXUajrchE1GZnRl8A4C2PJq+ZwL3JRVL3hQ28m8laqeiJ4sG
+        K9xR6BJmoJ4XtVu7zoo3CLlqv0fKiv4zGi5WlHXkvcOqlaD+LFDIKmoTmX8bDtdzF1i/2P/ihrAV
+        qsb2f9GCrtP9NSkCHK0er3GE4rAj9g3icVvovU/cxO994vc+8Xuf2Hfa6fo70ieuhN2gYTrKpuPn
+        bZ+tH/8HwYa+2RUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:43 GMT
+      etag:
+      - W/"bd8226bba107668f2e580b89a0d85eed"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:41 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:83154C8:9BEFD2D:5ED65FC2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3866'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:18:43 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90B:2668C:8315548:9BEFDC6:5ED65FC3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3865'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_delete.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_delete.yaml
@@ -1,0 +1,1395 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:30 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B016:142C9E5:5ED65FF2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3756'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:30 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B03D:142C9F7:5ED65FF2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3755'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821214,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEyMTQ=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:19:30Z","updated_at":"2020-06-02T14:19:31Z","pushed_at":"2020-06-02T14:19:32Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:32 GMT
+      etag:
+      - '"0a5e7ba48aae08727445e60b584396b3"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B056:142CA28:5ED65FF2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3754'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"401c09e66ec3fd46783e08c424189455ec5c6065","node_id":"MDY6Q29tbWl0MjY4ODIxMjE0OjQwMWMwOWU2NmVjM2ZkNDY3ODNlMDhjNDI0MTg5NDU1ZWM1YzYwNjU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/401c09e66ec3fd46783e08c424189455ec5c6065","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/401c09e66ec3fd46783e08c424189455ec5c6065","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:32Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:32Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:33 GMT
+      etag:
+      - '"4634eafb0d73832754212f70f9a6693e"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B0EF:142CADC:5ED65FF4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3753'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bMBD9lUBnJ1osywsQtAfnkIMcBM1SpygMmhpJdChSJSk7tpF/71BWFvuQ
+        RkF6y8WQSL3hmzcLx1tHkAKckVMQbUA5HYfKomDGGW0dnRPcCD2fekOIIqDdNAmj/qAL3oCGQegP
+        hmGvB7RHIy/qIVTIBGYsQVA8nkaXwdDMb7kXL6bhxfj8IV6ceReLy1V8G68ubq+DSXGziIO7+8l4
+        2r0YT3g8zheT8bkXX2W9yfjav7uN/elmuposrk/3eJHK5FJZhg33HznJiTo6Wyop8EsoCONIAvnj
+        8gnY5e+ZXTxB5/CDhBjrcuAF3rEXHXvBlR+O/OGoG9w5j08KWDX+2xEFaE0yS+JcMMMIZxs4Qlrk
+        SEEpNTNSrZGoUYDfPEXCT71hkgbdfn8QhH0/7A0gCYIh6c/n4YD2cWeQ9DE4CKyUFSA3ptQj1yUl
+        O8mYyau5FcCtj3ALMBhyqeCYs/mxAW20a39ns2JtmWgwLoJcy0G77z4b9fvEw3fJqN0WSWghIMyM
+        ykpgGnsdZwmKpYwSwzA9UM3dO2CepoRr6DgKiLZbTiU0ywTudBz7QEylUH9Rcd5xSrLmkiDIvj5+
+        npsfcDE3BZ/tq/wqvO8J7O7QD8iqD879cGq1ddtt4qoxNi8NgMuM2cDpvK5y3LPtJ+r1ou5+O7qM
+        bn5OOF1M/cnVdGNtLDHH1aE39aIOmmqpNCgqhcF0qguncmvL35anIVrIVGOj7nj/KjprS7svPN+O
+        4ct3qeRcrhB7SHW/pvfMu88gZLV7ZiJrbwBBW1eaHFAnpP9onWbYJ9pYqgFb7CTYWVhiTWiUWEHS
+        xkgDQTIrgTy2dQurbVVzTRUrbWm3orUHRENSZUSwTd0jWhlCoE3Juqe2cakGIBCWmF2tkDvE1i0V
+        WxK6tjIooMCWqGl7awdQNGbWpb2YrjHiVmFmYEaSwpZZ3S4PL8ivEmyu1a8SbFc5XyW4u7Swme1V
+        77tKsCTK9g1n9Os3FuSMM3GPLzgpAk8/Y/KbKyJojoPf8/8Ce2G9stxy4LBT5JMtJFwqaYCaVzNY
+        s9KMaCDInO9NaH8qZi8NvAlMpWdIje4cBpFKRaEe+Ti2P8tRpimKWN/cD41GL2fiCW/36fePxwci
+        YUeuvbI+PP4FfjijslkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:33 GMT
+      etag:
+      - W/"e3cb693911e34c476534cbcb224ad2bc"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B143:142CB3C:5ED65FF5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3752'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:34 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B15E:142CB5C:5ED65FF5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3751'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/401c09e66ec3fd46783e08c424189455ec5c6065
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPSTDmG6lSD+whB4hW3TQi1SoyMIApH5FtNs1G+e87bnro3nal
+        9mLhecy8NzPPV6JaTmLiUrukEfg+lE5duX4QOkDD0mWuHUau50HplT71PbIk41TBUVSYlCa5/8gi
+        Xex7mna5u002v9LugW67x3O6T8/b/Y5lw/cuZYefWZI72yTr06TtsmRD06fGy5Kdfdindv6an7Nu
+        9wWLz7LHwq3WJxVbFj+JdSN0OxfrchosCadJWQNorvQkYdWLYqVBaWWZ83gcLhVHDLSFSRZmDAKx
+        T7TW6qE/vpfwF/1HiO+kn+Hks24nSeIrGfkA2Py3lrdcLh5e5DTiRGDgwswE94ThNZjw18YEzUzw
+        B+zZpDHK6Ir6K8qebDe2o9hhB3JbkrsiDf+RQktABdc/VrJrGlU1c4IgZG5gu14IFWMRD4rCDcsA
+        kbAK0F3/dttGg7I+zI2DGUAp3pjRbUahBe/FKyyMgRa/fSbQYhfUeOISRq1I/ON5SV5AilqUXAvc
+        DXZ8vwM+hpr3CpZEAlcGIvOoRDMisiTmg+tZItU4970peeknjknmeru9ATFnBbiEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:34 GMT
+      etag:
+      - W/"bdd20b884bec50dec9168197438dab97"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B183:142CB87:5ED65FF6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3750'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["401c09e66ec3fd46783e08c424189455ec5c6065"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"ed430b228c7931b351f72757462b34c83c1ab737","node_id":"MDY6Q29tbWl0MjY4ODIxMjE0OmVkNDMwYjIyOGM3OTMxYjM1MWY3Mjc1NzQ2MmIzNGM4M2MxYWI3Mzc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ed430b228c7931b351f72757462b34c83c1ab737","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/ed430b228c7931b351f72757462b34c83c1ab737","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:34Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:34Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"401c09e66ec3fd46783e08c424189455ec5c6065","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/401c09e66ec3fd46783e08c424189455ec5c6065","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/401c09e66ec3fd46783e08c424189455ec5c6065"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:34 GMT
+      etag:
+      - '"08c506bd6078556ea5aa1ccbe3925844"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ed430b228c7931b351f72757462b34c83c1ab737
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B1A1:142CBAB:5ED65FF6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3749'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vnggM4bshMgVaymJqqLJFjH7WjOI7iAzVF/Pce6tilQ5e3vPvu
+        fVc2womV90zcgbaJB50QRvbA+mih9pZatVHyNVRBte/isHn+VO1TduhfumOvLnpXueNeXZq37Zfd
+        VROB57EjyCEOqeRcD37+4dGdm7mJgY8wRBoBpJk4wqzzzQwhYeL3rOswWU0dICeIrn97xaYFg6y8
+        suQ0DYlsYbI1SAlmdbJCPhYryAojlmJRrEWeg8mNzGROZjgNQAR5BI//a/rzM/E/29xu3zW+pPR9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:35 GMT
+      etag:
+      - W/"21006a10bfa9adeef338f63484cb8be3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B1D4:142CBDC:5ED65FF6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3748'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "ed430b228c7931b351f72757462b34c83c1ab737"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngkkcMM1MS0GymJqqLJE/Hk2iOI7sB2qK+O99qGOXDl3uct95
+        91xZhBMr75l4A9ol7nVCiOyBDcFB3Tpq1UatXn3lVfdeHDa7T9U9LQ7Dvj8O6qK3VXN8URfz9vzl
+        ttVE4Dn2BDWIYyo512M7/2ixOZu5DZ5HGAONANJMiDDrWzNDSJj4PevaT05TB8gJouvfXsF0YJGV
+        V5YaTUPgCrEweb628lFkRiyzk8zlUhar3IjCroXNtJFCkhlOIxBBHr7F/zX9+Zn4n21ut2+Uu42Y
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:35 GMT
+      etag:
+      - W/"e032a88a1555ebea63c16268de79de57"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B1E8:142CBFE:5ED65FF7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3747'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:36 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B22A:142CC53:5ED65FF7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3746'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOm2WNgaJ7aFdgQBZs6EPXF4GSaImxJGokZc8R8t33P1Ky
+        ZM9NHIePeUlsmvzd8Xh3PF47kelkPrt+/352Obu8OptUKhURjU1uP31e3xW/F8mXmwf+7a9VUi03
+        f9xnV7f3nze3X//8MMFkXgrMtMLYKCo3KbfcCIsfFk1RRN2vpcCoVVqcFzI+p7mG/X9FreWKW9AW
+        vDDibKLWldCTeTspVCYrCDmAgSDS9Pp6+sts9v5yT/nN3fJm8332W8O/1Xn6pVjF93/Pbj8lm9v7
+        7F8s5ZDHddToAvTc2trMGfOD5t1FJm3exI0ROlGVFZW9SFTJGtYL+7j6cAVIpjuMMxkG9nC17Eh+
+        OXCGHd5JbstiTxmvg1t5eM1CFYVag7m/iyPFsi2AzszBZJW9DgZAy5TNBUyL7T6SkSTO/FSqW9wy
+        +ge/JJzBsWmRngrslkNJcrHHlmlRK8dtYpNoWVupqpPV3YEAqnTGK/nAXwUFxIBFip6smFsMiFjB
+        mU+m+NUtc+GabMhsWiRCrnAeryPvYQC2m5qyy93IgnRK0oqIpyUlBZcrHs8QvS+MnQMJKBXbw5/M
+        K+Qvigi93CakJwPbGfdQkB4QRNRn7H80DgEMGKyyFJtgTGK1DH+7eEuQGHisNEcSDyZkB9qy8Vdy
+        Kit4GUyWgwGaKxXO8g4GqDSmEUf5/vGn6piG9cFWNWXsM+kxIXa8GE/DHrgxMquECGbxLbBl/SUQ
+        a14leTgRPa9l/pPzGp4F2wKxgIwLFQdj4kJnDtgyk3N/NdoopNYkgXg7ArRYBN0C8bYCrA7oN059
+        Am7xuK0tXCiY/j2Ptd0JFLzKGp6Fk7AF0mWFUiXjD89WaMfH7EAEnkpTLeMmbGIemLQDXxQh/4Q7
+        ggE5CHBV19Ml3QuMNKrknJnKUj5X8xxP73A7IRZYBMXBvhj6/nzp9rJtEK9lw/3iL7NOUqjT6G6z
+        Xv+xvO5tFcy1eh5rf6q5zSnDQmzNtQi1mQ7H2hhP3ceLi4s2F9w9S0qhA2YRTwOW6yRHeR1K/7bn
+        oXIsuXXPnwWpn+I5VCieBjuLLRBw7wKh9uBpYz+qUa8HU9zBxvRSFuhaqCrcHTEQx3IqZeVCJse8
+        FY8P8x1o+9HIKhFnHM8bRIWViUSc4MlOHoAiX4Szoqdhe+gR+WdiIRAywU5JC89rme8KpKIu1CZo
+        hhwhKZFogQZVGnGLR+lsOpueT6/Pp7Ovl1fzy5v5u+l3zGlq9MB+POdnmlM3Jn9mCtJ/Fyv4hK7U
+        042g/TcmdZwgx5h8gPw6IOYHekk/QCQFnH4vak/TZbV/t78Mg+3kqhQ16rT+cW7kAz5Pd2qsRDUV
+        TgeDa27x2EDNMgz1dVkPyLmJfCaZzK1u0HOkkVqre5FYMx4bMtlo4lou5c5CqiG33QL/yB+El1Jr
+        1TUbfXOhy8NoG3Ydz1QaHhdiGFC1qDoNx9uQiajM1gy+AUBbHk3fMYH7kooFbwob+bcStVPRk0WD
+        Fe4odAkzUM+L2q1dZ8UbhFy13yNlRf8ZDRcryjry3mHVUlB/FihkFbWOzD8Nh+u5C6xf7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgR+wbxuC301idu4rc+8Vuf+K1P7DvtdP0d6BNXwq7RMB1l0/Hz
+        ts/Wj/8B6Xt6lhUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:36 GMT
+      etag:
+      - W/"5dd045ea940b9624d51ba9f7e314a015"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:35 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B244:142CC70:5ED65FF8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3745'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:19:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B281:142CCB8:5ED65FF8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3744'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:37 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B2B3:142CCEA:5ED65FF9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3743'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B2CB:142CD0B:5ED65FF9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3742'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:37 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B2D9:142CD22:5ED65FF9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3741'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C916:26688:112B2FB:142CD3F:5ED65FF9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3740'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_delete_non_existing.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_delete_non_existing.yaml
@@ -1,0 +1,243 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:38 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C917:204BE:570ABF0:67644F6:5ED65FFA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3739'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:38 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C917:204BE:570AC3C:6764531:5ED65FFA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3738'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__someid
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C917:204BE:570AC89:676458E:5ED65FFA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3737'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_fetch_not_found.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_fetch_not_found.yaml
@@ -1,0 +1,243 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:43 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90E:33B7A:88301EE:A1E65E3:5ED65FC3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3864'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:44 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90E:33B7A:8830242:A1E6624:5ED65FC3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3863'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90E:33B7A:88302A7:A1E66A1:5ED65FC4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3862'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_fetch_revision.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_fetch_revision.yaml
@@ -1,0 +1,3691 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:13 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1219:C794BB8:5ED65FE0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3799'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:13 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B127D:C794C15:5ED65FE1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3798'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821143,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjExNDM=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:19:13Z","updated_at":"2020-06-02T14:19:13Z","pushed_at":"2020-06-02T14:19:14Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:15 GMT
+      etag:
+      - '"bfe114f00a72b587fb3b5084ebe5d295"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B131E:C794CC9:5ED65FE1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3797'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"809b10e2d82bb223842f6ec13aea7c6d833fe26b","node_id":"MDY6Q29tbWl0MjY4ODIxMTQzOjgwOWIxMGUyZDgyYmIyMjM4NDJmNmVjMTNhZWE3YzZkODMzZmUyNmI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/809b10e2d82bb223842f6ec13aea7c6d833fe26b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/809b10e2d82bb223842f6ec13aea7c6d833fe26b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:15Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:15Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:15 GMT
+      etag:
+      - '"2b8eb95a693c5f27af1f36c2e42e0488"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B15D8:C79502E:5ED65FE3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3796'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bMBD9lUBnJ5JlxxsQtAcHRQrYQdAstYvCoKSRRIciVZJyIhv5987IymIf
+        0ihIb7kYEqk3fPNm4XjjSJaBM3IyZixop+WEKsu4dUYbx6QMNwbeMGh74EcDPwh8vzPo+nEPwnaH
+        AeuHvWjQ6cTg9wKEShXBgkcImoxnvQt/aIMb4U2Ws+75+Ox+cnmxPl8md+c3+PztqpyPk3KWnZWT
+        5aQ7HX/Pptn1cnI5Tec3p53Zen57Pp6s59lVOc3OTnZ4scKmShPDmvuPlKVMH5yutJL4JWSMCySB
+        /HH5CGj5a0KLR+gcfhAxSy77nu8der1Dz79sd0ft4ah9PHceHhUgNf7bERkYwxIicSa55UzwNRwg
+        LXagIVeGW6VLJGo14DePkWjH3jCK/U6/P/C7/Xb3eACR7w9ZPwi6g7CPO4Oo3wEPgYUmAVJrczNy
+        XZbzo4TbtAhIALc6ws3AYsiVhkPBg0MLxhqXfheLrCQmBqyLIJc4GPfNZ6N+H3j4NhmN2yAJCQLS
+        LkJVSExjr+WsQPOYh8xyTA9Uc/sOmKcxEwZajgZmaMsppOGJxJ2WQw/MFhr1l4UQLSdnpVAMQfT6
+        8HFuvsPF1GZisavyi/C+JbDbQ98hq9k7992p1dRtt46rwdg8NwChEk6BM2lV5bhH7ad3fNzr7Laj
+        i971z6kIl7P29HK2JhsrzHG97021aPy6WgoDOlTSYjpVhVO4leUvq5MuWkh0baPqeP8qOrJl3Gee
+        r8fw+btYCaHuELtPdbemd8y7TyBktX3mMmluAEEbV9kUUCek/0BOc+wTTSxVgA12EuwsPCITBiXW
+        EDUxUkOQzJ1EHpuqhVW2isCEmudU2o1o7QDRkNIJk3xd9YhGhhBIKVn11CYuVQAEwgqzqxFyi9i4
+        ueYrFpYkg4YQ+Ao1bW5tD4rGbJnTxXSFESeFuYUFizIqs6pd7l+QnyVYX6ufJdiscj5LcHtpYTPb
+        qd43lWDONPUNZ/TrNxbkQnB5iy84KYKIP2LyCzSTYYqD39P/ArqwXlhuOHDQFPloCwnnWlkI7YsZ
+        rF6pRzSQLBA7E9qfgtOlgTeBLcwCqYVbh0HGSodQjXwC2x9xVHGMIlY3932t0fOZeMLrffrt4/Ge
+        SNiRK6/Ih4e/Byq2clkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:16 GMT
+      etag:
+      - W/"3b5347287271a6e7b241c8159af7b31d"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B176B:C79521A:5ED65FE3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3795'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:16 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B182E:C7952D8:5ED65FE4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3794'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/809b10e2d82bb223842f6ec13aea7c6d833fe26b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY6bMBD9lcjnJIBhgSBV6oFVlUokWjXbKFRVNMAATjFEttmWRPn3jpse2tuu
+        1F6QPc8z782b4cp0CyxhsbsqPBd5FfOi4NyPA16HWHo+IERlWMW+XyMPCzZn/VDhUVSUlKWH8Imv
+        TLHv3Ox0CLbp+ke2e7psT8337Z7OH56nPG2mg1xP2SkLNulHuZGfT9lu0+b7R/9wyb9t0+ySy+dp
+        I9fvqPioOircGnPWiePAWSwbYdqxWJaDdBSeB+1INKDNoHDRiWJhUBvt2O/xKKcKCEPjUJJDGVIQ
+        9obWWiO7498S/qB/DfGd9C2cMJp2UCy5sh4kUvOfWmhBzR5f1NCTIyhBWE9oThReog2/b2zQekIP
+        qGebxl3uLtxw4fKdFyTeKvEecnabs7sig/+RwigkBdffq+TV7qqquR9FMQ8iL3iIseJ8BVFRBHEZ
+        ERJXkY/uv5221aCdV3OTMRK1hsZat+6FEdCJC87sAs1+7ZmgFZtI4xkU9kaz5MvXOXtBJWpRghE0
+        G+r4fkf6GWroNM6ZQtAWYmOvRdMTMmf2AGZURNWPXWdLTt0AlGSvt9tPoel9KoQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:17 GMT
+      etag:
+      - W/"5d12d75379ccf1385e24b024397c8a1f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B191B:C7953EB:5ED65FE4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3793'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["809b10e2d82bb223842f6ec13aea7c6d833fe26b"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"969e0a8ee8c6eb9d9ffa1e91a87924109743503b","node_id":"MDY6Q29tbWl0MjY4ODIxMTQzOjk2OWUwYThlZThjNmViOWQ5ZmZhMWU5MWE4NzkyNDEwOTc0MzUwM2I=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/969e0a8ee8c6eb9d9ffa1e91a87924109743503b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/969e0a8ee8c6eb9d9ffa1e91a87924109743503b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:17Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:17Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"809b10e2d82bb223842f6ec13aea7c6d833fe26b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/809b10e2d82bb223842f6ec13aea7c6d833fe26b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/809b10e2d82bb223842f6ec13aea7c6d833fe26b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:17 GMT
+      etag:
+      - '"09f7dc1ab99a61ff4a44597817fd569f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/969e0a8ee8c6eb9d9ffa1e91a87924109743503b
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1992:C7954C4:5ED65FE5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3792'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4tnwOCgNM2MgFayEFKbqiyRHV+wURxH9oEaEP+9hzp26dDlLe++
+        e9+NRWhZ+cjELSiTuFcJIbIJ64OB2hlq5Urm777y8vS53K1evuTb/rrrX7tDLy9qU9nDVl70x/pq
+        NtVI4Dl2BFnEIZWcq8HNjg7tWc+a4HmEIdAIIM2ECNPO6SlCwsQfWdd+NIo6QE4QXf/2CvoEDbLy
+        xpJVNFTMn/ViDsIUQmshsmIp2hyaRaZAPTW5KbKsBZFrMsNxACLIwzv8X9Ofn4n/2eZ+/wY/BVix
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:17 GMT
+      etag:
+      - W/"5e2516d6f3035f1e30f43bc4bbda2d48"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1A6F:C7955DD:5ED65FE5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3791'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "969e0a8ee8c6eb9d9ffa1e91a87924109743503b"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngpOShjgzKrSShSq1qcoS2fEFG8VJZB+oAfHfe6hjlw4sb3n3
+        3fsuLEDLyltGbkGZyL2KCIE9sH4wUDtDrVzJ/MNXXh6+su3q5Vu+v523/Wu36+VJrSu728iT/nw+
+        m3U1EXgMHUEWcYwl52p0871De9TzZvA8wDjQCCDNDAFmndMzhIiR37Ku/WQUdYCcILr+6zXoAzTI
+        yguLVtGQyAUkqgAomhy0MKJtVQoiVcVSPGZpIpbZ4ilZaDLDaQQiyMM7vK/p78/I/21zvf4ADP1+
+        En0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:18 GMT
+      etag:
+      - W/"3bd1f6f0a889248ede3534f525eedfca"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1AD9:C795658:5ED65FE5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3790'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:18 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1C72:C795815:5ED65FE6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3789'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXTULbCbKpgaJ7SLfAAmmAxR66vQiURFuMJVFLUnYdIe++/5CS
+        Jbtu4jg85pLYNPnNcDgzHE4zkuloNr2+uZlOJleXZ6NSpSKisdHd7ef1ff5Xnnz58Mi//b1KyuXm
+        68Pi6u7h84+vt3cfR5jMC4GZVhgbRcUm5ZYbYfHDvM7zqP21EBi1SovzXMbnNNewn1dUWq64BW3O
+        cyPORmpdCj2aNaNcLWQJIQcwEESaXl+Pf59ObyZ7ym/ulx8236d/1vxblaVf8lX88O/07jbZ3D0s
+        fmAphzyuo1rnoGfWVmbGmB80lxcLabM6ro3QiSqtKO1FogpWs07Yp9XHK0AWusU4k2FgD1fJluSX
+        A2fY4Z1ktsj3lPE6uJWH18xVnqs1mPu7OFIs2wLozBxMlou3wQBomLKZgGmx3ScyksSZn0p1ixtG
+        /+CXhDM4Ni3SU4HtcihJLvbUMC0q5bh1bBItKytVebK6OxBAlV7wUj7yN0EBMWCRoicr5hYDIlZw
+        5pMpfnXDXLgmGzKbFomQK5zH28h7GIDtpqLscj+wIJ2StCLiaUFJweWKpzNE7ytj50ACSsX28Eez
+        EvmLIkIvtwnp2cB2xj0UpAcEEfUF+x+NQwADBqssxSYYk1gNw9823hIkBh4rzZHEgwnZgTZs+JWc
+        ygpeBJPlYIBmSoWzvIMBKo2pxVG+f/ypOqZhXbCVdRH7THpMiB0vxtOwB26MXJRCBLP4Ftiw7hKI
+        NS+TLJyIjtcw/8l5DV8E2wKxgIxzFQdj4kJnDtgwk3F/NdoopNYkgXg7ArSYB90C8bYCrA7oN059
+        Am7xuK0tXCiY/h2PNe0J5Lxc1HwRTsIWSJcVSpUFf3yxQjs+Znsi8FSaahnXYRNzz6Qd+KII+Sfc
+        EfTIXoCrup4v6V5hpEEl58xUFPKlmud4eovbCbHAIigO9sXQ95dLt9dtg3gN6+8Xf5m1kkKdRnub
+        dfoP5bVvq2Cu1fFY81vFbUYZFmIrrkWozbQ41sR46j5dXFw0meDuWVIIHTCLeBqwXCcZyutQ+jcd
+        D5Vjwa17/sxJ/RTPoVzxNNhZbIGAexcItQdPG/pRhXo9mOIONqQXMkfXQpXh7oieOJRTKivnMjnm
+        rXh8mO9Am09Glok443jeICqsTCTiBE928gAU+SKcFT0N20OPyD8Tc4GQCXZKWnhew3xXIBVVrjZB
+        M+QASYlECzSo0ohbPEqn4+n4fHx9Pp7+M7maTT7MJpffMaeu0AP79ZwbmlPVJnthCtJ/Gyv4hK7U
+        842g/TcmdZwgx5ish/zRI2YHekm/QCQ5nH4vak/TZbV/t78Og+1kqhAV6rTucW7kIz6Pd2qsRNUl
+        TgeDa27x2EDN0g91dVkHyLiJfCYZzayu0XOkkUqrB5FYMxzrM9lg4lou5c5CqiG33QL/yO+FF1Jr
+        1TYbfXOhzcNoG7Ydz1QaHueiH1CVKFsNh9uQiSjN1gy+AUBbHkzfMYH7koo5r3Mb+bcStVPRk0WD
+        Fe4odAEzUM+L2q1tZ8UbhFy12yNlRf8ZDRcriiry3mHVUlB/FihkFbWOzH81h+u5C6xb7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgSuwbxsC303ieu4/c+8Xuf+L1P7DvtdP0d6BOXwq7RMB1k0+Hz
+        tsvWT/8DULFA1xUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:19 GMT
+      etag:
+      - W/"de3cb4fe3ba92717f0715ac6091ac61d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1D14:C7958DF:5ED65FE6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3788'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngpOShjgzKrSShSq1qcoS2fEFG8VJZB+oAfHfe6hjlw4sb3n3
+        3fsuLEDLyltGbkGZyL2KCIE9sH4wUDtDrVzJ/MNXXh6+su3q5Vu+v523/Wu36+VJrSu728iT/nw+
+        m3U1EXgMHUEWcYwl52p0871De9TzZvA8wDjQCCDNDAFmndMzhIiR37Ku/WQUdYCcILr+6zXoAzTI
+        yguLVtGQyAUkqgAomhy0MKJtVQoiVcVSPGZpIpbZ4ilZaDLDaQQiyMM7vK/p78/I/21zvf4ADP1+
+        En0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:19 GMT
+      etag:
+      - W/"3bd1f6f0a889248ede3534f525eedfca"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1D83:C7959A1:5ED65FE7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3787'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/969e0a8ee8c6eb9d9ffa1e91a87924109743503b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUy67aMBD9FeQ1EMcJeSBV6gIWLAJChSKoKjROJsSQB4qdS+GKf+9YtFK7A+ne
+        TWTP+PjMnDnxO9MFsDGLgxg5RIhRGqCMszjPwcXYhSiMhe/yOPS9Efck67O6yXCvMgIlk22wFLGR
+        m5Inx62/mMx+JavlbXE8icVmfdmuinK3Ko7z6rtabJajXbUrks16lGym/vx2us4n08tilfLktr4k
+        YvaFLu/aki4ujDnrsePAWQ0PyhSdHKZN5bR4brRToQFtmhYHpZIDg9pox373++qaAeXQOARyCFEp
+        yr3QWmGqcv9/Cf/QP0P8IH2FEzpTNC0bv7MaKqTmvxVQQNubvrVNTYpgBcpqQnOi8BBt+OvBBq0m
+        dIB6tjDBBR/wYMDFyvXHbjx2wx2799mjIoOfSGFapAre/1gpDDEKPD/3Pcm9NM+DOPNDf5RyiSFi
+        7gmJKchg9LHTtjVo52luEqZCreFgpZvVyigoe9Y9Z0hPFO09ZKMaz9BibTQb//jbYMRj6XIUWSSk
+        FMKLfJEHmLoeIIRpkEWel6MI7L/yCXZ+gf3D7Pw05/1nn71hq3KVglHkX3LFY4/0YORQauyzFkHb
+        FOtqrQ41ZfrMLsB0LY2j7srSyn4tGyCQ3d7vvwGiUDegqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:19 GMT
+      etag:
+      - W/"09f7dc1ab99a61ff4a44597817fd569f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1DF7:C795A12:5ED65FE7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3786'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=969e0a8ee8c6eb9d9ffa1e91a87924109743503b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T3U7jMBCF3yXXUCdt8+NKK0QjQKkEaNkL0gqpsuNJ4uLYUexSdRHvvhOoBFv2
+        osuuEBe2Rh57zqcz40dPswa8iSeYYy0r7lkFg5U12jvyWubqP2dszTCRQJwUgjIRU6DD4Yj7SRQG
+        cRQKARHEoU99mvDIx1JW/kQRGh15607h09q51k4IYa0cVNLVaz4oTEM6aI0lDThmnengWEl+7MA6
+        S/p9uWy2PaYFRwqjHWhM7HOfdFB+oxEFnyUASREBp4KWJQuABiyJ6XAc+DQej0J/xJGsdo1a/g71
+        BugQFK4MJ4cqvuNFBNTbI/iwLViK9DyW/EVzhNloZZjYg+jYZtebtYVuZ/hzmw5x5V8Mcdu2H8lS
+        KkB7dsp4ABtTZelsPb8NVLbCuAnCxcW5P8+vlEgzm50+57eL/OpB5LPVIr+U13LKU3la3eksncZ9
+        lKX9mm3m+Y15qXJTi4uzB56r15c/wlUxmsuX+1N6p/so/95ihEigCyOkrpCJ4zhGYzxbKqnvrTd5
+        9Cyo8kvNOE7F/+D50HD1/+uN+Of+raenX2WmCuHgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1E5B:C795A99:5ED65FE7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3785'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1ED8:C795B36:5ED65FE8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3784'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXTULbCbKpgaJ7SLfAAmmAxR66vQiURFuMJVFLUnYdIe++/5CS
+        Jbtu4jg85pLYNPnNcDgzHE4zkuloNr2+uZlOJleXZ6NSpSKisdHd7ef1ff5Xnnz58Mi//b1KyuXm
+        68Pi6u7h84+vt3cfR5jMC4GZVhgbRcUm5ZYbYfHDvM7zqP21EBi1SovzXMbnNNewn1dUWq64BW3O
+        cyPORmpdCj2aNaNcLWQJIQcwEESaXl+Pf59ObyZ7ym/ulx8236d/1vxblaVf8lX88O/07jbZ3D0s
+        fmAphzyuo1rnoGfWVmbGmB80lxcLabM6ro3QiSqtKO1FogpWs07Yp9XHK0AWusU4k2FgD1fJluSX
+        A2fY4Z1ktsj3lPE6uJWH18xVnqs1mPu7OFIs2wLozBxMlou3wQBomLKZgGmx3ScyksSZn0p1ixtG
+        /+CXhDM4Ni3SU4HtcihJLvbUMC0q5bh1bBItKytVebK6OxBAlV7wUj7yN0EBMWCRoicr5hYDIlZw
+        5pMpfnXDXLgmGzKbFomQK5zH28h7GIDtpqLscj+wIJ2StCLiaUFJweWKpzNE7ytj50ACSsX28Eez
+        EvmLIkIvtwnp2cB2xj0UpAcEEfUF+x+NQwADBqssxSYYk1gNw9823hIkBh4rzZHEgwnZgTZs+JWc
+        ygpeBJPlYIBmSoWzvIMBKo2pxVG+f/ypOqZhXbCVdRH7THpMiB0vxtOwB26MXJRCBLP4Ftiw7hKI
+        NS+TLJyIjtcw/8l5DV8E2wKxgIxzFQdj4kJnDtgwk3F/NdoopNYkgXg7ArSYB90C8bYCrA7oN059
+        Am7xuK0tXCiY/h2PNe0J5Lxc1HwRTsIWSJcVSpUFf3yxQjs+Znsi8FSaahnXYRNzz6Qd+KII+Sfc
+        EfTIXoCrup4v6V5hpEEl58xUFPKlmud4eovbCbHAIigO9sXQ95dLt9dtg3gN6+8Xf5m1kkKdRnub
+        dfoP5bVvq2Cu1fFY81vFbUYZFmIrrkWozbQ41sR46j5dXFw0meDuWVIIHTCLeBqwXCcZyutQ+jcd
+        D5Vjwa17/sxJ/RTPoVzxNNhZbIGAexcItQdPG/pRhXo9mOIONqQXMkfXQpXh7oieOJRTKivnMjnm
+        rXh8mO9Am09Glok443jeICqsTCTiBE928gAU+SKcFT0N20OPyD8Tc4GQCXZKWnhew3xXIBVVrjZB
+        M+QASYlECzSo0ohbPEqn4+n4fHx9Pp7+M7maTT7MJpffMaeu0AP79ZwbmlPVJnthCtJ/Gyv4hK7U
+        842g/TcmdZwgx5ish/zRI2YHekm/QCQ5nH4vak/TZbV/t78Og+1kqhAV6rTucW7kIz6Pd2qsRNUl
+        TgeDa27x2EDN0g91dVkHyLiJfCYZzayu0XOkkUqrB5FYMxzrM9lg4lou5c5CqiG33QL/yO+FF1Jr
+        1TYbfXOhzcNoG7Ydz1QaHueiH1CVKFsNh9uQiSjN1gy+AUBbHkzfMYH7koo5r3Mb+bcStVPRk0WD
+        Fe4odAEzUM+L2q1tZ8UbhFy12yNlRf8ZDRcriiry3mHVUlB/FihkFbWOzH81h+u5C6xb7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgSuwbxsC303ieu4/c+8Xuf+L1P7DvtdP0d6BOXwq7RMB1k0+Hz
+        tsvWT/8DULFA1xUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      etag:
+      - W/"de3cb4fe3ba92717f0715ac6091ac61d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1F5C:C795BC7:5ED65FE8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3783'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XS2/iSBD+K5HPJH5iMNJo95AccgAULRmWrEao3S7jTtqP7W7DAOK/T5WBSeCQ
+        xVH2lguCtr/qr756srUKloM1sHKmDSirY/Eyz4WxBltLZwwfRGEEDusD9HkIcZREacpciFzW70Ve
+        4DpRL/C7jh8jtCgTmIsEQcPbWfjgRSaeSmf4PAvGt/c/h5OHzfj5xRtPH1ezSSafJtnzKP8uxtOH
+        7lP+lA2nj93h9C4YbV7Wo9u71XjCneHmcTX07r+d8GK1yUpFDA/c/8pYxtTV3VKVBb4JORMSSSB/
+        PL4BOv5zQYc36By+kDBDLnuO51w74bXjTdxg4EYDt/dk7Y4KkBr/2xU5aM0WROK+EEYweYWcWMX4
+        C55eHULQsYwCfOcYiV4P+qEfpIEfOz5P0zBKgl7Q5U4MPYDU92LgLA676GGtSIDMmEoPbJtV4mYh
+        TFbHJICtoCq1nYPBkJcKrqWIrw1oo236nM/zNZHRYGwE2cRB2xffjfp94uV7JbTdIgkJAoWZ87Iu
+        MI2djrUEJVLBmRGYHqjm/jdgnqZMauhYCpimR1ZdaLEo8EnHoi/M1Ar1L2opO1bF1rJkCKKfu89z
+        8wMuZiaX81OV34T3ksDuL/2ArPrs3g+nVlu37UNcNcbmtQHIciEocDprqhyfUfsJu93QP21HD+H3
+        v0eSP8/c0WS2IRtLzHF17k1zqL1DtdQaFC8Lg+nUFE5tN5b/WH4L0MJCHWw0He+/io5safuV5/sx
+        fH0vLaUsV4g9p3pa0yfm7d8gZLX/LopFewMI2tqlyQB1Qvo7clpgn2hjqQFssZNgZxEJmdAosYKk
+        jZEDBMmsCuSxbVpYY6uONVeiotJuResEiIZKtWCF2DQ9opUhBFJKNj21jUsNAIGwxOxqhdwjtnal
+        xJLxNcmggINYoqbtrZ1B0ZhZVzSYHjHipLAwMGdJTmXWtMvzAflVgoex+lWC7SrnqwT3Qwub2Un1
+        XlSCFVPUN6zBP8ftsO9EseuAl/S9OPY8vx94aQjc9RmwHg+Tvu+n4IW0p3/SgnYc4S1ufn/qtdhc
+        Lr5z9wMb1lyK4gXFQq1App+xGceKFTzDxfj3/yZy7Y3llgsZbdlHW0i4UqUBbt7sqIeTwwoLBYvl
+        yQb7by1oqOKkNLWeIzW+dxiKtFQcmpVY4nggjmWaYhY0m83PJod+0D77esP7c+zyvw9nIuHEarwi
+        H3a/AEcQs0B5DgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      etag:
+      - W/"e015dbfbabc982ab9aea9ad83241111c"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B1FED:C795C7F:5ED65FE8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3782'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2053:C795CFC:5ED65FE8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3781'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/969e0a8ee8c6eb9d9ffa1e91a87924109743503b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUy67aMBD9FeQ1EMcJeSBV6gIWLAJChSKoKjROJsSQB4qdS+GKf+9YtFK7A+ne
+        TWTP+PjMnDnxO9MFsDGLgxg5RIhRGqCMszjPwcXYhSiMhe/yOPS9Efck67O6yXCvMgIlk22wFLGR
+        m5Inx62/mMx+JavlbXE8icVmfdmuinK3Ko7z6rtabJajXbUrks16lGym/vx2us4n08tilfLktr4k
+        YvaFLu/aki4ujDnrsePAWQ0PyhSdHKZN5bR4brRToQFtmhYHpZIDg9pox373++qaAeXQOARyCFEp
+        yr3QWmGqcv9/Cf/QP0P8IH2FEzpTNC0bv7MaKqTmvxVQQNubvrVNTYpgBcpqQnOi8BBt+OvBBq0m
+        dIB6tjDBBR/wYMDFyvXHbjx2wx2799mjIoOfSGFapAre/1gpDDEKPD/3Pcm9NM+DOPNDf5RyiSFi
+        7gmJKchg9LHTtjVo52luEqZCreFgpZvVyigoe9Y9Z0hPFO09ZKMaz9BibTQb//jbYMRj6XIUWSSk
+        FMKLfJEHmLoeIIRpkEWel6MI7L/yCXZ+gf3D7Pw05/1nn71hq3KVglHkX3LFY4/0YORQauyzFkHb
+        FOtqrQ41ZfrMLsB0LY2j7srSyn4tGyCQ3d7vvwGiUDegqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      etag:
+      - W/"09f7dc1ab99a61ff4a44597817fd569f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B212B:C795DF1:5ED65FE9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3780'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["969e0a8ee8c6eb9d9ffa1e91a87924109743503b"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"21b49bf48db8a64b5c0179775e84a601a0b8351b","node_id":"MDY6Q29tbWl0MjY4ODIxMTQzOjIxYjQ5YmY0OGRiOGE2NGI1YzAxNzk3NzVlODRhNjAxYTBiODM1MWI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/21b49bf48db8a64b5c0179775e84a601a0b8351b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/21b49bf48db8a64b5c0179775e84a601a0b8351b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:21Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:21Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"969e0a8ee8c6eb9d9ffa1e91a87924109743503b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/969e0a8ee8c6eb9d9ffa1e91a87924109743503b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/969e0a8ee8c6eb9d9ffa1e91a87924109743503b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:22 GMT
+      etag:
+      - '"fa358558a1208c3e0b37d942d29f43c3"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/21b49bf48db8a64b5c0179775e84a601a0b8351b
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B21A0:C795E97:5ED65FE9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3779'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngpOShjgzKrSShSq1qcoS2fEFG8VJZB+oAfHfe6hjlw4sb3n3
+        3fsuLEDLyltGbkGZyL2KCIE9sH4wUDtDrVzJ/MNXXh6+su3q5Vu+v523/Wu36+VJrSu728iT/nw+
+        m3U1EXgMHUEWcYwl52p0871De9TzZvA8wDjQCCDNDAFmndMzhIiR37Ku/WQUdYCcILr+6zXoAzTI
+        yguLVtGQyAUkqgAomhy0MKJtVQoiVcVSPGZpIpbZ4ilZaDLDaQQiyMM7vK/p78/I/21zvf4ADP1+
+        En0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:22 GMT
+      etag:
+      - W/"3bd1f6f0a889248ede3534f525eedfca"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2281:C795F8C:5ED65FEA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3778'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "21b49bf48db8a64b5c0179775e84a601a0b8351b"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy27CMBBF/8XrgpPiPMgalbaShSq1qcomsuMBB8VxZA+oAfHvHdRlN12wuZs7
+        Z+65sAA7Vt0ycgvKRO5URAjsgQ3eQNMZauVK5h+udvLwJTarl2/5/nbeDK/9dpAnta7t9lme9OfT
+        2azricBj6AmyiGOsOFdjN993aI963nrHA4yeRgBpxgeY9Z2eIUSM/JZN4yajqAPkBNH1Xy+vD9Ai
+        qy4sWkVDj6kWS70TpdGlyoXO2iQtlkWRQSlUnqQq0eUiSzWZ4TQCEeThOryv6e/PyP9tc73+AFB7
+        +CF9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:23 GMT
+      etag:
+      - W/"6b53e2f81c16e157c525091b5d792023"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B22E2:C79602D:5ED65FEA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3777'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:23 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B245A:C7961FA:5ED65FEB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3776'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUU/jOBDHv0tfD0hbEAeVVnsP7K10Eot0uoe9fYmcxE3cJnHOdtotEd/9/mMn
+        TdotUIofeYHWtX8zHs+Mx9OMRDKaTa9vbqaTydXl2aiUCQ9pbHR/92X9kP+Vx19vH9n3v1dxudx8
+        W6RX94svP7/d3X8aYTIrOGYark0YFpuEGaa5wQ/zOs/D9teCY9RIxc9zEZ3TXB38uqJSYsUMaHOW
+        a342kuuSq9GsGeUyFSWEHMBAEGl6fT3+fTq9mewpv3lY3m5+TP+s2fcqS77mq2jx7/T+Lt7cL9Kf
+        WMogj6mwVjnomTGVngWBG9SXF6kwWR3VmqtYloaX5iKWRVAHnbDPq09XgKSqxViTYWAPV4mW5JYD
+        p4PDO8lMke8p43SwKw+vmcs8l2sw93dxpNhgC6AzszBRpu+DAdAE0mQcpsV2n8hIAmd+KtUubgL6
+        B78knMaxKZ6cCmyXQ0lysacmULySlltHOlaiMkKWJ6u7AwFUqpSV4pG9CwqIBosUPVkxuxgQvoIz
+        n0xxq5vAhmu8IbMpHnOxwnm8j7yHAdhsKsouDwML0ikJw0OWFJQUbK54OkP0vjF2DiSghG8PfzQr
+        kb8oItRym5BeDGxr3ENBekAQUV+x/9E4BDBgsMqSb7wxidUE+NvGW4zEwCKpGJK4NyE70CYYfiWn
+        MpwV3mRZGKCZlP4sb2GACq1rfpTvH3+qlqmDLtjKuohcJj0mxI4X42jYA9NapCXn3iy+BTZBdwlE
+        ipVx5k9Ex2sC98l6DUu9bYFYQEa5jLwxcaEHFtgEOmPuajShT61JAvF2BCg+97oF4m0FGOXRb6z6
+        BNzicVsbuJA3/Tte0LQnkLMyrVnqT8IWSJcVSpWUPb5aoR0fsz0ReCpNlYhqv4m5Z9IOXFGE/OPv
+        CHpkL8BWXS+XdG8w0qCSs2YqCvFazXM8vcXthJhnERQH+2Lo++ul29u2Qbwm6O8Xd5m1knydRnub
+        dfoP5bVvK2+u1fGC5reKmYwyLMRWTHFfm2lxQRPhqft0cXHRZJzZZ0nBlccs4mjAMhVnKK996d90
+        PFSOBTP2+TMn9RM8h3LJEm9nsQUC7lzA1x4cbehHFep1b4pb2JBeiBxdC1n6uyN64lBOKY2Yi/iY
+        t+LxYb4DbT5rUcb8jOF5g6gwIhaIEzzZyQNQ5HN/VnQ0bA89IvdMzDlCxtspKe54TeC6Agmvcrnx
+        miEHSEokiqNBlYTM4FE6HU/H5+Pr8/H0n8nVbHI7m1z+wJy6Qg/s2TnTMc2pap09P8VikP7bWMEn
+        dKVebgTtvzGp4wSI1lkP+aNHzA70kp5BxDmcfi9qT9NltX+3vw2D7WSy4BXqtO5xrsUjPo93aqxY
+        1iVOB4NrZvDYQM3SD3V1WQfImA5dJhnNjKrRc6SRSskFj40ejvWZbDBxLZZiZyHVkNtugXvk98IL
+        oZRsm42uudDmYbQN245nIjSLct4PyIqXrYbDbYiYl3prBtcAoC0Ppu+YwH5J+JzVuQndW4naqejJ
+        osEKd+SqgBmo50Xt1raz4gxCrtrtkbKi+4yGi+FFFTrvMHLJqT8LFLKKXIf6v5rB9ewF1i12v9gh
+        bIWqsd1fFKfrdHdNggBHq8dpHKI4bIldg3jYFvroE9fRR5/4o0/80Sd2nXa6/g70iUtu1miYDrLp
+        8HnbZeun/wF1fdNjFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:23 GMT
+      etag:
+      - W/"31dde6867045990d8a8b84c17b2e8304"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B24BD:C79627E:5ED65FEB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3775'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy27CMBBF/8XrgpPiPMgalbaShSq1qcomsuMBB8VxZA+oAfHvHdRlN12wuZs7
+        Z+65sAA7Vt0ycgvKRO5URAjsgQ3eQNMZauVK5h+udvLwJTarl2/5/nbeDK/9dpAnta7t9lme9OfT
+        2azricBj6AmyiGOsOFdjN993aI963nrHA4yeRgBpxgeY9Z2eIUSM/JZN4yajqAPkBNH1Xy+vD9Ai
+        qy4sWkVDj6kWS70TpdGlyoXO2iQtlkWRQSlUnqQq0eUiSzWZ4TQCEeThOryv6e/PyP9tc73+AFB7
+        +CF9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:23 GMT
+      etag:
+      - W/"6b53e2f81c16e157c525091b5d792023"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B256F:C79636D:5ED65FEB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3774'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/21b49bf48db8a64b5c0179775e84a601a0b8351b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VT24rbMBD9lUXPSSz5LkOhW7KEPCQm29DFLSWM7EmsrG9Y8pJNyL9XarqwfUtg
+        98VoZjQ6Z84cn4gqgSTEZcLnYuvHhYgh9EWQUxbxKAow9iGkDKiIvYAJMiJNW+BGFqZpMc3Clcu1
+        eKroYp/56XR+WKxXx3Q/P2T7VZDVGU1njzKdPbjL2Zxlx/vD8vjsLY8/qnT6WC7394ds/U2m0wVb
+        PM2/mMeHvjIPl1p3KnEc6ORkJ3U5iEne1k6PXaucGjUo3fY4rqQYa1RaOfa72dSvBZgaasc0Oaaj
+        lqZ2w2ilrqvN/xTewV8DfAG9BRMGXbY9SU6kgRrN8N9LKKG/e3jp28YogjVIq4nZk0lP0Ka/7mzS
+        amIumJltm0tdOqbhmLpr5ieMJy77Sc4jcmGk8RMhdI+GwemflRiwHPJC5LyIgiCMIlZ4Lg0wQORB
+        HESuFwrqMfdjt205KOdqbCNMjUrBzko3Na7pIH820d3QWT0LQ66DHhutSPLrbTIecqQQI8Z5iIIX
+        fLsFhpxBHHHXZ5RHvhdQz/4kn+DjG9A/zMdXY55/j8gL9nIrc9DSGNfY4RIbLZMtVApHpEdQtkSG
+        Rsld81dlewA99GYPzVBVVvbXqgXTZMPz+Q/gcNvSoQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:24 GMT
+      etag:
+      - W/"fa358558a1208c3e0b37d942d29f43c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B25EA:C7963FF:5ED65FEB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3773'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=21b49bf48db8a64b5c0179775e84a601a0b8351b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T32vbMBDH/xc/t5Ec/5AdGKMJW0lgGese5oRAkCw5VipLxlIa0tL/vafGjDbd
+        Q9aNsRdJ3OnuPtx97yHQtBHBKODU0ZaWt3QjBltrdHARtNTVv/bYmoKDsRRXHGfZMMFDnEeUJDgi
+        KSdpyrOURpxkZFhWGFJZeQ9FwjC+CHadgtjaudaOEKKtHGykq3dsUJoGdaI1FjXCUetMJy6VZJdO
+        WGeRP9fr5uA5rXCoNNoJDY5T8I+dqD4MQxbnrIozzjKaxiwpcUhyQhKRxTTFIcUsi5KQAVrtGrV+
+        DfUC6BwUpgxD51Z8wwsIUO+E4N1tgVTI81j0G9PhZq+VofwEoqP7fjY7K7q+4c9jOqcrf9IQd2i9
+        JiupBLSnrwwGsTeb6WSGRTFW0y28m/k9l1M7vXq27xY/wt4eJsvrz3hRzBWfHP0rDT8Oy2J+x4vZ
+        dll8kV/lmE3kFUSOyfH279l+UdyYY/abml9/umOFOqz0z8jvybaMFrKPzP1dfGvzlV8ZoUvDpd74
+        7QCZpjHY1krqWxuMHgIrVPVfaR/U8jd43iU6v3cviv/bnXt8fAI8atiI+QQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:24 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2659:C796483:5ED65FEC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3772'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:24 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B26E7:C79652C:5ED65FEC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3771'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUU/jOBDHv0tfD0hbEAeVVnsP7K10Eot0uoe9fYmcxE3cJnHOdtotEd/9/mMn
+        TdotUIofeYHWtX8zHs+Mx9OMRDKaTa9vbqaTydXl2aiUCQ9pbHR/92X9kP+Vx19vH9n3v1dxudx8
+        W6RX94svP7/d3X8aYTIrOGYark0YFpuEGaa5wQ/zOs/D9teCY9RIxc9zEZ3TXB38uqJSYsUMaHOW
+        a342kuuSq9GsGeUyFSWEHMBAEGl6fT3+fTq9mewpv3lY3m5+TP+s2fcqS77mq2jx7/T+Lt7cL9Kf
+        WMogj6mwVjnomTGVngWBG9SXF6kwWR3VmqtYloaX5iKWRVAHnbDPq09XgKSqxViTYWAPV4mW5JYD
+        p4PDO8lMke8p43SwKw+vmcs8l2sw93dxpNhgC6AzszBRpu+DAdAE0mQcpsV2n8hIAmd+KtUubgL6
+        B78knMaxKZ6cCmyXQ0lysacmULySlltHOlaiMkKWJ6u7AwFUqpSV4pG9CwqIBosUPVkxuxgQvoIz
+        n0xxq5vAhmu8IbMpHnOxwnm8j7yHAdhsKsouDwML0ikJw0OWFJQUbK54OkP0vjF2DiSghG8PfzQr
+        kb8oItRym5BeDGxr3ENBekAQUV+x/9E4BDBgsMqSb7wxidUE+NvGW4zEwCKpGJK4NyE70CYYfiWn
+        MpwV3mRZGKCZlP4sb2GACq1rfpTvH3+qlqmDLtjKuohcJj0mxI4X42jYA9NapCXn3iy+BTZBdwlE
+        ipVx5k9Ex2sC98l6DUu9bYFYQEa5jLwxcaEHFtgEOmPuajShT61JAvF2BCg+97oF4m0FGOXRb6z6
+        BNzicVsbuJA3/Tte0LQnkLMyrVnqT8IWSJcVSpWUPb5aoR0fsz0ReCpNlYhqv4m5Z9IOXFGE/OPv
+        CHpkL8BWXS+XdG8w0qCSs2YqCvFazXM8vcXthJhnERQH+2Lo++ul29u2Qbwm6O8Xd5m1knydRnub
+        dfoP5bVvK2+u1fGC5reKmYwyLMRWTHFfm2lxQRPhqft0cXHRZJzZZ0nBlccs4mjAMhVnKK996d90
+        PFSOBTP2+TMn9RM8h3LJEm9nsQUC7lzA1x4cbehHFep1b4pb2JBeiBxdC1n6uyN64lBOKY2Yi/iY
+        t+LxYb4DbT5rUcb8jOF5g6gwIhaIEzzZyQNQ5HN/VnQ0bA89IvdMzDlCxtspKe54TeC6Agmvcrnx
+        miEHSEokiqNBlYTM4FE6HU/H5+Pr8/H0n8nVbHI7m1z+wJy6Qg/s2TnTMc2pap09P8VikP7bWMEn
+        dKVebgTtvzGp4wSI1lkP+aNHzA70kp5BxDmcfi9qT9NltX+3vw2D7WSy4BXqtO5xrsUjPo93aqxY
+        1iVOB4NrZvDYQM3SD3V1WQfImA5dJhnNjKrRc6SRSskFj40ejvWZbDBxLZZiZyHVkNtugXvk98IL
+        oZRsm42uudDmYbQN245nIjSLct4PyIqXrYbDbYiYl3prBtcAoC0Ppu+YwH5J+JzVuQndW4naqejJ
+        osEKd+SqgBmo50Xt1raz4gxCrtrtkbKi+4yGi+FFFTrvMHLJqT8LFLKKXIf6v5rB9ewF1i12v9gh
+        bIWqsd1fFKfrdHdNggBHq8dpHKI4bIldg3jYFvroE9fRR5/4o0/80Sd2nXa6/g70iUtu1miYDrLp
+        8HnbZeun/wF1fdNjFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      etag:
+      - W/"31dde6867045990d8a8b84c17b2e8304"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2769:C7965D7:5ED65FEC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3770'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XWW/aQBD+K5Wfk/jAB0aqeogqygOgtOnhVhVar8d4ia/urgkB8d87Y6ApPKQ4
+        St/ygvCuv5lv7vHaKFkBxsAomNIgjTODV0UhtDFYGypjeOHYsRvGqdtP4j7z3djjlh2EQeBB32W+
+        ZTMr7vc8O0ZoWSUwFQmCRsPIv3ZCHX/NrdE8cifDq+Xo5no1mV8to/m1FxWRNbn8KCaXH5zx5ZUd
+        rd4tx6vb3nj1JZ8MP2bj+btldPNeTIYje/T16vUBL9borJLEcMf9U8YyJl99WMiqxDehYCJHEsgf
+        jy+Ajt/O6PACjcMXEqbJZMdyrHPLP7ecG9sd2OHAsb8bm70HyBv/TUUBSrEZkRgyzWrGb/HpVVMT
+        swQZagl4uQ+BzWzOeBLzMAk8zw8CO+k5lgceQOj1vcDp+bHVsx0ENpIsz7Su1cA0WS0uZkJnTUyW
+        mxLqSpkFaIx1JeE8F/G5BqWVSb/TaXGP+pkCbSLIJA7KPFk3Ou4ZlW+zUJkdso8gUOopr5oS89c6
+        MxYgRSo40wLzAr25fUYHD1KWKzgzJDBFV0ZTKjErW9fTH6Ybif4vmzw/M2p2n1cMQfS4eT4zn2Bi
+        pot8eujlv8J7SmC3Sp/gVnWk98mp1dVscxdXhbF5qPy8mgkKnMra8sY76js+VkfvsA9d+1++jXM+
+        j+zxTbQiGQvMcXlsTXuonF21NAokr0qN6dQWTmO2kt8sXrsoYSZ3MtpW96+iI1nKfOD5eAwf3kur
+        PK/uEHtM9bCmD8Sbf0DIavtflLPuAhC0NiudAfoJ6W/IaIF9ooukFrDGToKdRSQkQqGLJSRdhOwg
+        SOauRB7rtoW1sppYcSlqKu1OtA6AKKiSM1aKVdsjOglCIKVk21O7mNQCEAgLzK5OyC1ibdZSLBi/
+        JzdI4CAW6NPu0o6gKEzf1zSRPmPEycNCw5QlBZVZ2y6PJ+NLCe7G6ksJdquclxLcDi1sZgfVe1IJ
+        1kxS3zAGP/bbYeiHYLE+QJ/7EIdJmKbMhtBm/SB0XNsKA7fnWT1a0J9pQduP8A6aH596HTaXk3Vu
+        fmLDmuaivEVnoa8gT59jM44lK3mGi/GfDyYy7S/JHRcy2rL3spBwLSsNnD4C9jvq7mS3wkLJ4vxg
+        g/3VCBqqOCl1o6ZIjW8NhjKtJId2Jc5xPBDHKk0xC9rNZtnm0E/aZx80PD7HTv98OHISTqzWKrJh
+        8xukTQmfcg4AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      etag:
+      - W/"87fc77134e44cd246393738b34cc6fa8"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B27F3:C796687:5ED65FED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3769'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ],
+      \n  \"author\": \"jimbob@example.com\"\n}", "path": "datapackage.json", "type":
+      "blob", "mode": "100644"}], "base_tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '322'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"d1de3d252682e84d484fb8e42995b89cdfbb14ee","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/d1de3d252682e84d484fb8e42995b89cdfbb14ee","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"5be26dd4cd4fac4a5ff8befab9702deb9c4b40f2","size":149,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/5be26dd4cd4fac4a5ff8befab9702deb9c4b40f2"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      etag:
+      - '"653fd33ede1e8da8bd8e49b286d37385"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/d1de3d252682e84d484fb8e42995b89cdfbb14ee
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B286E:C796715:5ED65FED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3768'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/21b49bf48db8a64b5c0179775e84a601a0b8351b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VT24rbMBD9lUXPSSz5LkOhW7KEPCQm29DFLSWM7EmsrG9Y8pJNyL9XarqwfUtg
+        98VoZjQ6Z84cn4gqgSTEZcLnYuvHhYgh9EWQUxbxKAow9iGkDKiIvYAJMiJNW+BGFqZpMc3Clcu1
+        eKroYp/56XR+WKxXx3Q/P2T7VZDVGU1njzKdPbjL2Zxlx/vD8vjsLY8/qnT6WC7394ds/U2m0wVb
+        PM2/mMeHvjIPl1p3KnEc6ORkJ3U5iEne1k6PXaucGjUo3fY4rqQYa1RaOfa72dSvBZgaasc0Oaaj
+        lqZ2w2ilrqvN/xTewV8DfAG9BRMGXbY9SU6kgRrN8N9LKKG/e3jp28YogjVIq4nZk0lP0Ka/7mzS
+        amIumJltm0tdOqbhmLpr5ieMJy77Sc4jcmGk8RMhdI+GwemflRiwHPJC5LyIgiCMIlZ4Lg0wQORB
+        HESuFwrqMfdjt205KOdqbCNMjUrBzko3Na7pIH820d3QWT0LQ66DHhutSPLrbTIecqQQI8Z5iIIX
+        fLsFhpxBHHHXZ5RHvhdQz/4kn+DjG9A/zMdXY55/j8gL9nIrc9DSGNfY4RIbLZMtVApHpEdQtkSG
+        Rsld81dlewA99GYPzVBVVvbXqgXTZMPz+Q/gcNvSoQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      etag:
+      - W/"fa358558a1208c3e0b37d942d29f43c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2921:C7967EB:5ED65FED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3767'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["21b49bf48db8a64b5c0179775e84a601a0b8351b"],
+      "message": "Datapackage updated", "tree": "d1de3d252682e84d484fb8e42995b89cdfbb14ee"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"53ce2d6eb7e436627c58d8a314ded7777ab4c53e","node_id":"MDY6Q29tbWl0MjY4ODIxMTQzOjUzY2UyZDZlYjdlNDM2NjI3YzU4ZDhhMzE0ZGVkNzc3N2FiNGM1M2U=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/53ce2d6eb7e436627c58d8a314ded7777ab4c53e","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/53ce2d6eb7e436627c58d8a314ded7777ab4c53e","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:26Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:26Z"},"tree":{"sha":"d1de3d252682e84d484fb8e42995b89cdfbb14ee","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/d1de3d252682e84d484fb8e42995b89cdfbb14ee"},"message":"Datapackage
+        updated","parents":[{"sha":"21b49bf48db8a64b5c0179775e84a601a0b8351b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/21b49bf48db8a64b5c0179775e84a601a0b8351b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/21b49bf48db8a64b5c0179775e84a601a0b8351b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:26 GMT
+      etag:
+      - '"2339c57cbf03574d733c68d8aa1b384f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/53ce2d6eb7e436627c58d8a314ded7777ab4c53e
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2997:C79687F:5ED65FED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3766'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy27CMBBF/8XrgpPiPMgalbaShSq1qcomsuMBB8VxZA+oAfHvHdRlN12wuZs7
+        Z+65sAA7Vt0ycgvKRO5URAjsgQ3eQNMZauVK5h+udvLwJTarl2/5/nbeDK/9dpAnta7t9lme9OfT
+        2azricBj6AmyiGOsOFdjN993aI963nrHA4yeRgBpxgeY9Z2eIUSM/JZN4yajqAPkBNH1Xy+vD9Ai
+        qy4sWkVDj6kWS70TpdGlyoXO2iQtlkWRQSlUnqQq0eUiSzWZ4TQCEeThOryv6e/PyP9tc73+AFB7
+        +CF9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:26 GMT
+      etag:
+      - W/"6b53e2f81c16e157c525091b5d792023"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2A77:C796979:5ED65FEE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3765'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "53ce2d6eb7e436627c58d8a314ded7777ab4c53e"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Ou24CMRBF/8U1YIV9oa0Rj0gWikQ2Cs3KjwEbrdcre0BZEP+eQSnTpMgUt5k5
+        c8+dRTiy+pmJW5AmcS8TQmQT1gcDrTO0FUtRvvvGi/Nnvltuv8T+7bbrX7tDL65y3djDRlzVx+pm
+        1s1I4CV2BFnEIdWcy8HNTg7tRc108DzCEKgEkGpChGnn1BQhYeLPbFs/Gkk7QE4QXf/2CuoMGll9
+        Z8lKKioyDXNTgqogz8pyXuliYRYye8kNmIpGqlwXGZAZjgMQQR7e4f+a/vxM/M82j8c3YF3PKn0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:27 GMT
+      etag:
+      - W/"5888fbbb78619896acc6b7edaf01c6cf"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2AC9:C796A0D:5ED65FEE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3764'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:27 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2C87:C796C09:5ED65FEF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3763'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXJpHtZNPEQNE9pC2wQBpgsYe2F4GSaImxJGpJyq4j5N33H1Ky
+        ZK+TOA6PuSQ2TX4zHM4Mh9OMRDKaTS+vrqaTycX5yaiUCQ9pbHR782V1l/+Vx9+uH9iPv5dxuVh/
+        v08vbu+//P5+c/tphMms4JhpuDZhWKwTZpjmBj/M6zwP218LjlEjFT/NRXRKc3Xw/xWVEktmQJuz
+        XPOTkVyVXI1mzSiXqSghZA8GgkjTy8vxx+n0arKj/Ppucb3+Nf1asx9VlnzLl9H9z+ntTby+vU9/
+        YymDPKbCWuWgZ8ZUehYEblCfn6XCZHVUa65iWRpemrNYFkEddMI+Lz9dAJKqFmNNhoEdXCVaklsO
+        nA727yQzRb6jjNPBrty/Zi7zXK7A3N3FgWKDDYDOzMJEmb4NBkATSJNxmBbbfSQjCZz5sVS7uAno
+        H/yScBrHpnhyLLBdDiXJxR6bQPFKWm4d6ViJyghZHq3uFgRQqVJWigf2JiggGixS9GjF7GJA+BLO
+        fDTFrW4CG67xmsymeMzFEufxNvIOBmCzrii73A0sSKckDA9ZUlBSsLni8QTR+8rY2ZOAEr45/NGs
+        RP6iiFCLTUJ6NrCtcfcF6R5BRH3B/gfjEMCAwSoLvvbGJFYT4G8bbzESA4ukYkji3oRsQZtg+JWc
+        ynBWeJNlYYBmUvqzvIUBKrSu+UG+f/ipWqYOumAr6yJymfSQEDtcjKNhD0xrkZace7P4BtgE3SUQ
+        KVbGmT8RHa8J3CfrNSz1tgViARnlMvLGxIUeWGAT6Iy5q9GEPrUmCcTbEqD43OsWiLcRYJRHv7Hq
+        E3CDx21t4ELe9O94QdOeQM7KtGapPwkbIF1WKFVS9vBihXZ4zPZE4Kk0VSKq/Sbmnkk7cEUR8o+/
+        I+iRvQBbdT1f0r3CSINKzpqpKMRLNc/h9Ba3FWKeRVAc7Iqh7y+Xbq/bBvGaoL9f3GXWSvJ1Gu1t
+        1uk/lNe+rby5VscLmg8VMxllWIitmOK+NtPigibCU/fx7OysyTizz5KCK49ZxNGAZSrOUF770r/p
+        eKgcC2bs82dO6id4DuWSJd7OYgME3LmArz042tCPKtTr3hS3sCG9EDm6FrL0d0f0xKGcUhoxF/Eh
+        b8XDw3wL2nzWooz5CcPzBlFhRCwQJ3iykwegyOf+rOho2B56RO6ZmHOEjLdTUtzxmsB1BRJe5XLt
+        NUMOkJRIFEeDKgmZwaN0Op6OT8eXp+PpP5OL2eR6Njn/hTl1hR7Yk3Omf9CcqtbZ01M+0hSk/zZW
+        8AldqecbQbtvTOo4AaJ11kP+7BGzPb2kJxBxDqffidrjdFnu3u2vw2A7mSx4hTqte5xr8YDP460a
+        K5Z1idPB4IoZPDZQs/RDXV3WATKmQ5dJRjOjavQcaaRS8p7HRg/H+kw2mLgSC7G1kGrITbfAPfJ7
+        4YVQSrbNRtdcaPMw2oZtxzMRmkU57wdkxctWw+E2RMxLvTGDawDQlgfTt0xgvyR8zurchO6tRO1U
+        9GTRYIU7clXADNTzonZr21lxBiFX7fZIWdF9RsPF8KIKnXcYueDUnwUKWUWuQv1vzeB69gLrFrtf
+        7BC2QtXY9i+K03W6vSZBgKPV4zQOURy2xK5BPGwLvfeJ6+i9T/zeJ37vE7tOO11/e/rEJTcrNEwH
+        2XT4vO2y9eN/fBep6hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:28 GMT
+      etag:
+      - W/"7757dd17dc265e6c6b9bac9cec901746"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2CED:C796CB5:5ED65FEF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3762'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/21b49bf48db8a64b5c0179775e84a601a0b8351b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VT24rbMBD9lUXPSSz5LkOhW7KEPCQm29DFLSWM7EmsrG9Y8pJNyL9XarqwfUtg
+        98VoZjQ6Z84cn4gqgSTEZcLnYuvHhYgh9EWQUxbxKAow9iGkDKiIvYAJMiJNW+BGFqZpMc3Clcu1
+        eKroYp/56XR+WKxXx3Q/P2T7VZDVGU1njzKdPbjL2Zxlx/vD8vjsLY8/qnT6WC7394ds/U2m0wVb
+        PM2/mMeHvjIPl1p3KnEc6ORkJ3U5iEne1k6PXaucGjUo3fY4rqQYa1RaOfa72dSvBZgaasc0Oaaj
+        lqZ2w2ilrqvN/xTewV8DfAG9BRMGXbY9SU6kgRrN8N9LKKG/e3jp28YogjVIq4nZk0lP0Ka/7mzS
+        amIumJltm0tdOqbhmLpr5ieMJy77Sc4jcmGk8RMhdI+GwemflRiwHPJC5LyIgiCMIlZ4Lg0wQORB
+        HESuFwrqMfdjt205KOdqbCNMjUrBzko3Na7pIH820d3QWT0LQ66DHhutSPLrbTIecqQQI8Z5iIIX
+        fLsFhpxBHHHXZ5RHvhdQz/4kn+DjG9A/zMdXY55/j8gL9nIrc9DSGNfY4RIbLZMtVApHpEdQtkSG
+        Rsld81dlewA99GYPzVBVVvbXqgXTZMPz+Q/gcNvSoQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:28 GMT
+      etag:
+      - W/"fa358558a1208c3e0b37d942d29f43c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2D90:C796D56:5ED65FF0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3761'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=21b49bf48db8a64b5c0179775e84a601a0b8351b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T32vbMBDH/xc/t5Ec/5AdGKMJW0lgGese5oRAkCw5VipLxlIa0tL/vafGjDbd
+        Q9aNsRdJ3OnuPtx97yHQtBHBKODU0ZaWt3QjBltrdHARtNTVv/bYmoKDsRRXHGfZMMFDnEeUJDgi
+        KSdpyrOURpxkZFhWGFJZeQ9FwjC+CHadgtjaudaOEKKtHGykq3dsUJoGdaI1FjXCUetMJy6VZJdO
+        WGeRP9fr5uA5rXCoNNoJDY5T8I+dqD4MQxbnrIozzjKaxiwpcUhyQhKRxTTFIcUsi5KQAVrtGrV+
+        DfUC6BwUpgxD51Z8wwsIUO+E4N1tgVTI81j0G9PhZq+VofwEoqP7fjY7K7q+4c9jOqcrf9IQd2i9
+        JiupBLSnrwwGsTeb6WSGRTFW0y28m/k9l1M7vXq27xY/wt4eJsvrz3hRzBWfHP0rDT8Oy2J+x4vZ
+        dll8kV/lmE3kFUSOyfH279l+UdyYY/abml9/umOFOqz0z8jvybaMFrKPzP1dfGvzlV8ZoUvDpd74
+        7QCZpjHY1krqWxuMHgIrVPVfaR/U8jd43iU6v3cviv/bnXt8fAI8atiI+QQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:28 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2DFB:C796DFC:5ED65FF0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3760'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:28 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2E72:C796E91:5ED65FF0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3759'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXJpHtZNPEQNE9pC2wQBpgsYe2F4GSaImxJGpJyq4j5N33H1Ky
+        ZK+TOA6PuSQ2TX4zHM4Mh9OMRDKaTS+vrqaTycX5yaiUCQ9pbHR782V1l/+Vx9+uH9iPv5dxuVh/
+        v08vbu+//P5+c/tphMms4JhpuDZhWKwTZpjmBj/M6zwP218LjlEjFT/NRXRKc3Xw/xWVEktmQJuz
+        XPOTkVyVXI1mzSiXqSghZA8GgkjTy8vxx+n0arKj/Ppucb3+Nf1asx9VlnzLl9H9z+ntTby+vU9/
+        YymDPKbCWuWgZ8ZUehYEblCfn6XCZHVUa65iWRpemrNYFkEddMI+Lz9dAJKqFmNNhoEdXCVaklsO
+        nA727yQzRb6jjNPBrty/Zi7zXK7A3N3FgWKDDYDOzMJEmb4NBkATSJNxmBbbfSQjCZz5sVS7uAno
+        H/yScBrHpnhyLLBdDiXJxR6bQPFKWm4d6ViJyghZHq3uFgRQqVJWigf2JiggGixS9GjF7GJA+BLO
+        fDTFrW4CG67xmsymeMzFEufxNvIOBmCzrii73A0sSKckDA9ZUlBSsLni8QTR+8rY2ZOAEr45/NGs
+        RP6iiFCLTUJ6NrCtcfcF6R5BRH3B/gfjEMCAwSoLvvbGJFYT4G8bbzESA4ukYkji3oRsQZtg+JWc
+        ynBWeJNlYYBmUvqzvIUBKrSu+UG+f/ipWqYOumAr6yJymfSQEDtcjKNhD0xrkZace7P4BtgE3SUQ
+        KVbGmT8RHa8J3CfrNSz1tgViARnlMvLGxIUeWGAT6Iy5q9GEPrUmCcTbEqD43OsWiLcRYJRHv7Hq
+        E3CDx21t4ELe9O94QdOeQM7KtGapPwkbIF1WKFVS9vBihXZ4zPZE4Kk0VSKq/Sbmnkk7cEUR8o+/
+        I+iRvQBbdT1f0r3CSINKzpqpKMRLNc/h9Ba3FWKeRVAc7Iqh7y+Xbq/bBvGaoL9f3GXWSvJ1Gu1t
+        1uk/lNe+rby5VscLmg8VMxllWIitmOK+NtPigibCU/fx7OysyTizz5KCK49ZxNGAZSrOUF770r/p
+        eKgcC2bs82dO6id4DuWSJd7OYgME3LmArz042tCPKtTr3hS3sCG9EDm6FrL0d0f0xKGcUhoxF/Eh
+        b8XDw3wL2nzWooz5CcPzBlFhRCwQJ3iykwegyOf+rOho2B56RO6ZmHOEjLdTUtzxmsB1BRJe5XLt
+        NUMOkJRIFEeDKgmZwaN0Op6OT8eXp+PpP5OL2eR6Njn/hTl1hR7Yk3Omf9CcqtbZ01M+0hSk/zZW
+        8AldqecbQbtvTOo4AaJ11kP+7BGzPb2kJxBxDqffidrjdFnu3u2vw2A7mSx4hTqte5xr8YDP460a
+        K5Z1idPB4IoZPDZQs/RDXV3WATKmQ5dJRjOjavQcaaRS8p7HRg/H+kw2mLgSC7G1kGrITbfAPfJ7
+        4YVQSrbNRtdcaPMw2oZtxzMRmkU57wdkxctWw+E2RMxLvTGDawDQlgfTt0xgvyR8zurchO6tRO1U
+        9GTRYIU7clXADNTzonZr21lxBiFX7fZIWdF9RsPF8KIKnXcYueDUnwUKWUWuQv1vzeB69gLrFrtf
+        7BC2QtXY9i+K03W6vSZBgKPV4zQOURy2xK5BPGwLvfeJ6+i9T/zeJ37vE7tOO11/e/rEJTcrNEwH
+        2XT4vO2y9eN/fBep6hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:29 GMT
+      etag:
+      - W/"7757dd17dc265e6c6b9bac9cec901746"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:25 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2EDC:C796F1C:5ED65FF0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3758'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:19:29 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C914:2668D:A7B2F52:C796FA9:5ED65FF1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3757'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_update_full.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_update_full.yaml
@@ -1,0 +1,2646 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:57 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A439B49:C379A77:5ED65FD1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3830'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:57 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A439BB5:C379AD2:5ED65FD1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3829'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821089,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEwODk=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:18:58Z","updated_at":"2020-06-02T14:18:58Z","pushed_at":"2020-06-02T14:18:59Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:59 GMT
+      etag:
+      - '"fb2408e6d6f51fee2a6feef9ac142585"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A439C7E:C379BCA:5ED65FD1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3828'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"0a7543befb140acaa17c5a822330ca735d657cf0","node_id":"MDY6Q29tbWl0MjY4ODIxMDg5OjBhNzU0M2JlZmIxNDBhY2FhMTdjNWE4MjIzMzBjYTczNWQ2NTdjZjA=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0a7543befb140acaa17c5a822330ca735d657cf0","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/0a7543befb140acaa17c5a822330ca735d657cf0","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:59Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:59Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:00 GMT
+      etag:
+      - '"49a34a295016a09e7265615e24304fd0"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A439EBE:C379EBA:5ED65FD3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3827'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTW/jNhD9K4HOTiTLkuUYWLQNsgVSwF4Em23qLBYGRY0kuhSpkpQ3tpH/3hlZ
+        2cQ+bKMgveViSKTe8M2bD453nmIVeFOvYtaB8QYe11UlnDfdebZkuBGwJI5GKeTpMAoYZ2yY8JhN
+        wnA0CjhLRnE2jhOeBwhVOoOlyBA0u1yMr8Nzl97KYLZaRJ8ur+5nl0X8aXVRzrdfgln4h7yrru7n
+        lxflIvy9nN1kq/ntx2i2utrOtherxQ3fzm+vwzmu361++3DAizWu1IYYdtw/l6xk5uTj2miFX0LF
+        hEQSyB+Xz4CWfy1o8Qydww8y5sjlMAiD02B8GoQ3w2g6nEzj8zvv4VEBUuN/O6ICa1lBJK6UcIJJ
+        sYUTpMVODNTaCqfNBok6A/jNYySGeXCe5eEoSSZhlAyjeAJZGJ6zJE2jCU9wZ5IlI6BINIYEKJ2r
+        7dT3WS3OCuHKJiUB/PYIvwKHIdcGTqVITx1YZ336XS6rDTGx4HwE+cTB+i8+G/V7w8P3yWj9HklI
+        EFBuyXWjMI2DgbcGI3LBmROYHqjm/h0wT3MmLQw8A8zSltcoKwqFOwOPHphrDOqvGikHXs02UjME
+        0evD27n5ChdLV8nlocrPwvuSwO4PfYWs9ujcV6dWX7f9Lq4WY/PUAKQuBAXOlm2V4x61n3Ecj0eH
+        7eh6/Odfc8lXi+H8ZrElG2vMcXPsTbtow65aGguGa+UwndrCafzW8i/rDxFaKExno+14/1V0ZMv6
+        Tzx/HsOn73Itpf6O2GOqhzV9YN7/AUJW+2ehiv4GELTztSsBdUL6D+S0wD7Rx1IL2GEnwc4iMjJh
+        UWIDWR8jHQTJfFfIY9e2sNZWk1puRE2l3YvWARANaVMwJbZtj+hlCIGUkm1P7eNSC0AgrDG7eiH3
+        iJ1fG7FmfEMyGOAg1qhpf2tHUDTmNjVdTF8w4qSwcLBkWUVl1rbL4wvyvQS7a/W9BPtVznsJ7i8t
+        bGYH1fuiEqyZob7hTb9+w4JcSqH+xhecFEHmbzH5pYYpXuLg9+N/AV1Yzyz3HDhoiny0hYRrox1w
+        92wG61a6EQ0US+XBhPZPI+jSwJvANXaJ1PjeYVC5NhzakU9i+yOOOs9RxPbmvu80ejoTT/h5n375
+        eHwkEnbk1ivy4eFfJXwR2FkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:01 GMT
+      etag:
+      - W/"9cf278f49e3832f86658913a43425465"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A03C:C37A09E:5ED65FD4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3826'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"xls\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"611492251181a958ff3fb89b5c857f754f7c66c1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"0db3e0dc648ef5a75823501ad0bbebe7de1b0875","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/0db3e0dc648ef5a75823501ad0bbebe7de1b0875"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:01 GMT
+      etag:
+      - '"da07e5abb3046fbdcd5e221c600f2fa6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A116:C37A1A8:5ED65FD5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3825'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0a7543befb140acaa17c5a822330ca735d657cf0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTXYvbMBD8K0HPTizLduwYCm3IFVKwj6MpISklrO11LOOPIMnHJSH/vaumD3dv
+        d9C+CGvHuzO7O7oyXQNLGIcoDPwcq9wLOBQAXlSEEAvh+7yAyA/LeRgVFWcO64cSD7KkpHS1mz+J
+        hcm3LU+bXfC4Wr+kq2P42Czr7PKDp+Jbu+/WL9lqWe/E1zrdlE22fQjSZn1JL8tmtyku2fZJZBTf
+        N18+UfFRtVS4NuakE9eFk5wdpanHfFYMnavwNGi3QwPaDAqnrcynBrXRrj0Ph+5cAmFoXEpyKaOT
+        hH2gtdp07eGthFf07yG+k36EE0ZTD4olV9ZDh9T89xpqUJOHZzX0NBHsQNqZ0J4oPEMb/ny0QTsT
+        +oF6tmmCCz7l8ykXGy9IvDgJF3t2c9hdkcH/SGEUkoLrXyt5FV+UlfCjKBZB5AVhjKUQC4jyPIiL
+        iJC4jHy0VvqH27YatPtubhpMh1rD0Y5u3UsjoZUXnFgDTf74TJLFzqTxBAp7o1ny85fDnlHJShZg
+        JO2GOr7fkR5DBa1GhykEbSE29loee0IcZj/AjIqo+rFtbclzOwAl2evt9hshXopEhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:01 GMT
+      etag:
+      - W/"2204d50eca9fd84cdcbfbd159173618f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A234:C37A2EE:5ED65FD5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3824'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["0a7543befb140acaa17c5a822330ca735d657cf0"],
+      "message": "Initial datapackage commit", "tree": "611492251181a958ff3fb89b5c857f754f7c66c1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"af434369892655bff7c5622a62768863eccb3b4a","node_id":"MDY6Q29tbWl0MjY4ODIxMDg5OmFmNDM0MzY5ODkyNjU1YmZmN2M1NjIyYTYyNzY4ODYzZWNjYjNiNGE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/af434369892655bff7c5622a62768863eccb3b4a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/af434369892655bff7c5622a62768863eccb3b4a","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:01Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:01Z"},"tree":{"sha":"611492251181a958ff3fb89b5c857f754f7c66c1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1"},"message":"Initial
+        datapackage commit","parents":[{"sha":"0a7543befb140acaa17c5a822330ca735d657cf0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0a7543befb140acaa17c5a822330ca735d657cf0","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/0a7543befb140acaa17c5a822330ca735d657cf0"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:02 GMT
+      etag:
+      - '"c43352e765eefa71f18d4a9d2b3746ea"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/af434369892655bff7c5622a62768863eccb3b4a
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A2D0:C37A39E:5ED65FD5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3823'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vnggOJSZU5KgXJYmqqskRn+0KM4iSKD9QU8d97qGOXDl3e8u67
+        993EhI0oHhlli+CiDBAJJ/Ek+sFh7R23utSbt1AFff7IDuXuU5cndej33bHXV9hW7fFVX837y5fb
+        VjODl6ljqCUaYyEljH558tRezNIOQU44DjyCxDPDhIvOmwVhpCgfWddhdsAdkmSIr397DeaMlkRx
+        E7EFHkogV1lqsDGrLAELsMqtguf1Ok0TC3mq3EbltknYjOYRmWCP4Ol/TX9+Rvlnm/v9G8bv9VV9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:02 GMT
+      etag:
+      - W/"db6ce5f28ceb2c33413bc3abc6ae719a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A3EA:C37A4F0:5ED65FD6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3822'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "af434369892655bff7c5622a62768863eccb3b4a"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngqV8mJA5graSxdRUZYns+AUbxXFkP1BTxH/vQx27dOhyl/vO
+        u+fGIgysfmTiFpRJ3KuEENkTm4KBzhlqZSPFm2+9PH8Uh+blUzan8jC9jsdJXtW+tcdnedXvuy+z
+        bxcCL3EkyCLOqeZczW59cmgvet0HzyPMgUYAaSZEWI1OrxASJv7IrvOLUdQBcoLo+rdX0GfokdU3
+        lqyiITUUeZGLbbXNRFnqYdj0pcgyJbKNqCqRQ9/rXBeKzHCZgQjy8A7/1/TnZ+J/trnfvwFbqz6D
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:03 GMT
+      etag:
+      - W/"66dc41b9b284a2284793d6a9f17afb24"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A484:C37A5A6:5ED65FD6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3821'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:03 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A694:C37A7D4:5ED65FD7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3820'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjTVPHwGJ7SLtAgTRA0cPuXgRKoi3GkqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2lGMh3NJtfT6eRyPL05G5UqFRGNje5uf1vf53/kydebR/7tr1VSLjd/
+        Piyu7h4wfrv8PMJkXgjMtMLYKCo2KbfcCIsf5nWeR+2vhcCoVVqc5zI+p7mG/X9FpeWKW9DmPDfi
+        bKTWpdCjWTPK1UKWEHIAA0Gk6fX1+JfJZHq5p/zmfnmz+TH5vebfqiz9mq/ih++Tu9tkc/ew+BdL
+        OeRxHdU6Bz2ztjIzxvyg+XSxkDar49oInajSitJeJKpgNeuEfVl9vgJkoVuMMxkG9nCVbEl+OXCG
+        Hd5JZot8Txmvg1t5eM1c5blag7m/iyPFsi2AzszBZLl4HwyAhimbCZgW230iI0mc+alUt7hh9A9+
+        STiDY9MiPRXYLoeS5GJPDdOiUo5bxybRsrJSlSeruwMBVOkFL+UjfxcUEAMWKXqyYm4xIGIFZz6Z
+        4lc3zIVrsiGzaZEIucJ5vI+8hwHYbirKLvcDC9IpSSsinhaUFFyueDpD9L4xdg4koFRsD380K5G/
+        KCL0cpuQXgxsZ9xDQXpAEFFfsf/ROAQwYLDKUmyCMYnVMPxt4y1BYuCx0hxJPJiQHWjDhl/Jqazg
+        RTBZDgZoplQ4yzsYoNKYWhzl+8efqmMa1gVbWRexz6THhNjxYjwNe+DGyEUpRDCLb4EN6y6BWPMy
+        ycKJ6HgN85+c1/BFsC0QC8g4V3EwJi505oANMxn3V6ONQmpNEoi3I0CLedAtEG8rwOqAfuPUJ+AW
+        j9vawoWC6d/xWNOeQM7LRc0X4SRsgXRZoVRZ8MdXK7TjY7YnAk+lqZZxHTYx90zagS+KkH/CHUGP
+        7AW4quvlku4NRhpUcs5MRSFfq3mOp7e4nRALLILiYF8MfX+9dHvbNojXsP5+8ZdZKynUabS3Waf/
+        UF77tgrmWh2PNT9V3GaUYSG24lqE2kyLY02Mp+7TxcVFkwnuniWF0AGziKcBy3WSobwOpX/T8VA5
+        Fty658+c1E/xHMoVT4OdxRYIuHeBUHvwtKEfVajXgynuYEN6IXN0LVQZ7o7oiUM5pbJyLpNj3orH
+        h/kOtPliZJmIM47nDaLCykQiTvBkJw9AkS/CWdHTsD30iPwzMRcImWCnpIXnNcx3BVJR5WoTNEMO
+        kJRItECDKo24xaN0Mp6Mz8fX5+PJ35dXs8vp7OfpD8ypK/TAnplzMxtPaE5Vm+z5KZ9oCtJ/Gyv4
+        hK7Uy42g/TcmdZwAMSbrIb/2iNmBXtIziCSH0+9F7Wm6rPbv9rdhsJ1MFaJCndY9zo18xOfxTo2V
+        qLrE6WBwzS0eG6hZ+qGuLusAGTeRzySjmdU1eo40Umn1IBJrhmN9JhtMXMul3FlINeS2W+Af+b3w
+        Qmqt2majby60eRhtw7bjmUrD41z0A6oSZavhcBsyEaXZmsE3AGjLg+k7JnBfUjHndW4j/1aidip6
+        smiwwh2FLmAG6nlRu7XtrHiDkKt2e6Ss6D+j4WJFUUXeO6xaCurPAoWsotaR+afmcD13gXWL/S9u
+        CFuhamz3Fy3oOt1dkyLA0erxGkcoDlti1yAetoU++sR1/NEn/ugTf/SJfaedrr8DfeJS2DUapoNs
+        Onzedtn66T8+bZOkFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:04 GMT
+      etag:
+      - W/"22a0bb5b7912e410658cb2cc3b256f38"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A7BF:C37A973:5ED65FD7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3819'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngqV8mJA5graSxdRUZYns+AUbxXFkP1BTxH/vQx27dOhyl/vO
+        u+fGIgysfmTiFpRJ3KuEENkTm4KBzhlqZSPFm2+9PH8Uh+blUzan8jC9jsdJXtW+tcdnedXvuy+z
+        bxcCL3EkyCLOqeZczW59cmgvet0HzyPMgUYAaSZEWI1OrxASJv7IrvOLUdQBcoLo+rdX0GfokdU3
+        lqyiITUUeZGLbbXNRFnqYdj0pcgyJbKNqCqRQ9/rXBeKzHCZgQjy8A7/1/TnZ+J/trnfvwFbqz6D
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      etag:
+      - W/"66dc41b9b284a2284793d6a9f17afb24"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43A860:C37AA36:5ED65FD8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3818'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/af434369892655bff7c5622a62768863eccb3b4a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZkS/6AQg/ZlhzsULplcUoJY0eOlbXsYMlLk5D/viPShfaW
+        QHoR1oxGb96bJ5+JaYCkBOowCAORxAkTnJd1HVVcMAaCRSKORSCrqgzKEMiUdP1WbtQWi7JFIb6x
+        xJYvrZ/ti3C1WP7OFju+0l90vsj87FTw1eL1mO9/0EKvdc4ymu+Xx+K5OOYnd744rV/yfbHPVf71
+        6RNePg4tXtxYezCp58FBzXfKNmM5r3rtDfLQG09LC8b2g5y1qpxZaazx3LrZ6OMWMCeth0UeVmiF
+        uTuoNVa3m39b+Av+FuAr6D2YMNqmH0h6Jh1oieS/N9DAMHl6G/oOFZEalNME54ThuXThzzsXdJrg
+        AeTsypjP/JkvZj57pmFKk9Sna3KZkmtHVv5HCDtI7OD8x0qC0jBhjFMaU0h4XNdBXcZJyauYR3XE
+        Q/SWEBV97LRdD8a7GRuF0dIY2Dnplp2yCtqJc88BqleMTq6yYY8HGGRnDUl/fhD0AUkEpaxLGvpQ
+        AVB8LBAzFgR+BVHAt4JHVe0/luCHne9Af5idb8a8/JqSNzmoWlVgFfoXXXHdS/xh1NAaOSWDBONS
+        ZOyM2nWYmRL3AXYccBzd2LZO9mPbAxa57eXyDjtQHfqoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      etag:
+      - W/"c43352e765eefa71f18d4a9d2b3746ea"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43AA63:C37AC98:5ED65FD9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3817'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=af434369892655bff7c5622a62768863eccb3b4a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft5Gf7QTGaMJWEmjLuhd1QiDo4RwrlSVjKQ1e6XffOQmly/Yi
+        68bYG0nc6e5+3P3v2dO0Bm/kCepoQ/kjXcNgY432LryGuurXHltRdPiCReALnsY5lAnNkjyMEj+g
+        wmcMGGQCAubnWYKprPyGRYIgvvC2rcLYyrnGjgihjRyspau2bMBNTVpojCU1OGqdaeFSSXbpwDpL
+        +nO1qrue04Ij3GgHGh2n4B9bKD/QMo7iKB3mwzBNElaWGU/SMKRpmKV5nkbAOYtYTBGtcrVa/Qj1
+        BugcFKYMI+dW/IkXEbDeCcG724KpSM9jyW9MR5idVoaKE4iW7o6z2Vpojw3fj+mcrvxJQ1zX9Jos
+        pQJsz7EyGmBn1tPJzIdirKYbfOvK8m5qp1d7+3b+EBzsdZAsrj/78+JWicnBv9T4o1sUt0+imG0W
+        xY28k2M2kVcYOc4Od/+e7ebFvdlnr+8rcf3piRWqW+rXyK/JhkdzeYwc9nfxpRku+5UBzY2Qeo2s
+        DGWaxmhbKakfrTd69iyo8r/SPqrlb/C8S3T93r0p/m937uXlO+xXawX5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      etag:
+      - W/"0db3e0dc648ef5a75823501ad0bbebe7de1b0875"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43AAE2:C37AD29:5ED65FD9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3816'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:06 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43ABA8:C37ADC7:5ED65FD9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3815'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjzaaOgcX2kHaBAmmAooftXgRKoi3GkqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2lGMh3NJtfT6eRyPL05G5UqFRGNje5uf13f57/nybebR/79z1VSLjd/
+        PCyu7h4wfrv8MsJkXgjMtMLYKCo2KbfcCIsf5nWeR+2vhcCoVVqc5zI+p7mG/X9FpeWKW9DmPDfi
+        bKTWpdCjWTPK1UKWEHIAA0Gk6fX1+OfJZHq5p/zmfnmz+TH5rebfqyz9lq/ih78nd7fJ5u5h8S+W
+        csjjOqp1DnpmbWVmjPlB8+liIW1Wx7UROlGlFaW9SFTBatYJ+7r6cgXIQrcYZzIM7OEq2ZL8cuAM
+        O7yTzBb5njJeB7fy8Jq5ynO1BnN/F0eKZVsAnZmDyXLxPhgADVM2EzAttvtERpI481OpbnHD6B/8
+        knAGx6ZFeiqwXQ4lycWeGqZFpRy3jk2iZWWlKk9WdwcCqNILXspH/i4oIAYsUvRkxdxiQMQKznwy
+        xa9umAvXZENm0yIRcoXzeB95DwOw3VSUXe4HFqRTklZEPC0oKbhc8XSG6H1j7BxIQKnYHv5oViJ/
+        UUTo5TYhvRjYzriHgvSAIKK+Yv+jcQhgwGCVpdgEYxKrYfjbxluCxMBjpTmSeDAhO9CGDb+SU1nB
+        i2CyHAzQTKlwlncwQKUxtTjK948/Vcc0rAu2si5in0mPCbHjxXga9sCNkYtSiGAW3wIb1l0CseZl
+        koUT0fEa5j85r+GLYFsgFpBxruJgTFzozAEbZjLur0YbhdSaJBBvR4AW86BbIN5WgNUB/capT8At
+        Hre1hQsF07/jsaY9gZyXi5ovwknYAumyQqmy4I+vVmjHx2xPBJ5KUy3jOmxi7pm0A18UIf+EO4Ie
+        2QtwVdfLJd0bjDSo5JyZikK+VvMcT29xOyEWWATFwb4Y+v566fa2bRCvYf394i+zVlKo02hvs07/
+        obz2bRXMtToea36quM0ow0JsxbUItZkWx5oYT92ni4uLJhPcPUsKoQNmEU8DluskQ3kdSv+m46Fy
+        LLh1z585qZ/iOZQrngY7iy0QcO8CofbgaUM/qlCvB1PcwYb0QuboWqgy3B3RE4dySmXlXCbHvBWP
+        D/MdaPPVyDIRZxzPG0SFlYlEnODJTh6AIl+Es6KnYXvoEflnYi4QMsFOSQvPa5jvCqSiytUmaIYc
+        ICmRaIEGVRpxi0fpZDwZn4+vz8eTvy6vZpfT2efpD8ypK/TAnplzMxt/pjlVbbLnp3yiKUj/bazg
+        E7pSLzeC9t+Y1HECxJish/zSI2YHeknPIJIcTr8Xtafpstq/29+GwXYyVYgKdVr3ODfyEZ/HOzVW
+        ouoSp4PBNbd4bKBm6Ye6uqwDZNxEPpOMZlbX6DnSSKXVg0isGY71mWwwcS2Xcmch1ZDbboF/5PfC
+        C6m1apuNvrnQ5mG0DduOZyoNj3PRD6hKlK2Gw23IRJRmawbfAKAtD6bvmMB9ScWc17mN/FuJ2qno
+        yaLBCncUuoAZqOdF7da2s+INQq7a7ZGyov+MhosVRRV577BqKag/CxSyilpH5p+aw/XcBdYt9r+4
+        IWyFqrHdX7Sg63R3TYoAR6vHaxyhOGyJXYN42Bb66BPX8Uef+KNP/NEn9p12uv4O9IlLYddomA6y
+        6fB522Xrp/8AOziE+hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:06 GMT
+      etag:
+      - W/"9489eb1d34ae95792ef609243ed57bc6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43AC1B:C37AEA1:5ED65FDA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3814'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XS2/iSBD+K5HPJH6bhzSaPZBd5YCj0WZm1llFqNy07SZ+bXebCSD++1QZMwkc
+        MjjK3nJB0HZ9/dVXT7ZGCQU3JkYBSnNpDAxWFYXQxmRrqAzwASSe67nBeDR2At+Pk2TI/MBxIHCG
+        wWgUuJyx2I09QNOyWvC5WKDRbBoFX5yxjr/n1mwZebfTm6fZNPVviz+LcDqzZpvIv50+rsPlVzsq
+        7ovQmdnh8mYd3UXrcEPvR5v77+EyWoYi/Ov60xEvaHRWSWLYcf87gwzkxfVKViW+yQsQOZJA/nh8
+        xen4j5QOr9A5fGEBmlx2LMe6tIJLy7mzvYk9nlj2vbE7KEBq/G9XFFwpSInETSm0gPwCOUEN7BFP
+        L7oQDAwtOb5ziERg297YcXzbHtkw9kdJ4ibxaBz7bOQPk6HvYWiCgNnoYSNJgEzrWk1ME2pxlQqd
+        NTEJYEpeV8osuMaQV5Jf5iK+1FxpZdLnfF6siYzi2kQjkzgo8+y7Ub93vHyvhDJ7JCGZ8FLPWdWU
+        mMbWwFhxKRLBQAtMD1Rz/5tjniaQKz4wJAdFj4ymVCIt8cnAoC+gG4n6l02eD4wa1nkFaEQ/d+/n
+        5htczHSRz49VfhHecwK7v/QNsqqTe9+cWn3dNru4KozNcwPIq1RQ4FTWVjk+o/aDfSpwj9vRl+Db
+        P2HOlpEd3kUbwlhhjstTb9pD5XTV0iguWVVqTKe2cBqzRf68+uQhQio7jLbj/a7oCEuZzzxfj+Hz
+        e0mV59UPtD2lelzTR/DmLyNktf8uyrQ/ABptzUpnHHVC+jtyWmCf6IPUGmyxk2BnEQuCUCix5Is+
+        IJ0JkvlRIo9t28JarCZWTIqaSrsXrSNDBKpkCqXYtD2iFxAaUkq2PbWPS60BGvIVZlcvy73F1qyl
+        WAFbkwySMy5WqGl/tBNTBNPrmgbTV4w4KSw0n8OioDJr2+XpgPwowW6sfpRgv8r5KMH90MJmdlS9
+        Z5VgDZL6hjH597AdWoAboBvzJLY9CxiAjYs6jBzHdS0GQ9dfBP6QJRbCv9OCdhjhPW5+fer12FzO
+        vnP3gA1rnovyEcVCrXievMdmHEsoWYaL8a//TeTaC+SeCxlt2QcsJFzLSnOmX+yo3Um3wvIS4vxo
+        g/2vETRUcVLqRs2RGts7zMukkoy3K3GO44E4VkmCWdBuNk9tDj3QPvt8w+tz7Py/Dyci4cRqvSIf
+        dj8BAaNckHkOAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:07 GMT
+      etag:
+      - W/"28f6dff115eea9156ed2a0ddae660974"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43ACBA:C37AF40:5ED65FDA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3813'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"my-data-set\"\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "611492251181a958ff3fb89b5c857f754f7c66c1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"ff1d1a6660c5d87a7356fa8b481b1f729fdb4129","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/ff1d1a6660c5d87a7356fa8b481b1f729fdb4129","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"a48842e85e97ddd6e508d0d71fd8101b146b66ee","size":27,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/a48842e85e97ddd6e508d0d71fd8101b146b66ee"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:07 GMT
+      etag:
+      - '"60a59c458ad548fa6b7c798e6a887bcd"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/ff1d1a6660c5d87a7356fa8b481b1f729fdb4129
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43ADD7:C37B07F:5ED65FDB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3812'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/af434369892655bff7c5622a62768863eccb3b4a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZkS/6AQg/ZlhzsULplcUoJY0eOlbXsYMlLk5D/viPShfaW
+        QHoR1oxGb96bJ5+JaYCkBOowCAORxAkTnJd1HVVcMAaCRSKORSCrqgzKEMiUdP1WbtQWi7JFIb6x
+        xJYvrZ/ti3C1WP7OFju+0l90vsj87FTw1eL1mO9/0EKvdc4ymu+Xx+K5OOYnd744rV/yfbHPVf71
+        6RNePg4tXtxYezCp58FBzXfKNmM5r3rtDfLQG09LC8b2g5y1qpxZaazx3LrZ6OMWMCeth0UeVmiF
+        uTuoNVa3m39b+Av+FuAr6D2YMNqmH0h6Jh1oieS/N9DAMHl6G/oOFZEalNME54ThuXThzzsXdJrg
+        AeTsypjP/JkvZj57pmFKk9Sna3KZkmtHVv5HCDtI7OD8x0qC0jBhjFMaU0h4XNdBXcZJyauYR3XE
+        Q/SWEBV97LRdD8a7GRuF0dIY2Dnplp2yCtqJc88BqleMTq6yYY8HGGRnDUl/fhD0AUkEpaxLGvpQ
+        AVB8LBAzFgR+BVHAt4JHVe0/luCHne9Af5idb8a8/JqSNzmoWlVgFfoXXXHdS/xh1NAaOSWDBONS
+        ZOyM2nWYmRL3AXYccBzd2LZO9mPbAxa57eXyDjtQHfqoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:08 GMT
+      etag:
+      - W/"c43352e765eefa71f18d4a9d2b3746ea"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43AECD:C37B1A7:5ED65FDB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3811'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["af434369892655bff7c5622a62768863eccb3b4a"],
+      "message": "Datapackage updated", "tree": "ff1d1a6660c5d87a7356fa8b481b1f729fdb4129"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc","node_id":"MDY6Q29tbWl0MjY4ODIxMDg5OmFhYTVmNGM4MWRmOGFkMGM5MzJjZTEzMDU5YTJhMjJiZGQ5NmU3YmM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:08Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:08Z"},"tree":{"sha":"ff1d1a6660c5d87a7356fa8b481b1f729fdb4129","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/ff1d1a6660c5d87a7356fa8b481b1f729fdb4129"},"message":"Datapackage
+        updated","parents":[{"sha":"af434369892655bff7c5622a62768863eccb3b4a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/af434369892655bff7c5622a62768863eccb3b4a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/af434369892655bff7c5622a62768863eccb3b4a"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:08 GMT
+      etag:
+      - '"9c684484e10cbab8901635a24670ab52"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43AFC0:C37B303:5ED65FDC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3810'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngqV8mJA5graSxdRUZYns+AUbxXFkP1BTxH/vQx27dOhyl/vO
+        u+fGIgysfmTiFpRJ3KuEENkTm4KBzhlqZSPFm2+9PH8Uh+blUzan8jC9jsdJXtW+tcdnedXvuy+z
+        bxcCL3EkyCLOqeZczW59cmgvet0HzyPMgUYAaSZEWI1OrxASJv7IrvOLUdQBcoLo+rdX0GfokdU3
+        lqyiITUUeZGLbbXNRFnqYdj0pcgyJbKNqCqRQ9/rXBeKzHCZgQjy8A7/1/TnZ+J/trnfvwFbqz6D
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:09 GMT
+      etag:
+      - W/"66dc41b9b284a2284793d6a9f17afb24"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B0FD:C37B419:5ED65FDC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3809'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngiEQSjJHpa1kMTVVWaKzfcFGcRLZB2qK+O891LFLhy5veffd
+        +64iYivKeybpEGySARJhFA+iHyw23nKrKrV5C3VQp4/1vnr5VNUx3/ev3aFXF9jV7vCsLvr96cvu
+        6onBc+wYckRjKqWE0c+PntxZz80QZMRx4BEknhkizjqvZ4SJkrxn04TJAndIkiG+/u016BMaEuVV
+        JAc8BAB5uzbbpW23YBemWGUGl6tFXkAGWaatLTb4qA2b0TQiE+wRPP2v6c/PJP9sc7t9Ax115f99
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:10 GMT
+      etag:
+      - W/"0dbb08c09b368160bb07a292379c1966"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B1E8:C37B5A0:5ED65FDD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3808'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:10 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B361:C37B77E:5ED65FDE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3807'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZlPHwGJ7SLtAgTRA0cPuXgRKoi3GkqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2lGMh3NJtfT6eRyPL05G5UqFRGNje5uf1vf53/kydebR/7tr1VSLjd/
+        Piyu7h4wfrv8PMJkXgjMtMLYKCo2KbfcCIsf5nWeR+2vhcCoVVqc5zI+p7mG/X9FpeWKW9DmPDfi
+        bKTWpdCjWTPK1UKWEHIAA0Gk6fX1+JfJZHq5p/zmfnmz+TH5vebfqiz9mq/ih++Tu9tkc/ew+BdL
+        OeRxHdU6Bz2ztjIzxvyg+fliIW1Wx7UROlGlFaW9SFTBatYJ+7L6fAXIQrcYZzIM7OEq2ZL8cuAM
+        O7yTzBb5njJeB7fy8Jq5ynO1BnN/F0eKZVsAnZmDyXLxPhgADVM2EzAttvtERpI481OpbnHD6B/8
+        knAGx6ZFeiqwXQ4lycWeGqZFpRy3jk2iZWWlKk9WdwcCqNILXspH/i4oIAYsUvRkxdxiQMQKznwy
+        xa9umAvXZENm0yIRcoXzeB95DwOw3VSUXe4HFqRTklZEPC0oKbhc8XSG6H1j7BxIQKnYHv5oViJ/
+        UUTo5TYhvRjYzriHgvSAIKK+Yv+jcQhgwGCVpdgEYxKrYfjbxluCxMBjpTmSeDAhO9CGDb+SU1nB
+        i2CyHAzQTKlwlncwQKUxtTjK948/Vcc0rAu2si5in0mPCbHjxXga9sCNkYtSiGAW3wIb1l0CseZl
+        koUT0fEa5j85r+GLYFsgFpBxruJgTFzozAEbZjLur0YbhdSaJBBvR4AW86BbIN5WgNUB/capT8At
+        Hre1hQsF07/jsaY9gZyXi5ovwknYAumyQqmy4I+vVmjHx2xPBJ5KUy3jOmxi7pm0A18UIf+EO4Ie
+        2QtwVdfLJd0bjDSo5JyZikK+VvMcT29xOyEWWATFwb4Y+v566fa2bRCvYf394i+zVlKo02hvs07/
+        obz2bRXMtToea36quM0ow0JsxbUItZkWx5oYT92ni4uLJhPcPUsKoQNmEU8DluskQ3kdSv+m46Fy
+        LLh1z585qZ/iOZQrngY7iy0QcO8CofbgaUM/qlCvB1PcwYb0QuboWqgy3B3RE4dySmXlXCbHvBWP
+        D/MdaPPFyDIRZxzPG0SFlYlEnODJTh6AIl+Es6KnYXvoEflnYi4QMsFOSQvPa5jvCqSiytUmaIYc
+        ICmRaIEGVRpxi0fpZDwZn4+vz8eTvy+vZpfT2afpD8ypK/TAnplzMxt/ojlVbbJnp1yOaQrSfxsr
+        +ISu1MuNoP03JnWcADEm6yG/9ojZgV7SM4gkh9PvRe1puqz27/a3YbCdTBWiQp3WPc6NfMTn8U6N
+        lai6xOlgcM0tHhuoWfqhri7rABk3kc8ko5nVNXqONFJp9SASa4ZjfSYbTFzLpdxZSDXktlvgH/m9
+        8EJqrdpmo28utHkYbcO245lKw+Nc9AOqEmWr4XAbMhGl2ZrBNwBoy4PpOyZwX1Ix53VuI/9WonYq
+        erJosMIdhS5gBup5Ubu17ax4g5CrdnukrOg/o+FiRVFF3jusWgrqzwKFrKLWkfmn5nA9d4F1i/0v
+        bghboWps9xct6DrdXZMiwNHq8RpHKA5bYtcgHraFPvrEdfzRJ/7oE3/0iX2nna6/A33iUtg1GqaD
+        bDp83nbZ+uk/uMxlUxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:10 GMT
+      etag:
+      - W/"c69a25053c18f4f403c0d38562c92577"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B3D8:C37B81D:5ED65FDE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3806'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngiEQSjJHpa1kMTVVWaKzfcFGcRLZB2qK+O891LFLhy5veffd
+        +64iYivKeybpEGySARJhFA+iHyw23nKrKrV5C3VQp4/1vnr5VNUx3/ev3aFXF9jV7vCsLvr96cvu
+        6onBc+wYckRjKqWE0c+PntxZz80QZMRx4BEknhkizjqvZ4SJkrxn04TJAndIkiG+/u016BMaEuVV
+        JAc8BAB5uzbbpW23YBemWGUGl6tFXkAGWaatLTb4qA2b0TQiE+wRPP2v6c/PJP9sc7t9Ax115f99
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:11 GMT
+      etag:
+      - W/"0dbb08c09b368160bb07a292379c1966"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B46D:C37B8CD:5ED65FDE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3805'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VS72vbMBD9V4o+J7Et2/IPGOxD2rCAGrqlK8kY4SxLsVPLNpZc1ob87z2t29i+
+        pZB9Ebo7nd69d+9ITAUkJwAQq0ikQalSKH2RhVTIIPTjDChQWpRlxmRSCDIhbVfKXV1iE59v2B3N
+        bPHQ+PywiVbzTz/4fB+v9E21WX/Vtwse8YfPerW4eeQLHvOX5WG7vn7h8/t4s15W/LCst4u7+Fbf
+        hxvNP+Dn49Dgx5W1vck9D/p6tq9tNRYz0WlvkH1nPC0tGNsNctrUxdRKY43nzt1OP5eANWk9bPKw
+        Q9dYewe1yupm9+8If8GfA/wG+h5MGG3VDSQ/kha0RPJfKqhguLp+GroWFZEaaqcJ7gnTM+nSH/cu
+        6TTBB8jZtVGf+lOfTX26DqI8yHI/3ZLThLxNZOV/hLCDxAmOv6ykVFAGwBjzRVymCSRhzBSkRZQG
+        RaASmqmyiAKaXXbbbgbjnY2NwmhpDOyddHN0TQ/iEaOrsXd6ljhcD4NsrSH5t9/MQEVhFLIszSiL
+        40KpRMSMUmA0YWnKQilEERYRXJbZHx+fj345H5+Lefo+IU9yqFUtwNZoXLTDW4xa5goaIydkkGBc
+        iYytqfftT5XdBew44B7asWmc7M9NB9jkwtPpFQ1PYBOhBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:11 GMT
+      etag:
+      - W/"9c684484e10cbab8901635a24670ab52"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B4E8:C37B973:5ED65FDF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3804'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=aaa5f4c81df8ad0c932ce13059a2a22bdd96e7bc
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82STUsDMRCG/0vObbPZ7mdBPIhIxZMHiyCUSTL70WaTZZOl1NL/blZ6qNVDrSJe
+        Qphh5n2Y990RDQ2SGZHgoAWxhhInK2s0GZEWXPV1x1bgGxBlWRRiFmOeSikTjINMBjJlhcxYwDiL
+        Ep4kiH6VrV+9SJiOSN8pP1o519oZpdDWk7J2Vc8nwjS0w9ZY2qAD60yHY1XzsUPrLB3e5bLZDpgW
+        HRVGO9S+ccp93WFxBQBxEYmMySIDGYh8Ggpk0yDOIYQw5FLmCaZceLLKNWr5EeoI6BwUrgyn5yp+
+        4vUIXu+E4OKz+FV04LH0G+ZIs9HKgDyB6GBz8Ka32B0O/m7TOVf5yUHcth0iWdRqyM5B2RdwY8r5
+        zX3/vGBqvvL/hsUPi8dK3t06ET4F87LNX4bkohZG1rr0M9zHJYl8balqvbZktiMWVfGvMuhd+w2e
+        i8wf8n8k/rfZ3+/fAA7vCBCABAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:11 GMT
+      etag:
+      - W/"a48842e85e97ddd6e508d0d71fd8101b146b66ee"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B560:C37B9FD:5ED65FDF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3803'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:11 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B5E9:C37BA98:5ED65FDF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3802'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZlPHwGJ7SLtAgTRA0cPuXgRKoi3GkqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2lGMh3NJtfT6eRyPL05G5UqFRGNje5uf1vf53/kydebR/7tr1VSLjd/
+        Piyu7h4wfrv8PMJkXgjMtMLYKCo2KbfcCIsf5nWeR+2vhcCoVVqc5zI+p7mG/X9FpeWKW9DmPDfi
+        bKTWpdCjWTPK1UKWEHIAA0Gk6fX1+JfJZHq5p/zmfnmz+TH5vebfqiz9mq/ih++Tu9tkc/ew+BdL
+        OeRxHdU6Bz2ztjIzxvyg+fliIW1Wx7UROlGlFaW9SFTBatYJ+7L6fAXIQrcYZzIM7OEq2ZL8cuAM
+        O7yTzBb5njJeB7fy8Jq5ynO1BnN/F0eKZVsAnZmDyXLxPhgADVM2EzAttvtERpI481OpbnHD6B/8
+        knAGx6ZFeiqwXQ4lycWeGqZFpRy3jk2iZWWlKk9WdwcCqNILXspH/i4oIAYsUvRkxdxiQMQKznwy
+        xa9umAvXZENm0yIRcoXzeB95DwOw3VSUXe4HFqRTklZEPC0oKbhc8XSG6H1j7BxIQKnYHv5oViJ/
+        UUTo5TYhvRjYzriHgvSAIKK+Yv+jcQhgwGCVpdgEYxKrYfjbxluCxMBjpTmSeDAhO9CGDb+SU1nB
+        i2CyHAzQTKlwlncwQKUxtTjK948/Vcc0rAu2si5in0mPCbHjxXga9sCNkYtSiGAW3wIb1l0CseZl
+        koUT0fEa5j85r+GLYFsgFpBxruJgTFzozAEbZjLur0YbhdSaJBBvR4AW86BbIN5WgNUB/capT8At
+        Hre1hQsF07/jsaY9gZyXi5ovwknYAumyQqmy4I+vVmjHx2xPBJ5KUy3jOmxi7pm0A18UIf+EO4Ie
+        2QtwVdfLJd0bjDSo5JyZikK+VvMcT29xOyEWWATFwb4Y+v566fa2bRCvYf394i+zVlKo02hvs07/
+        obz2bRXMtToea36quM0ow0JsxbUItZkWx5oYT92ni4uLJhPcPUsKoQNmEU8DluskQ3kdSv+m46Fy
+        LLh1z585qZ/iOZQrngY7iy0QcO8CofbgaUM/qlCvB1PcwYb0QuboWqgy3B3RE4dySmXlXCbHvBWP
+        D/MdaPPFyDIRZxzPG0SFlYlEnODJTh6AIl+Es6KnYXvoEflnYi4QMsFOSQvPa5jvCqSiytUmaIYc
+        ICmRaIEGVRpxi0fpZDwZn4+vz8eTvy+vZpfT2afpD8ypK/TAnplzMxt/ojlVbbJnp1yOaQrSfxsr
+        +ISu1MuNoP03JnWcADEm6yG/9ojZgV7SM4gkh9PvRe1puqz27/a3YbCdTBWiQp3WPc6NfMTn8U6N
+        lai6xOlgcM0tHhuoWfqhri7rABk3kc8ko5nVNXqONFJp9SASa4ZjfSYbTFzLpdxZSDXktlvgH/m9
+        8EJqrdpmo28utHkYbcO245lKw+Nc9AOqEmWr4XAbMhGl2ZrBNwBoy4PpOyZwX1Ix53VuI/9WonYq
+        erJosMIdhS5gBup5Ubu17ax4g5CrdnukrOg/o+FiRVFF3jusWgrqzwKFrKLWkfmn5nA9d4F1i/0v
+        bghboWps9xct6DrdXZMiwNHq8RpHKA5bYtcgHraFPvrEdfzRJ/7oE3/0iX2nna6/A33iUtg1GqaD
+        bDp83nbZ+uk/uMxlUxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:12 GMT
+      etag:
+      - W/"c69a25053c18f4f403c0d38562c92577"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B667:C37BB3B:5ED65FDF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3801'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:19:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C912:16100:A43B703:C37BBEB:5ED65FE0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3800'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_datapackage_update_partial.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_datapackage_update_partial.yaml
@@ -1,0 +1,2647 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:44 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368364:9C45758:5ED65FC4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3861'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:45 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:83683A5:9C45795:5ED65FC4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3860'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821033,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEwMzM=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:18:45Z","updated_at":"2020-06-02T14:18:45Z","pushed_at":"2020-06-02T14:18:46Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:46 GMT
+      etag:
+      - '"116cf3b78fc373f35eefe760ced3fbd6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368402:9C45806:5ED65FC5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3859'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"8a2aaeefda3672e4db2737f841b7d5f0b0ab508a","node_id":"MDY6Q29tbWl0MjY4ODIxMDMzOjhhMmFhZWVmZGEzNjcyZTRkYjI3MzdmODQxYjdkNWYwYjBhYjUwOGE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8a2aaeefda3672e4db2737f841b7d5f0b0ab508a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/8a2aaeefda3672e4db2737f841b7d5f0b0ab508a","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:46Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:46Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:47 GMT
+      etag:
+      - '"258a8ff103e06c06076954f318723969"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368615:9C45AAC:5ED65FC6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3858'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW0/bMBT+KyjPhaRp2pRKaNMEm3goiI3LwjRVTnLSuDh2ZjuFtuK/75w0XNoH
+        RhB746VK7Hyfv3P16cqRrABn5BTMWNBOx0lUUXDrjFaOyRluDJnPGECWst4g9CFIYz/shdkw6MZh
+        2s+82GNx3xsyhEqVwoSnCBofRoMzf9/GV8Ibz6Lg9PD4bnw4Xp7O8nxcfM2vry6L629Hy5NZsrg+
+        /34TzY5742VanB6e3UWz9ObkKrqNZl/yaHZxe/rt6GBDF6tsrjQpbLT/yFnO9M7RXCuJX0LBuEAR
+        qB+X94CWP09pcQ+Nww9SZslk3/O9XW+w6/nn3WDUHY6CwbVz/+AB8sZ/O6IAY9iURBxLbjkTfAk7
+        KIvtaCiV4VbpBQq1GvCbh0h0M28/zfxeGA79IOwG/SGkvr/PwjgOhkmIO8M07IGHwEqTA3JrSzNy
+        XVbyvSm3eRWTA9z6CLcAiyFXGnYFj3ctGGtc+p1MigUpMWBdBLmkwbivPhv9946Hr5PRuC2SkCAg
+        7SRRlcQ09jrOHDTPeMIsx/RAb67fAfM0Y8JAx9HADG05lTR8KnGn49ADs5VG/8tKiI5TsoVQDEH0
+        ev9+Zr7BxNwWYrLp5WfhfU1g14e+wa1m69w3p1Zbs90mrgZj89QAhJpyCpzJ6yrHPWo/g35/0Nts
+        R2eDy58nIplF3ZPzaEkcc8xxvW1NvWj8ploqAzpR0mI61YVTuTXzp/lBgAxT3XDUHe9fRUdcxn3S
+        +XIMn77LlBDqFrHbUjdreoPefQShqvUzl9P2BAhaucrmgH5C+fdkNMc+0YapBqywk2Bn4SlRGHSx
+        hrQNSQNBMbcSdazqFlZzVbFJNC+ptFvJ2gAikdJTJvmy7hGtiBBIKVn31DYm1QAEwhyzqxVyjVi5
+        peZzlizIDRoS4HP0aXu2LSiS2UVJF9MFRpw8zC1MWFpQmdXtcvuC/CjB5lr9KMF2lfNRgutLC5vZ
+        RvW+qgRLpqlvOKNfv7EgJ4LLG3zBSRFE9h6TX6yZTHIc/B7/F9CF9Yy55cBBU+QDFwoutbKQ2Gcz
+        WLPSjGggWSw2JrQ/FadLA28CW5kJSkvWBoPMlE6gHvkEtj/SqLIMnVjf3HeNj57OxBNe7tOvH4+3
+        nIQdubaKbLj/C/hl7ihZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:47 GMT
+      etag:
+      - W/"34eb60f916b46a02915966b66181a879"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368795:9C45C6B:5ED65FC7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3857'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:48 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368802:9C45D04:5ED65FC7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3856'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8a2aaeefda3672e4db2737f841b7d5f0b0ab508a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTUW/aMBD+K8jPQIIJJESaNE2wiocUdWuHwjShC75gp3GCbKctIP77zqUP21sr
+        bS9WfF/uvu++O5+ZlcBSlgAHQCwFjKcxx0gUPB7HZRKNilhMyrAIoZiECbA+a1qBWyUoKZvn0zs+
+        c8W6DrMqj1bz5Us2z06rSspMf5Wb9Q+9uVmcbqvdcXP/7TGvluPsJPRqfveSV+Lxdp0/59UXmVcP
+        z6ubxScq3pmaCkvnDjYNAjio4V452RXDXasDg4fWBhodWNcaHNSqGDi0zgb+3G71UQBh6AJKCihD
+        K8I+0Jp0ut7+LeEP+vcQX0k/wgmdk61h6Zk1oJGa/y5BguktnkzbkCOoQXlPaE4UHqIPf977oPeE
+        fqCefRoPeTgIp4OQ34+idJSk0XTDLn12VeTwP1I4g6Tg/LZKozKciZKP4zjhUTyKJgkKzmcQF0WU
+        7GJCEhGPMfy30/YabPBubjJGo7Ww99YtG+UU1OqEPb9Avdc9U7RiR9J4AIONsyz9+avPntCoUu3A
+        KZoNdXy9Iz2GEmqLfWYQrIdY11i1bwjpM/8BrjNE1XR17Use6xYoyV8vl99UBxfNhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:48 GMT
+      etag:
+      - W/"b13ffe0141227c1409b96e4362545c59"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:46 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:836889A:9C45DBE:5ED65FC8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3855'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["8a2aaeefda3672e4db2737f841b7d5f0b0ab508a"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"8c1e9a7f3b3c7c951ef654222cfd5554cb805f41","node_id":"MDY6Q29tbWl0MjY4ODIxMDMzOjhjMWU5YTdmM2IzYzdjOTUxZWY2NTQyMjJjZmQ1NTU0Y2I4MDVmNDE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:48Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:48Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"8a2aaeefda3672e4db2737f841b7d5f0b0ab508a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8a2aaeefda3672e4db2737f841b7d5f0b0ab508a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/8a2aaeefda3672e4db2737f841b7d5f0b0ab508a"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:48 GMT
+      etag:
+      - '"bd5055ada86f5d493294bb9e80710227"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:83688E3:9C45E2E:5ED65FC8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3854'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OwW7CMAyG3yVnIF0ptOoZjQ0p4rRO41I5xF2CmqZKDFpBvPuMdtxlh10sWb8/
+        /99NROxE/ZhJWgSTpIdEGMVMDMFg6wynaqPWb77x6vRR7DevX7xf98OuPwzqAtvGHl7URb8/X822
+        mRg8x54hSzSmWkoY3eLTkT3rxTF4GXEMXILENSHivHd6TpgoycdsWz8Z4AxJMsTXv72CPuGRRH0T
+        yQIXVZADIHYGlusyx8LovFyWXVU86dKsukxnoFdZBWxG04hMsId39L+mPz+T/LPN/f4NR+5bZ30B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:49 GMT
+      etag:
+      - W/"0d3fbd69e344ef4d2d29da4e385e95ae"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:46 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368993:9C45EF8:5ED65FC8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3853'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "8c1e9a7f3b3c7c951ef654222cfd5554cb805f41"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy07DMBBF/8VrWpM07iPrigJS1BVBdBP5Mcau4jiypxVp1X9nKpZsWLAZaXTn
+        zD1XlsCy+j4zdyBN5kFmhMQe2BANdN5Q2myb5VtoQ3P8qPbbly/aL/vhtT8MzVnuWnd4bs7q/eli
+        du1E4Cn1BDnEMdecy9HPPz26k5rrGHiCMVIJINXEBLPeqxlCxszvs+vCZCRlgJwguv7tFdURNLL6
+        yrKTVLTWBWzkyi7UQq/0RhRgl6Iqy1JbI4SotFo/ClsVZIbTCESQR/D4v6Y/PzP/s83t9g3KCqDc
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:49 GMT
+      etag:
+      - W/"9850b0265345cef6a1e7fe06df2d020a"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:83689E9:9C45F65:5ED65FC9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3852'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:50 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368B1B:9C460C9:5ED65FC9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3851'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZNPEwGJ72O0CBdwFih529yJQEm0xlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE4zkuloOrm5vZ1cjq+uzkalSkVEY6PZ5y/rb/kfefL17oF//2uVlMvN
+        n/eL69n9l/XsYfZxhMm8EJhphbFRVGxSbrkRFj/M6zyP2l8LgVGrtDjPZXxOcw37/4pKyxW3oM15
+        bsTZSK1LoUfTZpSrhSwh5AAGgkjTm5vxr5PJ7eWe8ptvy7vNz8nvNf9eZenXfBXf/5jMPieb2f3i
+        XyzlkMd1VOsc9MzaykwZ84Pm6mIhbVbHtRE6UaUVpb1IVMFq1gn7tPp4DchCtxhnMgzs4SrZkvxy
+        4Aw7vJPMFvmeMl4Ht/LwmrnKc7UGc38XR4plWwCdmYPJcvE2GAANUzYTMC22+0hGkjjzU6luccPo
+        H/yScAbHpkV6KrBdDiXJxR4bpkWlHLeOTaJlZaUqT1Z3BwKo0gteygf+JiggBixS9GTF3GJAxArO
+        fDLFr26YC9dkQ2bTIhFyhfN4G3kPA7DdVJRdvg0sSKckrYh4WlBScLni8QzR+8rYOZCAUrE9/NG0
+        RP6iiNDLbUJ6NrCdcQ8F6QFBRH3B/kfjEMCAwSpLsQnGJFbD8LeNtwSJgcdKcyTxYEJ2oA0bfiWn
+        soIXwWQ5GKCZUuEs72CASmNqcZTvH3+qjmlYF2xlXcQ+kx4TYseL8TTsgRsjF6UQwSy+BTasuwRi
+        zcskCyei4zXMf3JewxfBtkAsIONcxcGYuNCZAzbMZNxfjTYKqTVJIN6OAC3mQbdAvK0AqwP6jVOf
+        gFs8bmsLFwqmf8djTXsCOS8XNV+Ek7AF0mWFUmXBH16s0I6P2Z4IPJWmWsZ12MTcM2kHvihC/gl3
+        BD2yF+CqrudLulcYaVDJOTMVhXyp5jme3uJ2QiywCIqDfTH0/eXS7XXbIF7D+vvFX2atpFCn0d5m
+        nf5Dee3bKphrdTzW/FJxm1GGhdiKaxFqMy2ONTGeuo8XFxdNJrh7lhRCB8wingYs10mG8jqU/k3H
+        Q+VYcOueP3NSP8VzKFc8DXYWWyDg3gVC7cHThn5UoV4PpriDDemFzNG1UGW4O6InDuWUysq5TI55
+        Kx4f5jvQ5pORZSLOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EXCBkgp2SFp7XMN8VSEWVq03Q
+        DDlAUiLRAg2qNOIWj9LJeDI+H9+cjyd/X15PL2+n1x9+Yk5doQf25JwPY5pT1SZ7csr1HU1B+m9j
+        BZ/QlXq+EbT/xqSOEyDGZD3ktx4xPdBLegKR5HD6vag9TZfV/t3+Ogy2k6lCVKjTuse5kQ/4PN6p
+        sRJVlzgdDK65xWMDNUs/1NVlHSDjJvKZZDS1ukbPkUYqre5FYs1wrM9kg4lruZQ7C6mG3HYL/CO/
+        F15IrVXbbPTNhTYPo23YdjxTaXici35AVaJsNRxuQyaiNFsz+AYAbXkwfccE7ksq5rzObeTfStRO
+        RU8WDVa4o9AFzEA9L2q3tp0VbxBy1W6PlBX9ZzRcrCiqyHuHVUtB/VmgkFXUOjL/1Byu5y6wbrH/
+        xQ1hK1SN7f6iBV2nu2tSBDhaPV7jCMVhS+waxMO20HufuI7f+8TvfeL3PrHvtNP1d6BPXAq7RsN0
+        kE2Hz9suWz/+B5P12O8VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:50 GMT
+      etag:
+      - W/"5eebdf57a827e7f37c5ae973cb04ffa1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368B71:9C4614C:5ED65FCA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3850'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy07DMBBF/8VrWpM07iPrigJS1BVBdBP5Mcau4jiypxVp1X9nKpZsWLAZaXTn
+        zD1XlsCy+j4zdyBN5kFmhMQe2BANdN5Q2myb5VtoQ3P8qPbbly/aL/vhtT8MzVnuWnd4bs7q/eli
+        du1E4Cn1BDnEMdecy9HPPz26k5rrGHiCMVIJINXEBLPeqxlCxszvs+vCZCRlgJwguv7tFdURNLL6
+        yrKTVLTWBWzkyi7UQq/0RhRgl6Iqy1JbI4SotFo/ClsVZIbTCESQR/D4v6Y/PzP/s83t9g3KCqDc
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:50 GMT
+      etag:
+      - W/"9850b0265345cef6a1e7fe06df2d020a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368BDD:9C461CE:5ED65FCA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3849'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUS4/aMBD+K8hnII7jPIhUqQf2QKWAUKEoVBUaJ2OSNA8UO6sFxH9fW7RVe2Ml
+        eonimYy/x3zKlagCSEyizMUZhNITXhZmM99FGficMZbJ3Pd9nomI+pK7ZEzaLsdDmZuhZJ4GazbT
+        YlfTpEr5ar54S+bJZVUVVbLb+ukmbxK2uKSXvFpttm/7XcqWm/U5qb5U+2btLjdbmrIFT+bfmuX8
+        5ZO5fOhrc3Gh9UnFjgOncnosdTGIadY1To+nTjkNalC663FSl2KiUWnl2Ofh0JxzMD3UjhlyzERT
+        mt4HpBW6qQ//UvgL/hHgO+hHMGHQRdeT+EpaaNCI/1pAAf3o5bXvWuMINlBaT8yeTHmKtvz5aIvW
+        E/OB0WzHGGV0QoMJZRuXx24U82hPbmNyZ6TxP0LoHg2D668ohSFGgccl9wT1MimDWc5D7mdUYIgo
+        PSYwAxH4z9225aCch7GNMQ0qBUdr3aItdQn1yKbnBNlPUx3dbTMcT9BjqxWJv/8WGAEDMEpy8IKQ
+        Ic8FC71QRtwVYe5LKigIn0bwXIF/4vw4+vPi/Cjm7ceYvGJfyjIDXZr8mlTcz2h+GBJqhWPSIyjb
+        IkOrymNrOmNiX0APvVlHO9S1tf1cd2CG7PF2ewcT4Na1qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:51 GMT
+      etag:
+      - W/"bd5055ada86f5d493294bb9e80710227"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368C39:9C46242:5ED65FCA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3848'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=8c1e9a7f3b3c7c951ef654222cfd5554cb805f41
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28h2ItsKjNKYrTjQlnUXdUIh6OPYVipLxlIastL/PrkNtEt3
+        kXVj7ELioCOd9+E9R4+Bpi0E00BQRzvK72kNo7U1OjgJOuqaX2dsQ30igzTjglCREiBxPGZhluAo
+        TbAQkECKQxKSjCWhL2Xldy9CkpNg0yv/tHGus1OEaCdHtXTNho24aVEPnbGoBUetMz2cKslOHVhn
+        0bCvVu1uwLTgEDfagfaJQ+6zHqpPGY+A0LQaszFPOcERVAmexHHMK4ExnnCWhbiaRJ6sca1a/Qz1
+        BugYFKYMQ8cqvuP1CF7vgODDtvhSaOCx6DeaI8xWK0PFAURPt/vebCz0e8Of23SMK39iiNt1w0hW
+        UoG3Z6/sD2Br6iKfbxa3kSrWPm4jvLz4Ei7KKyXywhbnz/ndsrx6EOV8vSwv5bWcsVye13e6yGfp
+        EBX5sObbRXljXqrcNOLi8wMr1evLb3jNxwv5cn9G7vQQlV87H3kk0NwIqWvPxPw4JhN/tlJS39tg
+        +hhYUNV/NeN+Kv4Gz4eGa/hfb8T/7d96evoB5XpjGuAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:51 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368C85:9C462A0:5ED65FCB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3847'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:51 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368CF7:9C4632A:5ED65FCB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3846'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZNPEwGJ72O0CBdwFih529yJQEm0xlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE4zkuloOrm5vZ1cjq+uzkalSkVEY6PZ5y/rb/kfefL17oF//2uVlMvN
+        n/eL69n9l/XsYfZxhMm8EJhphbFRVGxSbrkRFj/M6zyP2l8LgVGrtDjPZXxOcw37/4pKyxW3oM15
+        bsTZSK1LoUfTZpSrhSwh5AAGgkjTm5vxr5PJ7eWe8ptvy7vNz8nvNf9eZenXfBXf/5jMPieb2f3i
+        XyzlkMd1VOsc9MzaykwZ84Pm6mIhbVbHtRE6UaUVpb1IVMFq1gn7tPp4DchCtxhnMgzs4SrZkvxy
+        4Aw7vJPMFvmeMl4Ht/LwmrnKc7UGc38XR4plWwCdmYPJcvE2GAANUzYTMC22+0hGkjjzU6luccPo
+        H/yScAbHpkV6KrBdDiXJxR4bpkWlHLeOTaJlZaUqT1Z3BwKo0gteygf+JiggBixS9GTF3GJAxArO
+        fDLFr26YC9dkQ2bTIhFyhfN4G3kPA7DdVJRdvg0sSKckrYh4WlBScLni8QzR+8rYOZCAUrE9/NG0
+        RP6iiNDLbUJ6NrCdcQ8F6QFBRH3B/kfjEMCAwSpLsQnGJFbD8LeNtwSJgcdKcyTxYEJ2oA0bfiWn
+        soIXwWQ5GKCZUuEs72CASmNqcZTvH3+qjmlYF2xlXcQ+kx4TYseL8TTsgRsjF6UQwSy+BTasuwRi
+        zcskCyei4zXMf3JewxfBtkAsIONcxcGYuNCZAzbMZNxfjTYKqTVJIN6OAC3mQbdAvK0AqwP6jVOf
+        gFs8bmsLFwqmf8djTXsCOS8XNV+Ek7AF0mWFUmXBH16s0I6P2Z4IPJWmWsZ12MTcM2kHvihC/gl3
+        BD2yF+CqrudLulcYaVDJOTMVhXyp5jme3uJ2QiywCIqDfTH0/eXS7XXbIF7D+vvFX2atpFCn0d5m
+        nf5Dee3bKphrdTzW/FJxm1GGhdiKaxFqMy2ONTGeuo8XFxdNJrh7lhRCB8wingYs10mG8jqU/k3H
+        Q+VYcOueP3NSP8VzKFc8DXYWWyDg3gVC7cHThn5UoV4PpriDDemFzNG1UGW4O6InDuWUysq5TI55
+        Kx4f5jvQ5pORZSLOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EXCBkgp2SFp7XMN8VSEWVq03Q
+        DDlAUiLRAg2qNOIWj9LJeDI+H9+cjyd/X15PL2+n1x9+Yk5doQf25JwPY5pT1SZ7csr1HU1B+m9j
+        BZ/QlXq+EbT/xqSOEyDGZD3ktx4xPdBLegKR5HD6vag9TZfV/t3+Ogy2k6lCVKjTuse5kQ/4PN6p
+        sRJVlzgdDK65xWMDNUs/1NVlHSDjJvKZZDS1ukbPkUYqre5FYs1wrM9kg4lruZQ7C6mG3HYL/CO/
+        F15IrVXbbPTNhTYPo23YdjxTaXici35AVaJsNRxuQyaiNFsz+AYAbXkwfccE7ksq5rzObeTfStRO
+        RU8WDVa4o9AFzEA9L2q3tp0VbxBy1W6PlBX9ZzRcrCiqyHuHVUtB/VmgkFXUOjL/1Byu5y6wbrH/
+        xQ1hK1SN7f6iBV2nu2tSBDhaPV7jCMVhS+waxMO20HufuI7f+8TvfeL3PrHvtNP1d6BPXAq7RsN0
+        kE2Hz9suWz/+B5P12O8VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:51 GMT
+      etag:
+      - W/"5eebdf57a827e7f37c5ae973cb04ffa1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368D63:9C463AF:5ED65FCB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3845'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aMBT+K1WeaRNypUjT9sAeOolW1eg6Ok3IcU6ImWNntsMKiP++45Be4KEj
+        VffWFwROzufvfOfKxhGkBGfolEQbUE7PobIsmXGGG0cXBB8MaB/OSZIHaUATeh71IY+j0Pd9mmdR
+        FIU0HXhRHvbRVMgMZixDo/FoGl/75ya95d54MQ2vRhf349F4fbUoFuPbm2g6ycqxf7GerrPF1eTm
+        /u526l9OrlfjxZfFXXndv5zceFP/IhyPvpWXo88f9niR2hRSWYYt968FKYg6+bxUUuCbUBLGkQTy
+        x+MzsMef5vbwDJ3DFzJirMu+53unXnzq+ZN+OOwPhuHgztk+KGDV+G9XlKA1mVsSF4IZRvgJciIV
+        ob/w9KQNQc8xCvCdh0gkCQziIMzDIPUCmufxeRYmYUS9FBKAPPBToCSNI/SwVlaAwphKD12XVOxs
+        zkxRp1YAV0EltVuCwZBLBaecpacGtNGu/ZzNypUlo8G4aORaDto9+m7U7w0v3ymh3Q5JaE1AmBmV
+        tcA09nrOEhTLGSWGYXqgmrvfgHmaE66h5ygg2j5yaqHZXOCTnmO/EFMr1F/UnPeciqy4JGhkf27f
+        zs1XuFiYks/2VX4W3mMCu7v0FbLqg3tfnVpd3XbbuGqMzVMD4HLObOB00VQ5PrPtJ46iONhvR9fx
+        t++XnC6m2Fqma4uxxBxXh940h9pvq6XWoKgUBtOpKZzabZA/Lj+EiDBXLUbT8f5VdBZLu088X47h
+        03u55Fz+QdtDqvs1vQfvPhohq913JubdAdBo40pTAOqE9LfWaYZ9ogtSY7DBToKdhWUWQqPECrIu
+        IK0JkvkjkMemaWENVp1qqlhlS7sTrT1DBJJqTgRbNz2iExAa2pRsemoXlxoDNIQlZlcny53Fxq0U
+        WxK6sjIooMCWqGl3tANTBDOryg6mG4y4VZgZmJGstGXWtMvDAflegu1YfS/BbpXzXoK7oYXNbK96
+        jyrBiijbN5zhj8c9nfiE4BqYkSBOfAiz1E+CJB+E/TTJotxLPZJG3oAg/BstaI8j/PibX556XTaX
+        Y+/c/sSGNeNM/EKxUCvg+Vtsxqkigha4GD/+b7KuPUPuuJDZLfsBCwlXShqg5tmO2p60KywIkvK9
+        DfZ3zexQxUlpaj1DanTnMIhcKgrNSsxxPFiOMs8xC5rN5r7JoZ92n3264eU5dvzfhwORcGI1Xlkf
+        tn8BDmQpc3kOAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:52 GMT
+      etag:
+      - W/"13c0811a9281f98e0b7eea4cc7f97377"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368DCF:9C46438:5ED65FCB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3844'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:52 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368E18:9C46491:5ED65FCC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3843'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUS4/aMBD+K8hnII7jPIhUqQf2QKWAUKEoVBUaJ2OSNA8UO6sFxH9fW7RVe2Ml
+        eonimYy/x3zKlagCSEyizMUZhNITXhZmM99FGficMZbJ3Pd9nomI+pK7ZEzaLsdDmZuhZJ4GazbT
+        YlfTpEr5ar54S+bJZVUVVbLb+ukmbxK2uKSXvFpttm/7XcqWm/U5qb5U+2btLjdbmrIFT+bfmuX8
+        5ZO5fOhrc3Gh9UnFjgOncnosdTGIadY1To+nTjkNalC663FSl2KiUWnl2Ofh0JxzMD3UjhlyzERT
+        mt4HpBW6qQ//UvgL/hHgO+hHMGHQRdeT+EpaaNCI/1pAAf3o5bXvWuMINlBaT8yeTHmKtvz5aIvW
+        E/OB0WzHGGV0QoMJZRuXx24U82hPbmNyZ6TxP0LoHg2D668ohSFGgccl9wT1MimDWc5D7mdUYIgo
+        PSYwAxH4z9225aCch7GNMQ0qBUdr3aItdQn1yKbnBNlPUx3dbTMcT9BjqxWJv/8WGAEDMEpy8IKQ
+        Ic8FC71QRtwVYe5LKigIn0bwXIF/4vw4+vPi/Cjm7ceYvGJfyjIDXZr8mlTcz2h+GBJqhWPSIyjb
+        IkOrymNrOmNiX0APvVlHO9S1tf1cd2CG7PF2ewcT4Na1qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:52 GMT
+      etag:
+      - W/"bd5055ada86f5d493294bb9e80710227"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368F03:9C465BE:5ED65FCC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3842'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["8c1e9a7f3b3c7c951ef654222cfd5554cb805f41"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"32719616e34df4a0203e57b86acc6649beec37b7","node_id":"MDY6Q29tbWl0MjY4ODIxMDMzOjMyNzE5NjE2ZTM0ZGY0YTAyMDNlNTdiODZhY2M2NjQ5YmVlYzM3Yjc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/32719616e34df4a0203e57b86acc6649beec37b7","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/32719616e34df4a0203e57b86acc6649beec37b7","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:53Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:18:53Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"8c1e9a7f3b3c7c951ef654222cfd5554cb805f41","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/8c1e9a7f3b3c7c951ef654222cfd5554cb805f41"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:53 GMT
+      etag:
+      - '"348262e6bfd4c584cf99fc524f11b9d7"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/32719616e34df4a0203e57b86acc6649beec37b7
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368F58:9C4661D:5ED65FCC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3841'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy07DMBBF/8VrWpM07iPrigJS1BVBdBP5Mcau4jiypxVp1X9nKpZsWLAZaXTn
+        zD1XlsCy+j4zdyBN5kFmhMQe2BANdN5Q2myb5VtoQ3P8qPbbly/aL/vhtT8MzVnuWnd4bs7q/eli
+        du1E4Cn1BDnEMdecy9HPPz26k5rrGHiCMVIJINXEBLPeqxlCxszvs+vCZCRlgJwguv7tFdURNLL6
+        yrKTVLTWBWzkyi7UQq/0RhRgl6Iqy1JbI4SotFo/ClsVZIbTCESQR/D4v6Y/PzP/s83t9g3KCqDc
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:53 GMT
+      etag:
+      - W/"9850b0265345cef6a1e7fe06df2d020a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8368FF8:9C466FF:5ED65FCD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3840'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "32719616e34df4a0203e57b86acc6649beec37b7"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vngoGkTsmMSkGymJqqLJE/DmwUx5F9oAbEf++hjl06dDnp9N5z
+        73NjCQ6sfszMHSibeVAZIbEn1kcLrbeUypUU76EJ8vRZ7labL9qvu37b7Xt5UevG7d/kRX+8Xu26
+        GQk8p44ghzjkmnM1+OnRozvrqYmBJxgilQBSTUww6byeIGTM/DHbNoxWUQbICaLr315Rn8Agq28s
+        O0VFxaKaL8VcQFHaQ6lmi1kBz5V+EcoYIcqlBjBFpSsyw3EAIsgjePxf05+fmf/Z5n7/BplAq0V9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:54 GMT
+      etag:
+      - W/"979c79082cb98fe5c4a039c358349fe6"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:836905A:9C46759:5ED65FCD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3839'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:54 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8369166:9C468B7:5ED65FCE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3838'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZNOsgcX2sNsFCrgBih529yJQEm0xlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE4zkuloOrm5vZ1cjq+uzkalSkVEY6PZl6/ru/yPPPn28YF//2uVlMvN
+        n/eL69n91/XsYfZphMm8EJhphbFRVGxSbrkRFj/M6zyP2l8LgVGrtDjPZXxOcw37/4pKyxW3oM15
+        bsTZSK1LoUfTZpSrhSwh5AAGgkjTm5vxr5PJ7eWe8pu75cfNz8nvNf9eZem3fBXf/5jMviSb2f3i
+        XyzlkMd1VOsc9MzaykwZ84Pm6mIhbVbHtRE6UaUVpb1IVMFq1gn7vPp0DchCtxhnMgzs4SrZkvxy
+        4Aw7vJPMFvmeMl4Ht/LwmrnKc7UGc38XR4plWwCdmYPJcvE2GAANUzYTMC22+0hGkjjzU6luccPo
+        H/yScAbHpkV6KrBdDiXJxR4bpkWlHLeOTaJlZaUqT1Z3BwKo0gteygf+JiggBixS9GTF3GJAxArO
+        fDLFr26YC9dkQ2bTIhFyhfN4G3kPA7DdVJRd7gYWpFOSVkQ8LSgpuFzxeIbofWXsHEhAqdge/mha
+        In9RROjlNiE9G9jOuIeC9IAgor5g/6NxCGDAYJWl2ARjEqth+NvGW4LEwGOlOZJ4MCE70IYNv5JT
+        WcGLYLIcDNBMqXCWdzBApTG1OMr3jz9VxzSsC7ayLmKfSY8JsePFeBr2wI2Ri1KIYBbfAhvWXQKx
+        5mWShRPR8RrmPzmv4YtgWyAWkHGu4mBMXOjMARtmMu6vRhuF1JokEG9HgBbzoFsg3laA1QH9xqlP
+        wC0et7WFCwXTv+Oxpj2BnJeLmi/CSdgC6bJCqbLgDy9WaMfHbE8EnkpTLeM6bGLumbQDXxQh/4Q7
+        gh7ZC3BV1/Ml3SuMNKjknJmKQr5U8xxPb3E7IRZYBMXBvhj6/nLp9rptEK9h/f3iL7NWUqjTaG+z
+        Tv+hvPZtFcy1Oh5rfqm4zSjDQmzFtQi1mRbHmhhP3ceLi4smE9w9SwqhA2YRTwOW6yRDeR1K/6bj
+        oXIsuHXPnzmpn+I5lCueBjuLLRBw7wKh9uBpQz+qUK8HU9zBhvRC5uhaqDLcHdETh3JKZeVcJse8
+        FY8P8x1o89nIMhFnHM8bRIWViUSc4MlOHoAiX4Szoqdhe+gR+WdiLhAywU5JC89rmO8KpKLK1SZo
+        hhwgKZFogQZVGnGLR+lkPBmfj2/Ox5O/L6+nl7fT6w8/Maeu0AN7cs6HCc2papM9PeWapiD9t7GC
+        T+hKPd8I2n9jUscJEGOyHvJbj5ge6CU9gUhyOP1e1J6my2r/bn8dBtvJVCEq1Gnd49zIB3we79RY
+        iapLnA4G19zisYGapR/q6rIOkHET+Uwymlpdo+dII5VW9yKxZjjWZ7LBxLVcyp2FVENuuwX+kd8L
+        L6TWqm02+uZCm4fRNmw7nqk0PM5FP6AqUbYaDrchE1GarRl8A4C2PJi+YwL3JRVzXuc28m8laqei
+        J4sGK9xR6AJmoJ4XtVvbzoo3CLlqt0fKiv4zGi5WFFXkvcOqpaD+LFDIKmodmX9qDtdzF1i32P/i
+        hrAVqsZ2f9GCrtPdNSkCHK0er3GE4rAldg3iYVvovU9cx+994vc+8Xuf2Hfa6fo70CcuhV2jYTrI
+        psPnbZetH/8Dnm0cZBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:55 GMT
+      etag:
+      - W/"2b962512f0f0944347538e85419815fd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:83691C4:9C4691D:5ED65FCE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3837'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vngoGkTsmMSkGymJqqLJE/DmwUx5F9oAbEf++hjl06dDnp9N5z
+        73NjCQ6sfszMHSibeVAZIbEn1kcLrbeUypUU76EJ8vRZ7labL9qvu37b7Xt5UevG7d/kRX+8Xu26
+        GQk8p44ghzjkmnM1+OnRozvrqYmBJxgilQBSTUww6byeIGTM/DHbNoxWUQbICaLr315Rn8Agq28s
+        O0VFxaKaL8VcQFHaQ6lmi1kBz5V+EcoYIcqlBjBFpSsyw3EAIsgjePxf05+fmf/Z5n7/BplAq0V9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:55 GMT
+      etag:
+      - W/"979c79082cb98fe5c4a039c358349fe6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:836922F:9C46993:5ED65FCF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3836'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/32719616e34df4a0203e57b86acc6649beec37b7
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VSXYvbMBD8K4eek9iSLDs2FFpwKH1wwtHQ4pQSZHkdK/UXlnw0OfLfu2p60L4l
+        kL4I7a5WMzs7r8TUkiSEs4jGIQ2BB2UVSJ/5HERULEOpVBgGcQGgeFREZEa6voS9LrEpS/PwmcW2
+        +Nr42TEPNumnn1manTfH7LQ+r8T6uGK7bebvPuZ+vv1wytJ1s96WepPu6pxlbH18Fnn7pcnPGc+P
+        6h1+Po0NflxbO5jE8+SgFwdt66lYqL71Rhh647VgpbH9CPNGF3MLxhrPnft9eyol1sB62ORhR6ux
+        dsdotW2b/b8U/oK/BfgKeg+mnGzdjyR5JZ1sAYf/XMtajk+rl7HvUBFopXaa4J4wvQCXfn9wSacJ
+        PsCZXRvDnc39cO6zLQ0SukwE35HLjFwZWfiPEHYEZPD6x0pUUiVVWai4jIQIo4iWnPkCBEAsliJi
+        PCx8Ttljt+04GO9mbBSmBWPkwUmXomsGqX5g9DQNTs8SyQ1yhM4aknx7m2ypKMQyqnjBVaRiQaEK
+        RcAYU1UphAhUsfRFFdDHTvbm4zvQH+bjmzEv32fkBUZdaSWtRuOiHa4xaplUsjEwIyNI40pk6ow+
+        dL9VdhdppxH30E1N42Q/Nb3EJhdeLr8AthQc6qEEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:55 GMT
+      etag:
+      - W/"348262e6bfd4c584cf99fc524f11b9d7"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:83692BD:9C46A2B:5ED65FCF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3835'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=32719616e34df4a0203e57b86acc6649beec37b7
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf29iObSkOjNGEtiTQjHUPc0IgSNY5VipLxlIa0tLv3nNjRpvu
+        IevG6Isk7nR3P+7+9+hpVoE39ARzrGb5HVtDb2ON9s68mrny9x5bMnRwToJCBINBPwn6QRoxmgQR
+        JYISIgaERYIOaD8vAkxl5QMWCcP4zNs2CmNL52o79H1Wy95aunLLe7mp/AZqY/0KHLPONHCuJD93
+        YJ3123O1qvYtpwXn50Y70Og4Bv/aQPEl6tMwJSGBKBZFzBAvgoRypMpzQuKUA+QR5RTRSlep1Vuo
+        V0CnoHBluH9qxXe8iID1jgg+3BZM5bc81v+D6Qiz08owcQTRsF03m62Fpmv4y5hO6crfNMTt61aT
+        hVSA7ekqowF2Zj0ZTwPIRmqywXc1exByYicXL/bt/GfY2cNkcX0VzLOZEuODf6nxx36Rze5FNt0s
+        shv5TY74WF5g5Ige7vY93c2zW3PIfluK68t7nqn9Uv+K/JFs8mguu8i0vbPvdbpsVwZ0boTU63Y7
+        UKYkRttKSX1nveGjZ0EVn0r7qJZ/wfMh0bV796r4/925p6dnpMGZbPkEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:55 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:8369323:9C46ADA:5ED65FCF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3834'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:56 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:836939E:9C46B67:5ED65FCF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3833'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZNOsgcX2sNsFCrgBih529yJQEm0xlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE4zkuloOrm5vZ1cjq+uzkalSkVEY6PZl6/ru/yPPPn28YF//2uVlMvN
+        n/eL69n91/XsYfZphMm8EJhphbFRVGxSbrkRFj/M6zyP2l8LgVGrtDjPZXxOcw37/4pKyxW3oM15
+        bsTZSK1LoUfTZpSrhSwh5AAGgkjTm5vxr5PJ7eWe8pu75cfNz8nvNf9eZem3fBXf/5jMviSb2f3i
+        XyzlkMd1VOsc9MzaykwZ84Pm6mIhbVbHtRE6UaUVpb1IVMFq1gn7vPp0DchCtxhnMgzs4SrZkvxy
+        4Aw7vJPMFvmeMl4Ht/LwmrnKc7UGc38XR4plWwCdmYPJcvE2GAANUzYTMC22+0hGkjjzU6luccPo
+        H/yScAbHpkV6KrBdDiXJxR4bpkWlHLeOTaJlZaUqT1Z3BwKo0gteygf+JiggBixS9GTF3GJAxArO
+        fDLFr26YC9dkQ2bTIhFyhfN4G3kPA7DdVJRd7gYWpFOSVkQ8LSgpuFzxeIbofWXsHEhAqdge/mha
+        In9RROjlNiE9G9jOuIeC9IAgor5g/6NxCGDAYJWl2ARjEqth+NvGW4LEwGOlOZJ4MCE70IYNv5JT
+        WcGLYLIcDNBMqXCWdzBApTG1OMr3jz9VxzSsC7ayLmKfSY8JsePFeBr2wI2Ri1KIYBbfAhvWXQKx
+        5mWShRPR8RrmPzmv4YtgWyAWkHGu4mBMXOjMARtmMu6vRhuF1JokEG9HgBbzoFsg3laA1QH9xqlP
+        wC0et7WFCwXTv+Oxpj2BnJeLmi/CSdgC6bJCqbLgDy9WaMfHbE8EnkpTLeM6bGLumbQDXxQh/4Q7
+        gh7ZC3BV1/Ml3SuMNKjknJmKQr5U8xxPb3E7IRZYBMXBvhj6/nLp9rptEK9h/f3iL7NWUqjTaG+z
+        Tv+hvPZtFcy1Oh5rfqm4zSjDQmzFtQi1mRbHmhhP3ceLi4smE9w9SwqhA2YRTwOW6yRDeR1K/6bj
+        oXIsuHXPnzmpn+I5lCueBjuLLRBw7wKh9uBpQz+qUK8HU9zBhvRC5uhaqDLcHdETh3JKZeVcJse8
+        FY8P8x1o89nIMhFnHM8bRIWViUSc4MlOHoAiX4Szoqdhe+gR+WdiLhAywU5JC89rmO8KpKLK1SZo
+        hhwgKZFogQZVGnGLR+lkPBmfj2/Ox5O/L6+nl7fT6w8/Maeu0AN7cs6HCc2papM9PeWapiD9t7GC
+        T+hKPd8I2n9jUscJEGOyHvJbj5ge6CU9gUhyOP1e1J6my2r/bn8dBtvJVCEq1Gnd49zIB3we79RY
+        iapLnA4G19zisYGapR/q6rIOkHET+Uwymlpdo+dII5VW9yKxZjjWZ7LBxLVcyp2FVENuuwX+kd8L
+        L6TWqm02+uZCm4fRNmw7nqk0PM5FP6AqUbYaDrchE1GarRl8A4C2PJi+YwL3JRVzXuc28m8laqei
+        J4sGK9xR6AJmoJ4XtVvbzoo3CLlqt0fKiv4zGi5WFFXkvcOqpaD+LFDIKmodmX9qDtdzF1i32P/i
+        hrAVqsZ2f9GCrtPdNSkCHK0er3GE4rAldg3iYVvovU9cx+994vc+8Xuf2Hfa6fo70CcuhV2jYTrI
+        psPnbZetH/8Dnm0cZBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:18:56 GMT
+      etag:
+      - W/"2b962512f0f0944347538e85419815fd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:18:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:836940B:9C46BEF:5ED65FD0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3832'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:18:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C90F:160FF:836948A:9C46C8B:5ED65FD0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3831'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_fetch.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_fetch.yaml
@@ -1,0 +1,2564 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:28 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:573460C:6757C0F:5ED6602C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3621'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:29 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734667:6757C59:5ED6602C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3620'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821448,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE0NDg=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:20:29Z","updated_at":"2020-06-02T14:20:29Z","pushed_at":"2020-06-02T14:20:30Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:30 GMT
+      etag:
+      - '"46e50d92612939ee2bab942e99e3ac34"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:57346C4:6757CC5:5ED6602D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3619'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"fcbc5166b3632df3d21346c6bb171c8fc957ebee","node_id":"MDY6Q29tbWl0MjY4ODIxNDQ4OmZjYmM1MTY2YjM2MzJkZjNkMjEzNDZjNmJiMTcxYzhmYzk1N2ViZWU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fcbc5166b3632df3d21346c6bb171c8fc957ebee","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fcbc5166b3632df3d21346c6bb171c8fc957ebee","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:31Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:31Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:31 GMT
+      etag:
+      - '"eeb45713ad9b6a40cde3b44c7cf1a5c5"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734895:6757EED:5ED6602E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3618'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTW/aQBD9K5HPJP4ADEGK2kN6aCWooqZpnapC6/UYL1nvurtrGkD5750xbhI4
+        pHGU3nJB9q7f7Js3HztsPcVK8CZeyawD4/U8rstSOG+y9WzBcCPnKR+GcZz2436U5f0sCvuDmMdp
+        Go5CPs756XAEKQBClc5gLjIETc+T+CI6dek3GUyXyeDz+cfb2fnF4HN5vUzKaTi9TKJkOY2mm083
+        18vZzXT5YTM7x6fyk5he8ttkU5TJ5iacRVfi+tvXsz1erHaFNsSw5f6lYAUzRx9WRiv8EkomJJJA
+        /rh8ArT8fkGLJ+gcfpAxRy5HQRQcB/FxEF2Gg0kUTPrhtXf3VwFS478dUYK1bEEkPirhBJNiA0dI
+        ix0ZqLQVTps1EnUGdb2PRJgHp1ke9UejcTQYhYPhGLIoOmWjNB2M+Qh3xtmoDwECa0MCFM5VduL7
+        rBInC+GKOiUB/OYIvwSHIdcGjqVIjx1YZ336nc/LNTGx4HwE+cTB+s8+G/V7xcN3yWj9DklIEFBu
+        znWtMI2DnrcCI3LBmROYHqjm7h0wT3MmLfQ8A8zSllcrKxYKd3oePTBXG9Rf1VL2vIqtpWYIote7
+        13PzBS4WrpTzfZUfhfc5gd0d+gJZ7cG5L06trm77bVwtxuahAUi9EBQ4WzRVjnvUfuLhMO7vt6OL
+        +Or7TPJlEs4ukw3ZWGGOm0NvmkUbtdVSWzBcK4fp1BRO7TeW363OBmhhYVobTcf7V9GRLes/8Hw6
+        hg/f5VpK/Ruxh1T3a3rPvH8PQla7Z6EW3Q0gaOtrVwDqhPTvyGmBfaKLpQawxU6CnUVkZMKixAay
+        LkZaCJL5rZDHtmlhja06tdyIikq7E609IBrSZsGU2DQ9opMhBFJKNj21i0sNAIGwwuzqhNwhtn5l
+        xIrxNclggINYoabdrR1A0ZhbV3QxfcWIk8LCwZxlJZVZ0y4PL8i3Emyv1bcS7FY5byW4u7Swme1V
+        77NKsGKG+oY3+fETC3IuhbrBF5zZQeavMfmlhile4OB3/7+ALqxHljsOHDRF/rWFhCujHXD3aAZr
+        V9oRDRRL5d6E9qsWdGngTeBqO0dqfOcwqFwbDs3IJ7H9EUed5yhic3Pftho9nIknPN2nnz8eH4iE
+        Hbnxiny4+wNmk6IEWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:32 GMT
+      etag:
+      - W/"27ec44dc822df62c2ccc6e9de766d456"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734A2A:67580A7:5ED6602F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3617'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:32 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734A7B:6758125:5ED66030
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3616'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fcbc5166b3632df3d21346c6bb171c8fc957ebee
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwW6jMBD9lchnErAhQJBW2kN6aCVSVZu2IqtVZMMQTDBEtqkaqvx7x82le2ul
+        3Quy53nmzXszvBHTcJKRuhTlksaxCOOQVXVYMRpGcRkLQRNapnW5WiYgAIhH+qGCvawwKV8X8QNb
+        WfHcBXlbRPfr29fN+iG6V7u2UDnNtwUr2pzl091x126OeXszbdZ4Uncy35avxdSoYjrSDXuSu+fH
+        H1h81B0Wbqw9mcz3+UkuDtI2o1iUg/I1nAbjK7Dc2EHDvJNibsFY47vvfq/OFUcMrI9JPmYoidg3
+        pDVWdfu/W/hE/xXiK+l3OPlom0GT7I30XAGK/9XwhuvZzYseenQEFJfOE5wThhfgwj8PLug8wQeo
+        2aWxgAXzIJ4HbEujjAVZSHfk4pFrRxb+I4XVuBgo4LpKtA5WVc3CJElZlNBomULF2IonQkRpmSCS
+        VkkIwb+dtuvB+F/mRmMUGMMPzrrbXlrJOznBzC3Q7GPPJK7YGXs8cQ29NST7/ccjL6BlLUtuJc4G
+        FV/vgD9DzTsDHtHAjYPI2Bt56BHxiDtwO2qk6seucyXP3cAxyV0vl3dVR2cnhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:32 GMT
+      etag:
+      - W/"b5ac1d71d4f6ca5aca4e1d0ffa45024d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:31 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734B04:67581D2:5ED66030
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3615'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["fcbc5166b3632df3d21346c6bb171c8fc957ebee"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"38efd9e598a113263043a7be6af45391b5317cd5","node_id":"MDY6Q29tbWl0MjY4ODIxNDQ4OjM4ZWZkOWU1OThhMTEzMjYzMDQzYTdiZTZhZjQ1MzkxYjUzMTdjZDU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/38efd9e598a113263043a7be6af45391b5317cd5","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/38efd9e598a113263043a7be6af45391b5317cd5","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:33Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:33Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"fcbc5166b3632df3d21346c6bb171c8fc957ebee","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fcbc5166b3632df3d21346c6bb171c8fc957ebee","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fcbc5166b3632df3d21346c6bb171c8fc957ebee"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:33 GMT
+      etag:
+      - '"b5fc8f8523e9b0d8b94178304b57637e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/38efd9e598a113263043a7be6af45391b5317cd5
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734B60:675821D:5ED66030
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3614'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBRF/4tnWitN6kLmiAKSqRgIokvkjxfsKo4j+7UiVP3vvIqRhYHlLved
+        d8+ZJehZfc3MHSibeVAZIbEbNkYLnbfUykaK19AGeXivds3j53PzUu3Gp2E/ypPatm7/IE/67f7L
+        btuZwGMaCHKIU645V5Nffnh0R700MfAEU6QRQJqJCRaD1wuEjJlfs+vCbBV1gJwguv7tFfUBDLL6
+        zLJTNNQbbdaFELoU5cr2pV0VZSWM0LrYFOa2N3frDWgAMsN5AiLII3j8X9Ofn5n/2eZy+Qadyo9I
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:33 GMT
+      etag:
+      - W/"a2d324fc3e96f343a427e07dac94d762"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:31 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734BF6:67582F9:5ED66031
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3613'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "38efd9e598a113263043a7be6af45391b5317cd5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWhOcpE3miLZIpmIgiC6RHV+wqziO4mtFqPrfuYqRhYHlLe++
+        e9+FTdCx8paRW1Amcq8iwsTu2BAMNM5QKyuZv/ray+N7uq92n8/VS7ofnvrDIM9qU9vDVp712+OX
+        2dQzgaepJ8gijrHkXI1u+eHQnvSyDZ5PMAYaAaSZMMGid3qBEDHyWzaNn42iDpATRNe/vYI+Qous
+        vLBoFQ2JNXSmgKxYqyQRD7m4T4VaachVl2aiSHQmklVrMjLDeQQiyMM7/F/Tn5+R/9nmev0GN7aX
+        Qn0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:34 GMT
+      etag:
+      - W/"5089e8d1b60e73465875ee7c8954e91f"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734C48:6758358:5ED66031
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3612'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:34 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734D80:67584D7:5ED66032
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3611'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjNdKsgcX2kO0CBbIBih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kl1v4iQ85pLYNPnNcDgzHE47kelkMbu6vp5dzufXZ5NKpSKiscntzZfNXfFHkXz9+MC//7lOqtX2
+        2302v73/Mv12k32aYDIvBWZaYWwUlduUW26ExQ/Lpiii7tdSYNQqLc4LGZ/TXMP+v6LWcs0taEte
+        GHE2UZtK6MminRQqkxWEHMFAEGl6dTX9dTa7vjxQfnu3+rj9Mfu94d/rPP1arOP7v2e3N8n29j77
+        F0s55HEdNboAPbe2NgvG/KD5cJFJmzdxY4ROVGVFZS8SVbKG9cI+rz/NAcl0h3Emw8ABrpYdyS8H
+        zrDjO8ltWRwo43VwK4+vWaqiUBswD3dxoli2A9CZOZissrfBAGiZsrmAabHdRzKSxJm/luoWt4z+
+        wS8JZ3BsWqSvBXbLoSS52GPLtKiV4zaxSbSsrVTVq9XdgwCqdMYr+cDfBAXEgEWKvloxtxgQsYYz
+        v5riV7fMhWuyJbNpkQi5xnm8jXyAAdhua8oudyML0ilJKyKelpQUXK54PEP0vjB2jiSgVOwOf7Ko
+        kL8oIvRql5CeDGxn3GNBekQQUZ+x/8k4BDBgsMpKbIMxidUy/O3iLUFi4LHSHEk8mJA9aMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGnOT7p5+qYxrWB1vVlLHPpKeE2OliPA174MbIrBIimMV3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4u0J0GIZdAvE2wmwOqDfOPUJ
+        uMPjtrZwoWD69zzWdidQ8CpreBZOwg5IlxVKlYw/PFuhnR6zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdT5d0LzDSqJJzZipL+VzNczq9w+2FWGARFAeHYuj786Xby7ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9peY2pwwLsTXXItRmOhxrYzx1Hy8uLtpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/lqR+iudQoXga7Cx2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlUuZnPJW
+        PD3M96DtZyOrRJxxPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQ26AZ
+        coSkRKIFGlRpxC0epbPpbHo+vTqfzv66nC9m08Xs4w/MaWr0wH4658Oc5tSNyZ+ZgvTfxQo+oSv1
+        dCPo8I1JHSfIMSYfIL8NiMWRXtJPEEkBpz+I2tfpsj6821+GwXZyVYoadVr/ODfyAZ+nezVWopoK
+        p4PBDbd4bKBmGYb6uqwH5NxEPpNMFlY36DnSSK3VvUisGY8NmWw0cSNXcm8h1ZC7boF/5A/CS6m1
+        6pqNvrnQ5WG0DbuOZyoNjwsxDKhaVJ2G423IRFRmZwbfAKAtj6bvmcB9ScWSN4WN/FuJ2qnoyaLB
+        CncUuoQZqOdF7daus+INQq7a75Gyov+MhosVZR1577BqJag/CxSyitpE5p+Gw/XcBdYv9r+4IWyF
+        qrH9X7Sg63R/TYoAR6vHaxyhOOyIfYN43BZ67xM38Xuf+L1P/N4n9p12uv6O9IkrYTdomI6y6fh5
+        22frx/8As+onNhUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:35 GMT
+      etag:
+      - W/"0c25970ee90d46c2a75dd972d3cfa73a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:34 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734DD5:675853D:5ED66032
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3610'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWhOcpE3miLZIpmIgiC6RHV+wqziO4mtFqPrfuYqRhYHlLe++
+        e9+FTdCx8paRW1Amcq8iwsTu2BAMNM5QKyuZv/ray+N7uq92n8/VS7ofnvrDIM9qU9vDVp712+OX
+        2dQzgaepJ8gijrHkXI1u+eHQnvSyDZ5PMAYaAaSZMMGid3qBEDHyWzaNn42iDpATRNe/vYI+Qous
+        vLBoFQ2JNXSmgKxYqyQRD7m4T4VaachVl2aiSHQmklVrMjLDeQQiyMM7/F/Tn5+R/9nmev0GN7aX
+        Qn0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:35 GMT
+      etag:
+      - W/"5089e8d1b60e73465875ee7c8954e91f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:34 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734E28:67585A1:5ED66033
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3609'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/38efd9e598a113263043a7be6af45391b5317cd5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUS4vbMBD+K0HnJH7IlmNDoQfvYQ9uCHUIcSlBksexEj+CJS+7CfnvHZFdaG8J
+        pBdjzXj0PebDF6JrThJCF1CVMYTxgnse9Rl1A8ojAYxXQUhjT4TUi2QZkinp+hJ2qsShLN2ylR8b
+        sWnc7LANlunr+490FSwPWVBsiuNys/aWeV1n+csZ++csXZ23eamKvKiLw8rLzsf37WF9zvLyUKTr
+        b3j5ODR4cW3MSSeOw09qvlemHsVc9q0zwKnXTguGa9MPMGuUmBnQRjv2udu1HyXHHhgHhxycaBX2
+        HpBWm7bZ/UvhL/h7gG+gj2Dy0dT9QJIL6XgLKP5nzWs+TF7ehr5DR6DlynqCe8LyHGz5+94WrSf4
+        AWq2Y77ruzOXzVw/94LEdxNKC3KdkhsjA/8RwgyADC6fUYoiWDAaVAEVLpVVxeIyiIJQugIigIr6
+        AiQXzEbpidu2HLRzNzYa04LWfG+te+2UUbyZ2PScuDxidXKzDTme+ACd0ST59SWwkkKGHmOCMuqX
+        FS19jwZMMiG8yJOLSsZhBAItearArzg/gP60ON+Nef09JW8wqEpJbhTmF1NxOwP+MCreaJiSAbi2
+        LTJ2Wu077EyJfeFmHHAd3dg01vaPpuc4ZI/X6x/oXV4KqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:35 GMT
+      etag:
+      - W/"b5fc8f8523e9b0d8b94178304b57637e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734E72:67585F6:5ED66033
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3608'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=38efd9e598a113263043a7be6af45391b5317cd5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf29iOI9sKjNKYrTjQlnUPdUIhSNbZVipLxlIastLvvnMbaJfu
+        IevG2IPEoZPu/+N/p0dPsxa8qSeYYx0r71kNo7U12jvxOuaaX2dswzCRQpKWgjKRUKDjccSDNCZh
+        EhMhIIaEBDSgKY8DLGXldxSh8Ym36RU+bZzr7NT3WSdHtXTNho9K0/o9dMb6LThmnenhVEl+6sA6
+        6w/7atXuBkwLzi+NdqAxcch91kP1KUqhEhQITVkYRuM4CiYRSzjErJqQiIacRGFSCoJkjWvV6meo
+        N0DHoHBluH+s4jteREC9A4IP24Kl/IHH+r/RHGG2WhkmDiB6tt33ZmOh3xv+3KZjXPkTQ9yuG0ay
+        kgrQnr0yHsDW1Hk23yxuQ5WvMW5Dsrz4EiyKKyWy3Obnz/ndsrh6EMV8vSwu5bWc8Uye13c6z2bJ
+        EOXZsObbRXFjXqrcNOLi8wMv1OvLb2RdRgv5cn9G7/QQFV87jBAJdGmE1DUycRzHeIJnKyX1vfWm
+        j54FVf1XM45T8Td4PjRcw/96I/5v/9bT0w9KWQAM4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:36 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734F05:67586A8:5ED66033
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3607'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:36 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734F61:6758713:5ED66034
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3606'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjNdKsgcX2kO0CBbIBih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kl1v4iQ85pLYNPnNcDgzHE47kelkMbu6vp5dzufXZ5NKpSKiscntzZfNXfFHkXz9+MC//7lOqtX2
+        2302v73/Mv12k32aYDIvBWZaYWwUlduUW26ExQ/Lpiii7tdSYNQqLc4LGZ/TXMP+v6LWcs0taEte
+        GHE2UZtK6MminRQqkxWEHMFAEGl6dTX9dTa7vjxQfnu3+rj9Mfu94d/rPP1arOP7v2e3N8n29j77
+        F0s55HEdNboAPbe2NgvG/KD5cJFJmzdxY4ROVGVFZS8SVbKG9cI+rz/NAcl0h3Emw8ABrpYdyS8H
+        zrDjO8ltWRwo43VwK4+vWaqiUBswD3dxoli2A9CZOZissrfBAGiZsrmAabHdRzKSxJm/luoWt4z+
+        wS8JZ3BsWqSvBXbLoSS52GPLtKiV4zaxSbSsrVTVq9XdgwCqdMYr+cDfBAXEgEWKvloxtxgQsYYz
+        v5riV7fMhWuyJbNpkQi5xnm8jXyAAdhua8oudyML0ilJKyKelpQUXK54PEP0vjB2jiSgVOwOf7Ko
+        kL8oIvRql5CeDGxn3GNBekQQUZ+x/8k4BDBgsMpKbIMxidUy/O3iLUFi4LHSHEk8mJA9aMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGnOT7p5+qYxrWB1vVlLHPpKeE2OliPA174MbIrBIimMV3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4u0J0GIZdAvE2wmwOqDfOPUJ
+        uMPjtrZwoWD69zzWdidQ8CpreBZOwg5IlxVKlYw/PFuhnR6zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdT5d0LzDSqJJzZipL+VzNczq9w+2FWGARFAeHYuj786Xby7ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9peY2pwwLsTXXItRmOhxrYzx1Hy8uLtpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/lqR+iudQoXga7Cx2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlUuZnPJW
+        PD3M96DtZyOrRJxxPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQ26AZ
+        coSkRKIFGlRpxC0epbPpbHo+vTqfzv66nC9m08Xs4w/MaWr0wH4658Oc5tSNyZ+ZgvTfxQo+oSv1
+        dCPo8I1JHSfIMSYfIL8NiMWRXtJPEEkBpz+I2tfpsj6821+GwXZyVYoadVr/ODfyAZ+nezVWopoK
+        p4PBDbd4bKBmGYb6uqwH5NxEPpNMFlY36DnSSK3VvUisGY8NmWw0cSNXcm8h1ZC7boF/5A/CS6m1
+        6pqNvrnQ5WG0DbuOZyoNjwsxDKhaVJ2G423IRFRmZwbfAKAtj6bvmcB9ScWSN4WN/FuJ2qnoyaLB
+        CncUuoQZqOdF7daus+INQq7a75Gyov+MhosVZR1577BqJag/CxSyitpE5p+Gw/XcBdYv9r+4IWyF
+        qrH9X7Sg63R/TYoAR6vHaxyhOOyIfYN43BZ67xM38Xuf+L1P/N4n9p12uv6O9IkrYTdomI6y6fh5
+        22frx/8As+onNhUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:36 GMT
+      etag:
+      - W/"0c25970ee90d46c2a75dd972d3cfa73a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:34 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5734FBF:675877A:5ED66034
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3605'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTW/aTBD+K5HPJP42Aal6e6CHHkiESprCqwqt12O8xPb63V3TBMR/74wxTeCQ
+        4ijvLRdkdj0zzzzz6a1VsgKsoVUwbUBZPYvLohDGGm4tnTG88K8hTQYQDq6Z6/pe5DuBz/oxRCwN
+        Qn/gxqHv9nkSomgpE1iIBIXGo1k08QYmvs+d8WoW3I6+Pt6MJsHtahzM7+cPt/d37u00y8bTLxu8
+        34xHk81smoj5dJ7NVxN3vHl4nK3uNuNpspqP7j4d4WK1yaQihC32bxnLmLr4slayxDehYCJHEIgf
+        j6+Ajj8v6fAKncMXEmbIZc/xnEsnunS8qRsMPWfo+3Nrd2CA2PjfTBSgNVsSiK+lMILlF4iJVYw/
+        4OlFG4KeZRTgO4dI9PtwHflBGvix4/M0jQZJ0A9C7sTQB0h9LwbO4ogiUSsiIDOm0kPbZpW4WgqT
+        1TERYCuopLYLMBhyqeAyF/GlAW20Tb+LRfFEYDQYG4VswqDts20jf+9ofM+EtjskIYlAaRZc1iWm
+        sdOz1qBEKjgzAtMD2dz/B8zTlOUaepYCpunKqkstliXe9Cx6YKZWyH9Z53nPqthTLhkK0d/d+7n5
+        BhczU+SLY5ZfhPecwO6NvoFWfWL3zanV1W27javG2Dw3gFwuBQVOZ02V4x21nygMI/+4HU2i7z9u
+        cr6auTfT2YZ0rDHH1ak3zaH22mqpNSguS4Pp1BRObTea/1l/ClDDUrU6mo73t6IjXdp+xvl6DJ/f
+        S2Wey18oewr1uKaP1Nt/hBDV/lmUy+4KUGhrS5MB8oTwd+S0wD7RRVMjsMVOgp1FJKRCI8UKki5K
+        WhEE86tEHNumhTW66lhzJSoq7U6wjgRRkVRLVopN0yM6KUJBSsmmp3ZxqRFAQVhjdnWS3Ets7UqJ
+        NeNPRIMCDmKNnHbXdiKKysxTRYPpDiNODAsDC5YUVGZNuzwdkB8l2I7VjxLsVjkfJbgfWtjMjqr3
+        rBKsmKK+YQ3/PWyHKY956EZR7Ee+l6R+4rl+EPEojt2+y69TPgj7EOM++W4L2mGEd7D8+tTrsLmc
+        bXP3ExvWIhflA5KFXEGevsdmHCtW8gwX4z/fTeTaC80dFzLasg+6EHClpAFuXuyo7Um7wkLJ4vxo
+        g/2vFjRUcVKaWi8QGt87DGUqFYdmJc5xPBBGmaaYBc1m89jk0E/aZ58tvD7Hzv98OCEJJ1bjFfmw
+        +w3OFqQseQ4AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:37 GMT
+      etag:
+      - W/"81c73578f73ddafc22642e20dc4cb21c"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5735040:6758818:5ED66034
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3604'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:37 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5735093:6758888:5ED66035
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3603'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/38efd9e598a113263043a7be6af45391b5317cd5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUS4vbMBD+K0HnJH7IlmNDoQfvYQ9uCHUIcSlBksexEj+CJS+7CfnvHZFdaG8J
+        pBdjzXj0PebDF6JrThJCF1CVMYTxgnse9Rl1A8ojAYxXQUhjT4TUi2QZkinp+hJ2qsShLN2ylR8b
+        sWnc7LANlunr+490FSwPWVBsiuNys/aWeV1n+csZ++csXZ23eamKvKiLw8rLzsf37WF9zvLyUKTr
+        b3j5ODR4cW3MSSeOw09qvlemHsVc9q0zwKnXTguGa9MPMGuUmBnQRjv2udu1HyXHHhgHhxycaBX2
+        HpBWm7bZ/UvhL/h7gG+gj2Dy0dT9QJIL6XgLKP5nzWs+TF7ehr5DR6DlynqCe8LyHGz5+94WrSf4
+        AWq2Y77ruzOXzVw/94LEdxNKC3KdkhsjA/8RwgyADC6fUYoiWDAaVAEVLpVVxeIyiIJQugIigIr6
+        AiQXzEbpidu2HLRzNzYa04LWfG+te+2UUbyZ2PScuDxidXKzDTme+ACd0ST59SWwkkKGHmOCMuqX
+        FS19jwZMMiG8yJOLSsZhBAItearArzg/gP60ON+Nef09JW8wqEpJbhTmF1NxOwP+MCreaJiSAbi2
+        LTJ2Wu077EyJfeFmHHAd3dg01vaPpuc4ZI/X6x/oXV4KqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:37 GMT
+      etag:
+      - W/"b5fc8f8523e9b0d8b94178304b57637e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:573510D:6758916:5ED66035
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3602'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["38efd9e598a113263043a7be6af45391b5317cd5"],
+      "message": "Set type to csv", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"00a4202ae5b0767b547b37926f176a86bc231c77","node_id":"MDY6Q29tbWl0MjY4ODIxNDQ4OjAwYTQyMDJhZTViMDc2N2I1NDdiMzc5MjZmMTc2YTg2YmMyMzFjNzc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/00a4202ae5b0767b547b37926f176a86bc231c77","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/00a4202ae5b0767b547b37926f176a86bc231c77","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:37Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:37Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Set
+        type to csv","parents":[{"sha":"38efd9e598a113263043a7be6af45391b5317cd5","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/38efd9e598a113263043a7be6af45391b5317cd5","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/38efd9e598a113263043a7be6af45391b5317cd5"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1181'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:38 GMT
+      etag:
+      - '"0bcbf0d32e42e8596236579c3edebba5"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/00a4202ae5b0767b547b37926f176a86bc231c77
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5735149:6758961:5ED66035
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3601'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWhOcpE3miLZIpmIgiC6RHV+wqziO4mtFqPrfuYqRhYHlLe++
+        e9+FTdCx8paRW1Amcq8iwsTu2BAMNM5QKyuZv/ray+N7uq92n8/VS7ofnvrDIM9qU9vDVp712+OX
+        2dQzgaepJ8gijrHkXI1u+eHQnvSyDZ5PMAYaAaSZMMGid3qBEDHyWzaNn42iDpATRNe/vYI+Qous
+        vLBoFQ2JNXSmgKxYqyQRD7m4T4VaachVl2aiSHQmklVrMjLDeQQiyMM7/F/Tn5+R/9nmev0GN7aX
+        Qn0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:38 GMT
+      etag:
+      - W/"5089e8d1b60e73465875ee7c8954e91f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:57351DA:6758A0D:5ED66036
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3600'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "00a4202ae5b0767b547b37926f176a86bc231c77"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWqdpakPmiBakUDEQRJfIjq+1qziO7GtFqPrfuYqRhYHlLe++
+        e9+FRdiz8paJW1Amca8SQmR3bAgGWmeoratavPnG18ePYls9fb5Ur8V2eO53Q31W68buNvVZvz9+
+        mXUzEXiKPUEWcUwl52p084NDe9LzLngeYQw0AkgzIcKsd3qGkDDxW7atn4yiDpATRNe/vYI+Qoes
+        vLBkFQ1lmSryLFew0pkUUq8KqZfyIRf7hRTqXuguXy46KckMpxGIIA/v8H9Nf34m/meb6/UbdPc+
+        kX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:39 GMT
+      etag:
+      - W/"c2285e328ea92b9bdd2620947361ead6"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:573522A:6758A68:5ED66036
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3599'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:39 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:573532E:6758BAC:5ED66037
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3598'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUU/jOBDHv0tfD3DpIg4qrfYe2FvpJBbpdA97+xI5iZuYJnHOdtorEd/9/mMn
+        TdorUMCPvEDr2r8Zj2fG42knMp3MZ5dXV7Pzi4urk0mlUhHR2OT25uv6rvijSL5dP/Aff66Sarn5
+        fp9d3N5/nX6/yT5PMJmXAjOtMDaKyk3KLTfC4odFUxRR92spMGqVFqeFjE9prmH/X1FrueIWtAUv
+        jDiZqHUl9GTeTgqVyQpCDmAgiDS9vJz+Optdne8pv7lbXm9+zn5v+I86T78Vq/j+79ntTbK5vc/+
+        xVIOeVxHjS5Az62tzZwxP2g+nWXS5k3cGKETVVlR2bNElaxhvbAvq88XgGS6wziTYWAPV8uO5JcD
+        Z9jhneS2LPaU8Tq4lYfXLFRRqDWY+7s4UizbAujMHExW2ftgALRM2VzAtNjuIxlJ4szfSnWLW0b/
+        4JeEMzg2LdK3ArvlUJJc7LFlWtTKcZvYJFrWVqrqzeruQABVOuOVfODvggJiwCJF36yYWwyIWMGZ
+        30zxq1vmwjXZkNm0SIRc4TzeR97DAGw3NWWXu5EF6ZSkFRFPS0oKLlc8niB6Xxk7BxJQKraHP5lX
+        yF8UEXq5TUjPBrYz7qEgPSCIqC/Y/2gcAhgwWGUpNsGYxGoZ/nbxliAx8FhpjiQeTMgOtGXjr+RU
+        VvAymCwHAzRXKpzlHQxQaUwjjvL940/VMQ3rg61qythn0mNC7HgxnoY9cGNkVgkRzOJbYMv6SyDW
+        vErycCJ6Xsv8J+c1PAu2BWIBGRcqDsbEhc4csGUm5/5qtFFIrUkC8XYEaLEIugXibQVYHdBvnPoE
+        3OJxW1u4UDD9ex5ruxMoeJU1PAsnYQukywqlSsYfXqzQjo/ZgQg8laZaxk3YxDwwaQe+KEL+CXcE
+        A3IQ4Kqu50u6VxhpVMk5M5WlfKnmOZ7e4XZCLLAIioN9MfT95dLtddsgXsuG+8VfZp2kUKfR3Wa9
+        /mN53dsqmGv1PNb+UnObU4aF2JprEWozHY61MZ66j2dnZ20uuHuWlEIHzCKeBizXSY7yOpT+bc9D
+        5Vhy654/C1I/xXOoUDwNdhZbIODeBULtwdPGflSjXg+muION6aUs0LVQVbg7YiCO5VTKyoVMjnkr
+        Hh/mO9D2i5FVIk44njeICisTiTjBk508AEW+CGdFT8P20CPyz8RCIGSCnZIWntcy3xVIRV2oTdAM
+        OUJSItECDao04haP0tl0Nj2dXp5OZ3+dX8xn0/ns+ifmNDV6YE/O+XRJc+rG5E9PcRik/y5W8Ald
+        qecbQftvTOo4AWJMPkB+GxDzA72kJxBJAaffi9q36bLav9tfh8F2clWKGnVa/zg38gGfpzs1VqKa
+        CqeDwTW3eGygZhmG+rqsB+TcRD6TTOZWN+g50kit1b1IrBmPDZlsNHEtl3JnIdWQ226Bf+QPwkup
+        teqajb650OVhtA27jmcqDY8LMQyoWlSdhuNtyERUZmsG3wCgLY+m75jAfUnFgjeFjfxbidqp6Mmi
+        wQp3FLqEGajnRe3WrrPiDUKu2u+RsqL/jIaLFWUdee+waimoPwsUsopaR+afhsP13AXWL/a/uCFs
+        haqx3V+0oOt0d02KAEerx2scoTjsiH2DeNwW+ugTN/FHn/ijT/zRJ/addrr+DvSJK2HXaJiOsun4
+        edtn68f/AIKenj0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:39 GMT
+      etag:
+      - W/"45190dcb2a2a1757c6f9fc393c84d7d6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:573537C:6758C0C:5ED66037
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3597'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/00a4202ae5b0767b547b37926f176a86bc231c77
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXavaQBD9K7LPavYjmzWBQgtp4RbiRSotWopMNqNZyYdkN7Z68b/fTe2F9k3B
+        voTsTM6eM2cOeSG2BJIQSiHklAPKnKpI5TJUuVAxj7ZMRTCLcs0F00qRMWnaAjem8KAsXUULHrv8
+        W0Wz/Sp8Tp9+zdNF+Lz/8HO1XJyy9HO5Xn41War5nD+xeVqY7Kxltl/X2VLz1XLHV3V2ys6f9vOz
+        fucv77vKX1w6d7BJEMDBTHfGlX0+1W0ddHhobVCjA+vaDieVyScOrbPB8Nxs6lMBvocu8KDAI2rj
+        e3eMVrq62vwr4S/6W4ivpPdwQu/KtiPJC2mgRj/8lxJK6EYfj13beEewBjN44vfky1Mcyu93Q3Hw
+        xH/gZx5gfnt0QqMJ5UsWJpwmQq3JZUyuihz+RwrXoVfw8idKDJgGXeQ6LpSUkVKsEJxKlIixnEnF
+        RZRTwfhjtz1osMHN3N6YGq2F3W/H0Y3c6YAj1460PXphB+iwcZYk39+mEjPcFjHKeAaMCR4JGgpQ
+        OUawDaWIWS4FU7qQj53qLcN3sD8swzdzXn6MyRE7szUanPGh9VG4ntH/JbZQWRyTDsEOLdI31uwa
+        3xmT4QVc3/kdNH1VDbafqhY8aDheLq/C0oS5nQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:39 GMT
+      etag:
+      - W/"0bcbf0d32e42e8596236579c3edebba5"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:57353DE:6758C75:5ED66037
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3596'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=00a4202ae5b0767b547b37926f176a86bc231c77
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T30vrMBTH/5c+65K2a9INLhc3VDZwoj7YjcFImnTNTJPSZI4p/u8mrlx03of5
+        A/ElCefknPPhnO95DBSpeNAPGLGkJvkdWfLOymgVHAU1seX/PaYkzkEpggWDaRolMIK9mOAExhgx
+        jBBLEYkZTnGUF9ClMuLBFQnD7lGwbqSLLa2tTR8AUovOUthyTTu5rkDDa21AxS0xVjf8WAp6bLmx
+        Bvhzsai2ntNwC3KtLFfOsQ/+t+HFHwhJN4IR4QmFGGGadDGNcS9CRYgRSRHNozjMMXZopa3k4i3U
+        K6BDUKjUFBxa8R2vQ3D19gg+3RaXCngeAz4wHaY3SmrC9iAasmlnsza8aRv+MqZDuvKVhtht7TVZ
+        CMlde9rKzsA3ejkajiHPBnK0cu9q8sDEyIxOXuzr6W3Y2sNkdn4Gp9lEsuHOP1fux3aWTe5ZNl7N
+        sgtxKQZ0KE5c5ADvbv8eb6bZtd5lvy7Z+ek9zeR2rv5F3iSrPJ6KNrLn7+yq7s39ynCVaybU0m+H
+        kynqOttCCnVngv5jYLgsfpX2nVq+g+dTovN796r4z+7c09Mzzk5ea/kEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:40 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5735415:6758CCA:5ED66037
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3595'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:40 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:5735462:6758D1E:5ED66038
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3594'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUU/jOBDHv0tfD3DpIg4qrfYe2FvpJBbpdA97+xI5iZuYJnHOdtorEd/9/mMn
+        TdorUMCPvEDr2r8Zj2fG42knMp3MZ5dXV7Pzi4urk0mlUhHR2OT25uv6rvijSL5dP/Aff66Sarn5
+        fp9d3N5/nX6/yT5PMJmXAjOtMDaKyk3KLTfC4odFUxRR92spMGqVFqeFjE9prmH/X1FrueIWtAUv
+        jDiZqHUl9GTeTgqVyQpCDmAgiDS9vJz+Optdne8pv7lbXm9+zn5v+I86T78Vq/j+79ntTbK5vc/+
+        xVIOeVxHjS5Az62tzZwxP2g+nWXS5k3cGKETVVlR2bNElaxhvbAvq88XgGS6wziTYWAPV8uO5JcD
+        Z9jhneS2LPaU8Tq4lYfXLFRRqDWY+7s4UizbAujMHExW2ftgALRM2VzAtNjuIxlJ4szfSnWLW0b/
+        4JeEMzg2LdK3ArvlUJJc7LFlWtTKcZvYJFrWVqrqzeruQABVOuOVfODvggJiwCJF36yYWwyIWMGZ
+        30zxq1vmwjXZkNm0SIRc4TzeR97DAGw3NWWXu5EF6ZSkFRFPS0oKLlc8niB6Xxk7BxJQKraHP5lX
+        yF8UEXq5TUjPBrYz7qEgPSCIqC/Y/2gcAhgwWGUpNsGYxGoZ/nbxliAx8FhpjiQeTMgOtGXjr+RU
+        VvAymCwHAzRXKpzlHQxQaUwjjvL940/VMQ3rg61qythn0mNC7HgxnoY9cGNkVgkRzOJbYMv6SyDW
+        vErycCJ6Xsv8J+c1PAu2BWIBGRcqDsbEhc4csGUm5/5qtFFIrUkC8XYEaLEIugXibQVYHdBvnPoE
+        3OJxW1u4UDD9ex5ruxMoeJU1PAsnYQukywqlSsYfXqzQjo/ZgQg8laZaxk3YxDwwaQe+KEL+CXcE
+        A3IQ4Kqu50u6VxhpVMk5M5WlfKnmOZ7e4XZCLLAIioN9MfT95dLtddsgXsuG+8VfZp2kUKfR3Wa9
+        /mN53dsqmGv1PNb+UnObU4aF2JprEWozHY61MZ66j2dnZ20uuHuWlEIHzCKeBizXSY7yOpT+bc9D
+        5Vhy654/C1I/xXOoUDwNdhZbIODeBULtwdPGflSjXg+muION6aUs0LVQVbg7YiCO5VTKyoVMjnkr
+        Hh/mO9D2i5FVIk44njeICisTiTjBk508AEW+CGdFT8P20CPyz8RCIGSCnZIWntcy3xVIRV2oTdAM
+        OUJSItECDao04haP0tl0Nj2dXp5OZ3+dX8xn0/ns+ifmNDV6YE/O+XRJc+rG5E9PcRik/y5W8Ald
+        qecbQftvTOo4AWJMPkB+GxDzA72kJxBJAaffi9q36bLav9tfh8F2clWKGnVa/zg38gGfpzs1VqKa
+        CqeDwTW3eGygZhmG+rqsB+TcRD6TTOZWN+g50kit1b1IrBmPDZlsNHEtl3JnIdWQ226Bf+QPwkup
+        teqajb650OVhtA27jmcqDY8LMQyoWlSdhuNtyERUZmsG3wCgLY+m75jAfUnFgjeFjfxbidqp6Mmi
+        wQp3FLqEGajnRe3WrrPiDUKu2u+RsqL/jIaLFWUdee+waimoPwsUsopaR+afhsP13AXWL/a/uCFs
+        haqx3V+0oOt0d02KAEerx2scoTjsiH2DeNwW+ugTN/FHn/ijT/zRJ/addrr+DvSJK2HXaJiOsun4
+        edtn68f/AIKenj0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:41 GMT
+      etag:
+      - W/"45190dcb2a2a1757c6f9fc393c84d7d6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:57354B0:6758D88:5ED66038
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3593'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:20:41 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C927:3CF2F:573555F:6758E62:5ED66039
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3592'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_fetch_no_package.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_fetch_no_package.yaml
@@ -1,0 +1,243 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:41 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92B:28A9F:A9D16B0:CA2ED3C:5ED66039
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3591'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:42 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92B:28A9F:A9D1708:CA2ED87:5ED66039
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3590'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92B:28A9F:A9D1774:CA2EE13:5ED6603A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3589'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_fetch_no_revision.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_fetch_no_revision.yaml
@@ -1,0 +1,1593 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:42 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D1828:CA2EF1E:5ED6603A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3588'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:43 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D189D:CA2EF6E:5ED6603A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3587'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821498,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE0OTg=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:20:43Z","updated_at":"2020-06-02T14:20:43Z","pushed_at":"2020-06-02T14:20:45Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:45 GMT
+      etag:
+      - '"da33ad69e48e14d7f90f3f599cec2393"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D1921:CA2F01C:5ED6603B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3586'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"679de3b1d9dbb3563829f36e3b769086da1d0b0a","node_id":"MDY6Q29tbWl0MjY4ODIxNDk4OjY3OWRlM2IxZDlkYmIzNTYzODI5ZjM2ZTNiNzY5MDg2ZGExZDBiMGE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/679de3b1d9dbb3563829f36e3b769086da1d0b0a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/679de3b1d9dbb3563829f36e3b769086da1d0b0a","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:45Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:45Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:46 GMT
+      etag:
+      - '"1da4c4ae545c2d90288118a6ff3c51ff"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D1D8D:CA2F57C:5ED6603D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3585'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW0/bMBT+KyjPhaRpm14ktGkqQjy0iI2NtdNUOclJYnDszHYKbcV/3zlpuLQP
+        jCD2xgtqbH/H37l9PmwcyXJwRk7OjAXttJxI5Tm3zmjjmIzhRtAfxtAJ2/EwDsNOL+gM/GHSCXCp
+        Hwy9QRCzduyFHkOoVDEseIygyXgWXPhDG14Jb3I9656Pz+6m45vu+fWsc371VUz8s7v5WNzM8rP1
+        9HK2xv3e/Hrizy+nfLqe9Sbj1J+fnuCZL3xyenK8w4uVNlOaGNbcv2UsY/rgZKmVxJOQMy6QBPLH
+        5SOg5c8pLR6hc3ggZpZc9j3fO/SCQ8+/bHdHvjfq9ubO/UMEKBr/7YocjGEpkTiT3HIm+BoOkBY7
+        0FAow63SKyRqNeCZh0y0E28YJ36n3x/43X672xtA7PtD1g/D7iDq484g7nfAQ2CpKQCZtYUZuS4r
+        +FHKbVaGFAC3usLNwWLKlYZDwcNDC8Yal/4uFvmKmBiwLoJc4mDcV9+N8XvHy7fFaNwGRUgQkHYR
+        qVJiGXstZwmaJzxilmN5YDS334B1mjBhoOVoYIa2nFIankrcaTn0g9lSY/xlKUTLKdhKKIYg+rx/
+        Pzff4GJmc7HYjfKz9L4msdtL3xBWs3fvm0urqdtunVeDuXkSAKFSTokzWdXluEfyE/RQpnbl6CL4
+        8XMqoutZm+SGbCyxxvW+N9Wi8etuKQ3oSEmL5VQ1TulWlj8tj7toIdW1jUrx/tV0ZMu4TzxfzuHT
+        uUQJoW4Ru091t6d3zLuPIGS1/c1l2twAgjaushlgnJD+PTnNUSeaWKoAG1QSVBYekwmDIdYQNzFS
+        Q5DMrUQem0rCKltlaCLNC2rtRrR2gGhI6ZRJvq40opEhBFJJVpraxKUKgEBYYnU1Qm4RG7fQfMmi
+        FYVBQwR8iTFtbm0PisbsqqCH6TtmnCLMLSxYnFObVXK5/0B+tGD9rH60YLPO+WjB7aOFYrbTva9q
+        wYJp0g1n9Os3NuRCcHmDHzgpgkjeY/ILNZNRhoPf4/8F9GA9s9xw4KAp8sEWEi60shDZZzNYvVKP
+        aCBZKHYmtD8lp0cDXwJbmgVSi7YOg0yUjqAa+QTKH3FUSYJBrF7uuzpGT3fiDS/r9OvH470goSJX
+        XpEP938BniqgHVkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:46 GMT
+      etag:
+      - W/"059621d0c960da08837c7c901bc2696c"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D1F71:CA2F7B2:5ED6603E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3584'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:47 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2018:CA2F874:5ED6603E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3583'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/679de3b1d9dbb3563829f36e3b769086da1d0b0a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTYvbMBD9K0HnJFbkb0OhFIclBye0DSzOsgQ5GtvKynaQ5GWTkP++o6aH9rYL
+        7cVI8/TmzbwZX4lpOclIFKcC/GohUlFVfhj5CUtrP8JQHKU0iQRfCFpRTqakHwTspUBSkZfRd5ba
+        6lHR4lgGm3z1ts5fgs2x9DePP1TBVm+7XL2U3eqy3pYXxMPdsWC77VquL2VY5A3bPSzxzTdZPCy/
+        YPJRK0zcWnsymefxk5w30rZjNT8MnafhNBivA8uNHTTMlKxmFow1nvvu991ZcMTAekjykNFJxD7R
+        Wms7tf+7hD/kPyJ8F/2MJh9tO2iSXUnPO8Dmf7a85XqyfNVDj45Ax6XzBOeE4Tm48NfGBZ0n+AB7
+        djRGGZ3RaEbZdhFkjGZBuCO3KblXZOE/SlgNWMH19yotapqKmvlxnLAgXgRhAoKxlMdVFSSHGJFE
+        xD7QfzttV4PxPqyNxnRgDG+cdateWsmVvMDELdDk155JXLEz1njiGnprSPb0PCWvoGUtD9xKnA12
+        fL8D/gw1VwamRAM3DiJjb2TTIzIl7sDtqFGqH5VyKc9q4Ehy19vtHeKEINaEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:47 GMT
+      etag:
+      - W/"e02716716f4f2589f9aff2d2c2e36624"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2125:CA2F9A7:5ED6603F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3582'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["679de3b1d9dbb3563829f36e3b769086da1d0b0a"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"dcc77a81c1730ea1075082cd0e6abbdb890d4c35","node_id":"MDY6Q29tbWl0MjY4ODIxNDk4OmRjYzc3YTgxYzE3MzBlYTEwNzUwODJjZDBlNmFiYmRiODkwZDRjMzU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/dcc77a81c1730ea1075082cd0e6abbdb890d4c35","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/dcc77a81c1730ea1075082cd0e6abbdb890d4c35","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:47Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:47Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"679de3b1d9dbb3563829f36e3b769086da1d0b0a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/679de3b1d9dbb3563829f36e3b769086da1d0b0a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/679de3b1d9dbb3563829f36e3b769086da1d0b0a"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:48 GMT
+      etag:
+      - '"736701d4445aa58215a5da425c0dfc71"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/dcc77a81c1730ea1075082cd0e6abbdb890d4c35
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D219F:CA2FA64:5ED6603F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3581'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBCG38VzwaGhhmSOCq3kMjVVWSKbO+pAHEf2gZoi3r2HOnbp0OWG+++7
+        /7uIiHtR3maSDg0k6U0ijOJO9AGwaYFTXWn16muvD+/zTfX0+VId55v+udv2+mxWtduu9dm+PX7B
+        qh4ZPMWOIUc0pFJKM7TTj5bcyU53wcuIQ+ASJK4JESddayeEiZK8zabxIxjOkCRDfP3bK9gD7kiU
+        F5Gc4SK1KABzO4MCrM0fVL68L/a54tVCFdlSgZlBZjPDZjQOyAR7+Jb+1/TnZ5J/trlevwGkhhTG
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:48 GMT
+      etag:
+      - W/"9c6d77add8c7cffcbc18e26ae3275bf3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2286:CA2FB7F:5ED66040
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3580'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "dcc77a81c1730ea1075082cd0e6abbdb890d4c35"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBRF/4tnWjs0bULmiAJS6EQQXSJ/PLBLHEf2a0Wo+t95VccuDF3uct95
+        9xxZhE9WnTNxC9Ik7mVCiOyODcFA5wy1Td2s3nzrm91Hvqmff17r73wzvPTboTnIdWu3T81BvT/+
+        mnU7EbiPPUEWcUwV53J08y+Hdq/mOngeYQw0AkgzIcKsd2qGkDDxc3adn4ykDpATRNfXXkHtQCOr
+        jixZSUNG66KQZaazYiFAZqJYivJeGwErqZRR5YMwuV4syQynEYggD+/wtqaXn4n/2+Z0+gP8tXyO
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:49 GMT
+      etag:
+      - W/"d24b8c23a30d95bf01526ce7f19a9794"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2305:CA2FC09:5ED66040
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3579'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:49 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D24E7:CA2FE45:5ED66041
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3578'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdLEwGJ72O0CBdIAxR62exEoiZYYS6JKUnYdIe/ef0jJ
+        kl0ncbw85pLYNPnNcDgzHE47kelkPru+uZldXt3enE0qlYqIxiZ3n7+s74s/iuTr7SP//tcqqZab
+        Px+yq7uHL9P7b9nHCSbzUmCmFcZGUblJueVGWPywaIoi6n4tBUat0uK8kPE5zTXs/ytqLVfcgrbg
+        hRFnE7WuhJ7M20mhMllByAEMBJGm19fTX2ezm8s95Tf3y9vNj9nvDf9e5+nXYhU//D27+5xs7h6y
+        f7GUQx7XUaML0HNrazNnzA+aDxeZtHkTN0boRFVWVPYiUSVrWC/s0+rjFSCZ7jDOZBjYw9WyI/nl
+        wBl2eCe5LYs9ZbwObuXhNQtVFGoN5v4ujhTLtgA6MweTVfZzMABapmwuYFps94mMJHHmp1Ld4pbR
+        P/gl4QyOTYv0VGC3HEqSiz21TItaOW4Tm0TL2kpVnazuDgRQpTNeyUf+U1BADFik6MmKucWAiBWc
+        +WSKX90yF67JhsymRSLkCufxc+Q9DMB2U1N2uR9ZkE5JWhHxtKSk4HLF0xmi942xcyABpWJ7+JN5
+        hfxFEaGX24T0YmA74x4K0gOCiPqK/Y/GIYABg1WWYhOMSayW4W8XbwkSA4+V5kjiwYTsQFs2/kpO
+        ZQUvg8lyMEBzpcJZ3sEAlcY04ijfP/5UHdOwPtiqpox9Jj0mxI4X42nYAzdGZpUQwSy+BbasvwRi
+        zaskDyei57XMf3Jew7NgWyAWkHGh4mBMXOjMAVtmcu6vRhuF1JokEG9HgBaLoFsg3laA1QH9xqlP
+        wC0et7WFCwXTv+extjuBgldZw7NwErZAuqxQqmT88dUK7fiYHYjAU2mqZdyETcwDk3bgiyLkn3BH
+        MCAHAa7qermke4ORRpWcM1NZytdqnuPpHW4nxAKLoDjYF0PfXy/d3rYN4rVsuF/8ZdZJCnUa3W3W
+        6z+W172tgrlWz2PtLzW3OWVYiK25FqE20+FYG+Op+3RxcdHmgrtnSSl0wCziacByneQor0Pp3/Y8
+        VI4lt+75syD1UzyHCsXTYGexBQLuXSDUHjxt7Ec16vVgijvYmF7KAl0LVYW7IwbiWE6lrFzI5Ji3
+        4vFhvgNtPxlZJeKM43mDqLAykYgTPNnJA1Dki3BW9DRsDz0i/0wsBEIm2Clp4Xkt812BVNSF2gTN
+        kCMkJRIt0KBKI27xKJ1NZ9Pz6fX5dPbt8mo+m86vPvzAnKZGD+z5OTc0p25M/vyUW5qC9N/FCj6h
+        K/VyI2j/jUkdJ0CMyQfIbwNifqCX9AwiKeD0e1F7mi6r/bv9bRhsJ1elqFGn9Y9zIx/xebpTYyWq
+        qXA6GFxzi8cGapZhqK/LekDOTeQzyWRudYOeI43UWj2IxJrx2JDJRhPXcil3FlINue0W+Ef+ILyU
+        Wquu2eibC10eRtuw63im0vC4EMOAqkXVaTjehkxEZbZm8A0A2vJo+o4J3JdULHhT2Mi/laidip4s
+        GqxwR6FLmIF6XtRu7Tor3iDkqv0eKSv6z2i4WFHWkfcOq5aC+rNAIauodWT+aThcz11g/WL/ixvC
+        Vqga2/1FC7pOd9ekCHC0erzGEYrDjtg3iMdtofc+cRO/94nf+8TvfWLfaafr70CfuBJ2jYbpKJuO
+        n7d9tn76D/QvvJMVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:49 GMT
+      etag:
+      - W/"cba38cf94cf2f486235acfe2385b27a2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2567:CA2FEEF:5ED66041
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3577'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/dcc77a81c1730ea1075082cd0e6abbdb890d4c35
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW4vaQBT+KzLPaiaZmBsUyhILW1CpdSmxFJnJnJjRXCQzWXcV/3vPYBfaNwX7
+        EjLn5Mx3OR85E11ykhCZ52HIIzd3Q0aBuzSc0MjLJYWACyFFFFPp52xChqRpJWyUxKFZmgXfvNiI
+        HxWd7TJ/kT6/zdO9v6iXu+yUs2y1fctOUzY7PVXZanqcn16Oi/Trbp0+VfP6i8rqpVqk++M6Xe5m
+        p5dPeHnfVXhxacxBJ47DD2q8VabsxThva6eDQ6udGgzXpu1gVCkxMqCNduxzs6nfJcceGAeHHJyo
+        FfbukFaautr8S+Ev+FuAr6D3YPLelG1HkjNpeA0o/nvJS94Npq9d26AjUHNlPcE9YXkMtvx5a4vW
+        E/wANdsxj3p0RIMR9Vaun3g08cM1uQzJlZGB/whhOkAG5z9RCkOIAuYXPhOU5UURxNIP/UlOBYQA
+        BfME5FwENkoP3LbloJ2bsdGYGrTmW2vdc6OM4tXApufA8z1WB1fbkOOBd9AYTZKfHwKDMJbAhCtj
+        KQSbBCzy4oIFWAqDmEaB5K6kgvLHCvyI8x3oD4vzzZiXX0PyCp0qVM6NwvxiKq5nwB9GwSsNQ9IB
+        17ZF+karbYOdIbEv3PQdrqPpq8ra/l61HIfs8XL5Ddb++7SoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:50 GMT
+      etag:
+      - W/"736701d4445aa58215a5da425c0dfc71"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D25F4:CA2FF84:5ED66041
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3576'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=dcc77a81c1730ea1075082cd0e6abbdb890d4c35
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXU/bMBSG/0uuoXZa8lUJIRptKJXGBLtYWiFV/jhNXBw7il2qgvjvO4FKg7KL
+        jk2IC1tHPvZ5H73n+CEwrIFgHEjmWcvELatgsHLWBEdBy3z954yrGSZSSFIhMyaTDLLhcMRpGkdh
+        EkdSQgxJRDOapTymWMqpexTJ4qNg3Wl8WnvfujEhrFWDSvl6zQfCNqSD1jrSgGfO2w6OteLHHpx3
+        pN8Xi2bbYzrwRFjjwWBin/usg+WpFCJJWBqKMBlRYCFFmHQoJIWYcS55mlF5IkYRktW+0YvXUC+A
+        DkHh2nJyqOIbXkRAvT2Cd9uCpUjP48hfNEfajdGWyT2Ijm12vVk76HaGP7XpEFf+xRC/bfuRXCoN
+        aM9OGQ9gY6sin65nP0NdrDBuwmh+8ZXOykst88IV50/57by8vJPldDUvv6nvasJzdV7dmCKfJH1U
+        5P2abmbltX2ucl3Liy93vNS/X/6IVmI0U8/3J9mN6aPyqsUIkcAIK5WpkInjOMYneLbQyty6YPwQ
+        ONDLTzXjOBX/g+ddw9X/rxfiH/u3Hh9/AVt3EmLgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:50 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2646:CA2FFFB:5ED66042
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3575'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:50 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D26C4:CA30088:5ED66042
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3574'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2739:CA3011B:5ED66042
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3573'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:51 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D27B1:CA301A4:5ED66042
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3572'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdLEwGJ72O0CBdIAxR62exEoiZYYS6JKUnYdIe/ef0jJ
+        kl0ncbw85pLYNPnNcDgzHE47kelkPru+uZldXt3enE0qlYqIxiZ3n7+s74s/iuTr7SP//tcqqZab
+        Px+yq7uHL9P7b9nHCSbzUmCmFcZGUblJueVGWPywaIoi6n4tBUat0uK8kPE5zTXs/ytqLVfcgrbg
+        hRFnE7WuhJ7M20mhMllByAEMBJGm19fTX2ezm8s95Tf3y9vNj9nvDf9e5+nXYhU//D27+5xs7h6y
+        f7GUQx7XUaML0HNrazNnzA+aDxeZtHkTN0boRFVWVPYiUSVrWC/s0+rjFSCZ7jDOZBjYw9WyI/nl
+        wBl2eCe5LYs9ZbwObuXhNQtVFGoN5v4ujhTLtgA6MweTVfZzMABapmwuYFps94mMJHHmp1Ld4pbR
+        P/gl4QyOTYv0VGC3HEqSiz21TItaOW4Tm0TL2kpVnazuDgRQpTNeyUf+U1BADFik6MmKucWAiBWc
+        +WSKX90yF67JhsymRSLkCufxc+Q9DMB2U1N2uR9ZkE5JWhHxtKSk4HLF0xmi942xcyABpWJ7+JN5
+        hfxFEaGX24T0YmA74x4K0gOCiPqK/Y/GIYABg1WWYhOMSayW4W8XbwkSA4+V5kjiwYTsQFs2/kpO
+        ZQUvg8lyMEBzpcJZ3sEAlcY04ijfP/5UHdOwPtiqpox9Jj0mxI4X42nYAzdGZpUQwSy+BbasvwRi
+        zaskDyei57XMf3Jew7NgWyAWkHGh4mBMXOjMAVtmcu6vRhuF1JokEG9HgBaLoFsg3laA1QH9xqlP
+        wC0et7WFCwXTv+extjuBgldZw7NwErZAuqxQqmT88dUK7fiYHYjAU2mqZdyETcwDk3bgiyLkn3BH
+        MCAHAa7qermke4ORRpWcM1NZytdqnuPpHW4nxAKLoDjYF0PfXy/d3rYN4rVsuF/8ZdZJCnUa3W3W
+        6z+W172tgrlWz2PtLzW3OWVYiK25FqE20+FYG+Op+3RxcdHmgrtnSSl0wCziacByneQor0Pp3/Y8
+        VI4lt+75syD1UzyHCsXTYGexBQLuXSDUHjxt7Ec16vVgijvYmF7KAl0LVYW7IwbiWE6lrFzI5Ji3
+        4vFhvgNtPxlZJeKM43mDqLAykYgTPNnJA1Dki3BW9DRsDz0i/0wsBEIm2Clp4Xkt812BVNSF2gTN
+        kCMkJRIt0KBKI27xKJ1NZ9Pz6fX5dPbt8mo+m86vPvzAnKZGD+z5OTc0p25M/vyUW5qC9N/FCj6h
+        K/VyI2j/jUkdJ0CMyQfIbwNifqCX9AwiKeD0e1F7mi6r/bv9bRhsJ1elqFGn9Y9zIx/xebpTYyWq
+        qXA6GFxzi8cGapZhqK/LekDOTeQzyWRudYOeI43UWj2IxJrx2JDJRhPXcil3FlINue0W+Ef+ILyU
+        Wquu2eibC10eRtuw63im0vC4EMOAqkXVaTjehkxEZbZm8A0A2vJo+o4J3JdULHhT2Mi/laidip4s
+        GqxwR6FLmIF6XtRu7Tor3iDkqv0eKSv6z2i4WFHWkfcOq5aC+rNAIauodWT+aThcz11g/WL/ixvC
+        Vqga2/1FC7pOd9ekCHC0erzGEYrDjtg3iMdtofc+cRO/94nf+8TvfWLfaafr70CfuBJ2jYbpKJuO
+        n7d9tn76D/QvvJMVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:51 GMT
+      etag:
+      - W/"cba38cf94cf2f486235acfe2385b27a2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D2827:CA3022E:5ED66043
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3571'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:20:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92C:28A9F:A9D289F:CA302CE:5ED66043
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3570'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_list_multiple_authors.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_list_multiple_authors.yaml
@@ -1,0 +1,3619 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:07 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958914B:B2E5CC7:5EDF6832
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4999'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:07 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:95891CB:B2E5D39:5EDF6833
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4998'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":270975462,"node_id":"MDEwOlJlcG9zaXRvcnkyNzA5NzU0NjI=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-09T10:45:07Z","updated_at":"2020-06-09T10:45:07Z","pushed_at":"2020-06-09T10:45:08Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:09 GMT
+      etag:
+      - '"6ae0e93f558d8d8876a6a5aaac879d56"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589252:B2E5DCB:5EDF6833
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4997'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"32f16a78ed2574840e037ce5014fe688e3e72bce","node_id":"MDY6Q29tbWl0MjcwOTc1NDYyOjMyZjE2YTc4ZWQyNTc0ODQwZTAzN2NlNTAxNGZlNjg4ZTNlNzJiY2U=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/32f16a78ed2574840e037ce5014fe688e3e72bce","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/32f16a78ed2574840e037ce5014fe688e3e72bce","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-09T10:45:09Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-09T10:45:09Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:10 GMT
+      etag:
+      - '"db6c30a2b7ace2170183f542807a2592"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589512:B2E6120:5EDF6835
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4996'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTW/jNhD9K4HOTiTLsmUbWLQLZFG0QBQE9e7WLgqDokYSXYpUScpZ28h/74ys
+        bGIftlGQ3nIxJFJv+ObNB8cHT7EKvLlXMevAeAOP66oSzpsfPFsy3BiF+XDC4ilk4TiOplEAwSjm
+        MA6GUQ6T6RRGEIcpB4QqncFaZAi6uV5O7sKZS7/K4GbD728XfJhcL3e3m5vdavMpXC54tPp6t0sW
+        PLi9vrtfLT7ukzCRyeLjt+SXlUw2RbRa4Pv+N7EMP3844cUaV2pDDDvuv5esZObi09ZohV9CxYRE
+        Esgfl6+Aln8uaPEKncMPMubI5TAIg8tgchnMFsNgHo3nwWzlPTwqQGr8b0dUYC0riMSvSjjBpNjD
+        BdJiFwZqbYXTZodEnQH85jESwzyYZXk4iuNpGMXDaEwxCWcsTtNoymPcmWbxCAIENoYEKJ2r7dz3
+        WS2uCuHKJiUB/PYIvwKHIdcGLqVILx1YZ336Xa+rHTGx4HwE+cTB+i8+G/V7w8OPyWj9HklIEFBu
+        zXWjMI2DgbcFI3LBmROYHqjm8R0wT3MmLQw8A8zSltcoKwqFOwOPHphrDOqvGikHXs12UjME0evD
+        27n5ChdLV8n1qcrPwvuSwB4PfYWs9uzcV6dWX7f9Lq4WY/PUAKQuBAXOlm2V4x61n8l4PBmdtqO7
+        yZc/Esk3y2GyWO7JxhZz3Jx70y7asKuWxoLhWjlMp7ZwGr+1/NP2Q4QWCtPZaDvefxUd2bL+E88f
+        x/Dpu1xLqe8Re071tKZPzPvfQcjq+CxU0d8Agg6+diWgTkj/gZwW2Cf6WGoBB+wk2FlERiYsSmwg
+        62OkgyCZe4U8Dm0La201qeVG1FTavWidANGQNgVTYt/2iF6GEEgp2fbUPi61AATCFrOrF/KIOPi1
+        EVvGdySDAQ5ii5r2t3YGRWNuV9PF9BkjTgoLB2uWVVRmbbs8vyDfS7C7Vt9LsF/lvJfg8dLCZnZS
+        vS8qwZoZ6hve/M+/sCDXUqi/8QUnRZD5W0x+qWGKlzj4ff9fQBfWM8s9Bw6aIh9tIeHaaAfcPZvB
+        upVuRAPFUnkyof3TCLo08CZwjV0jNX50GFSuDYd25JPY/oijznMUsb25v3UaPZ2JJ/y4T798PD4T
+        CTty6xX58PAvw6SCfFkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:10 GMT
+      etag:
+      - W/"01f6a76331a12bddfb99db27c9e16707"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:95896E4:B2E6341:5EDF6836
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4995'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:10 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958976B:B2E63D3:5EDF6836
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4994'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/32f16a78ed2574840e037ce5014fe688e3e72bce
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTUYubQBD+K2GfTVxXkzVCoQc5SgsxhFqOWEpYddQNq4bd9a4m5L/fbNOH9u0O
+        2hdx5nPm+2bm80pMK0hCQlYHK8FjqNiSR3FEgYa8hCUNohpWcQwhcFaUQDzSDxUcZYVF281htWdr
+        Wzwpuj2VL7usDNLNYdqdtlN+emSHrIzyp/2UZiXdbfYvefZwSVmq0uzhZ/opV+mpifIM48sXeWDf
+        PmDzUSts3Fp7Nonvi7NcNNK2Y7Eoh87XcB6M34EVxg4a5koWcwvGGt89j8duqgRiYH0s8rGik4i9
+        Y7TWdur4t4Q/6N9CfCd9D6cYbTtoklxJLzrA4b+2ohV69vishx43Ap2Qbid4J0wvwKU/Ni7pdoIf
+        4MyujFFG53Q1p+ssoEm0TOg6JzeP3BVZ+I8UVgMquP62UlDTdVWzkPOYRTyIls5UbC14UURxyRGJ
+        Kx4C/bfXdhqM/2ZuXEwHxojGre5zL60USl5g5gw0++UziRabUONZaOitIcn3Hx55Bi1rWQor8TY4
+        8T0G/BlqoQx4RIMwDiJjb2TTI+IR9yLsqJGqH5VyLSc1CCxy4e32Ct4GfTiEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:10 GMT
+      etag:
+      - W/"b69b8a6b5e1eb35ff710758dd27edbc0"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589828:B2E64BF:5EDF6836
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4993'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["32f16a78ed2574840e037ce5014fe688e3e72bce"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65",
+      "author": {"name": "Bob Example", "email": "bob@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"c66f5a42b3d3e9710800b5a1b968cd1e9d946b31","node_id":"MDY6Q29tbWl0MjcwOTc1NDYyOmM2NmY1YTQyYjNkM2U5NzEwODAwYjVhMWI5NjhjZDFlOWQ5NDZiMzE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31","author":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:45:11Z"},"committer":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:45:11Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"32f16a78ed2574840e037ce5014fe688e3e72bce","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/32f16a78ed2574840e037ce5014fe688e3e72bce","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/32f16a78ed2574840e037ce5014fe688e3e72bce"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1176'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:11 GMT
+      etag:
+      - '"facf7565039c3cca3b77f38f5fe367c9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958989C:B2E6545:5EDF6836
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4992'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy07DMBBF/8VrWufVJMq6ahFS6AaC6CbyY4JdxXFkT4tC1X9nKpZsWLC5mztn
+        7rmyAANr7hm5AaEjdyIiBPbAJq+ht5radtuWr65z7Ul9Hl5U+rx9Xw7T03ic2ovYd+b42F7k2+5L
+        77uFwHMYCTKIc2w4F7Ndf1g0Z7lW3vEAs6cRQJrxAVajlSuEiJHfs+/dogV1gJwguv7t5eUJFLLm
+        yqIRNJRnQ1qKqgadbaqiLhJI8krBJkmLAcq6hhyqTCogM1xmIII8nMX/Nf35GfmfbW63b4ZUolR9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:11 GMT
+      etag:
+      - W/"8c2705507dba0ec534804db34de28dd9"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958996A:B2E6638:5EDF6837
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4991'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "c66f5a42b3d3e9710800b5a1b968cd1e9d946b31"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngmMCLsmMCkJyWdpUZYn88aiN4jiyH1Qp4r/XUccuHbrc5b7z
+        7rmRCCdST5moBWkS9TIhRPJA+mCgdSa3YiP4q2+8OOvPw4tmz5v38dDvu2MvrnLb2ONOXNXb05fZ
+        NmMGL7HLkEUcUk2pHNz8w6G9qLkOnkYYQh4BzDMhwqxzaoaQMNEp29aPRuYOkGYoX//2CuoMGkl9
+        I8nKPKQ5P63kcqFKU0L1yIp1UaiVZKria20YVKZaclWybIbjABMRvHf4v6Y/PxP9s839/g0GIug8
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:12 GMT
+      etag:
+      - W/"8a450004767ca5bb4a167c58a556e54f"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:95899E5:B2E66BE:5EDF6837
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4990'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:12 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589B51:B2E6880:5EDF6838
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4989'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHzUdjYLEtsO2iBZIAxRbY7kWgJNpiLIkqSdl1hPz3vkNK
+        lux6E8fhMZfEpslnhsOZ4XCakUxH08n1+Ob68uJqcjIqVSoiGhvdfvp1dZ//kSefbx751z+XSblY
+        3z3+cnn3+Nf47uH3DyNM5oXATCuMjaJinXLLjbD4YVbnedT+WgiMWqXFaS7jU5pr2P9XVFouuQVt
+        xnMjTkZqVQo9mjajXM1lCSF7MBBEml5dja8nk5/Od5Rf3y9u1t8mv9X8a5Wln/Nl/PD35PZTsr59
+        mP+LpRzyuI5qnYOeWVuZKWN+0Px4Npc2q+PaCJ2o0orSniWqYDXrhH1cfrgAZK5bjDMZBnZwlWxJ
+        fjlwhu3fSWaLfEcZr4NbuX/NTOW5WoG5u4sDxbINgM7MwWQ5fxsMgIYpmwmYFtt9IiNJnPmxVLe4
+        YfQPfkk4g2PTIj0W2C6HkuRiTw3TolKOW8cm0bKyUpVHq7sFAVTpOS/lI38TFBADFil6tGJuMSBi
+        CWc+muJXN8yFa7Ims2mRCLnEebyNvIMB2K4ryi73AwvSKUkrIp4WlBRcrng6QfS+Mnb2JKBUbA5/
+        NC2Rvygi9GKTkJ4NbGfcfUG6RxBRX7D/wTgEMGCwykKsgzGJ1TD8beMtQWLgsdIcSTyYkC1ow4Zf
+        yams4EUwWQ4GaKZUOMs7GKDSmFoc5PuHn6pjGtYFW1kXsc+kh4TY4WI8DXvgxsh5KUQwi2+ADesu
+        gVjzMsnCieh4DfOfnNfwebAtEAvIOFdxMCYudOaADTMZ91ejjUJqTRKItyVAi1nQLRBvI8DqgH7j
+        1CfgBo/b2sKFgunf8VjTnkDOy3nN5+EkbIB0WaFUmfPHFyu0w2O2JwJPpamWcR02MfdM2oEvipB/
+        wh1Bj+wFuKrr+ZLuFUYaVHLOTEUhX6p5Dqe3uK0QCyyC4mBXDH1/uXR73TaI17D+fvGXWSsp1Gm0
+        t1mn/1Be+7YK5lodjzU/VNxmlGEhtuJahNpMi2NNjKfu09nZWZMJ7p4lhdABs4inAct1kqG8DqV/
+        0/FQORbcuufPjNRP8RzKFU+DncUGCLh3gVB78LShH1Wo14Mp7mBDeiFzdC1UGe6O6IlDOaWyciaT
+        Q96Kh4f5FrT5aGSZiBOO5w2iwspEIk7wZCcPQJEvwlnR07A99Ij8MzEXCJlgp6SF5zXMdwVSUeVq
+        HTRDDpCUSLRAgyqNuMWjdDKejE/HV6fjmy/n4+nF5XR8/Q1z6go9sO/OOZ/QnKo22QtTkP7bWMEn
+        dKWebwTtvjGp4wQ5xmQ95OceMd3TS/oOIsnh9DtRe5wuy927/XUYbCdThahQp3WPcyMf8Xm8VWMl
+        qi5xOhhccYvHBmqWfqiryzpAxk3kM8loanWNniONVFo9iMSa4VifyQYTV3IhtxZSDbnpFvhHfi+8
+        kFqrttnomwttHkbbsO14ptLwOBf9gKpE2Wo43IZMRGk2ZvANANryYPqWCdyXVMx4ndvIv5WonYqe
+        LBqscEehC5iBel7Ubm07K94g5KrdHikr+s9ouFhRVJH3DqsWgvqzQCGrqFVk/qk5XM9dYN1i/4sb
+        wlaoGtv+RQu6TrfXpAhwtHq8xhGKw5bYNYiHbaH3PnEdv/eJ3/vE731i32mn629Pn7gUdoWG6SCb
+        Dp+3XbZ++g8gZir3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:13 GMT
+      etag:
+      - W/"3063d6084a03fffa98598b32091328de"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589BD2:B2E6916:5EDF6838
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4988'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngmMCLsmMCkJyWdpUZYn88aiN4jiyH1Qp4r/XUccuHbrc5b7z
+        7rmRCCdST5moBWkS9TIhRPJA+mCgdSa3YiP4q2+8OOvPw4tmz5v38dDvu2MvrnLb2ONOXNXb05fZ
+        NmMGL7HLkEUcUk2pHNz8w6G9qLkOnkYYQh4BzDMhwqxzaoaQMNEp29aPRuYOkGYoX//2CuoMGkl9
+        I8nKPKQ5P63kcqFKU0L1yIp1UaiVZKria20YVKZaclWybIbjABMRvHf4v6Y/PxP9s839/g0GIug8
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:13 GMT
+      etag:
+      - W/"8a450004767ca5bb4a167c58a556e54f"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589C67:B2E69D6:5EDF6839
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4987'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnZC3f5AsU2pIU9sEOgbTBKSVI8jhW1rKNJTfNhvx7JdxC+5bA
+        7ouQdDRzZs4cdEWqpihFnJAqpIHH/NKHJHJxjDELqcsSEvPShaRMAsJ8F81R25VwEKUJypYF2XiJ
+        ZrsGZyd+Xm+5my+Ly1pmXi4Lt9huLsUpf8m8r2H+ujqvl5/Oxelbne2ew/xUn/bLL816twnz5V5k
+        r6sPJvk4NCZxrXWvUsehvXg6Cl2P7Il30hmg75QjQVOluwEWjWALDUorx66Hg7yU1GCgHRPkmAgp
+        DPZAa7WWzeH/Ev6hv4d4In2Ek4667gaUXlFLJZjmP3dstvpFZd+AEQQkFVYS1rGPMN1aLQxierXP
+        PezhBSYLnGxdnAZh6rp7dJujqRIN75BaD2CYr3+sE0UQEz+oAp9hn1cVScogCkKOGUQAle8x4JSR
+        8G2na2tQzt3cRhAJStGjley5FVrQZmbd0lP+Ym5nk1ymxp4O0GqF0u9/G/S9yiU0iqH0wiiIAwzY
+        jziE2A0qIHEMPkQe43Za72DfB9jfzL53c95+zNFPGEQlONWia60rpjOYD6KijYI5GoAqC6GxVeLY
+        GmSO7IbqcTDjaMemsbJfmo6aIHu83X4DhLK/l5gEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:13 GMT
+      etag:
+      - W/"facf7565039c3cca3b77f38f5fe367c9"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589CE5:B2E6A6B:5EDF6839
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4986'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=c66f5a42b3d3e9710800b5a1b968cd1e9d946b31
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28iOY9kKjNKYrTiwjnUPc0IhSNbFVipLxlIastLvvnMbWJfu
+        IevG2IPEoZPu/+N/p4fA8BaCaSC55x2v7ngNo42zJjgLOu6bX2dcwzGRQZpVknGZMmDjcSzCjCZR
+        ShMpgUKahCxkmaAhlnLqG4owehZse41PG+87NyWEd2pUK99sxaiyLemhs4604LnztodzrcS5B+cd
+        GfbVqt0PmA48qazxYDBxzH3Rw/pdRek64ZOxiGUMLI3CLAxFwiPBKBJHwCSbUBFHSNb4Vq9+hnoB
+        dAqK0FaQUxVf8SIC6h0RvNkWLEUGHkd+oznS7oy2XB5B9Hx36M3WQX8w/KlNp7jyJ4b4fTeM5Fpp
+        QHsOyngAO1sX+Xy7+BrpYoNxGyXLqw/horzWMi9ccfmU3y/L63tZzjfL8qP6pGYiV5f1rSnyWTpE
+        RT6s+W5R3tjnKjeNvHp/L0r94+WXZFPFC/V8f8ZuzRCVnzuMEAlMZaUyNTIJHEc6wbOVVubOBdOH
+        wIFe/1czjlPxN3jeNFzD/3oh/m//1uPjd7cFl4DgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:14 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589D5B:B2E6AF7:5EDF6839
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4985'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:14 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589DEB:B2E6BAC:5EDF683A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4984'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHzUdjYLEtsO2iBZIAxRbY7kWgJNpiLIkqSdl1hPz3vkNK
+        lux6E8fhMZfEpslnhsOZ4XCakUxH08n1+Ob68uJqcjIqVSoiGhvdfvp1dZ//kSefbx751z+XSblY
+        3z3+cnn3+Nf47uH3DyNM5oXATCuMjaJinXLLjbD4YVbnedT+WgiMWqXFaS7jU5pr2P9XVFouuQVt
+        xnMjTkZqVQo9mjajXM1lCSF7MBBEml5dja8nk5/Od5Rf3y9u1t8mv9X8a5Wln/Nl/PD35PZTsr59
+        mP+LpRzyuI5qnYOeWVuZKWN+0Px4Npc2q+PaCJ2o0orSniWqYDXrhH1cfrgAZK5bjDMZBnZwlWxJ
+        fjlwhu3fSWaLfEcZr4NbuX/NTOW5WoG5u4sDxbINgM7MwWQ5fxsMgIYpmwmYFtt9IiNJnPmxVLe4
+        YfQPfkk4g2PTIj0W2C6HkuRiTw3TolKOW8cm0bKyUpVHq7sFAVTpOS/lI38TFBADFil6tGJuMSBi
+        CWc+muJXN8yFa7Ims2mRCLnEebyNvIMB2K4ryi73AwvSKUkrIp4WlBRcrng6QfS+Mnb2JKBUbA5/
+        NC2Rvygi9GKTkJ4NbGfcfUG6RxBRX7D/wTgEMGCwykKsgzGJ1TD8beMtQWLgsdIcSTyYkC1ow4Zf
+        yams4EUwWQ4GaKZUOMs7GKDSmFoc5PuHn6pjGtYFW1kXsc+kh4TY4WI8DXvgxsh5KUQwi2+ADesu
+        gVjzMsnCieh4DfOfnNfwebAtEAvIOFdxMCYudOaADTMZ91ejjUJqTRKItyVAi1nQLRBvI8DqgH7j
+        1CfgBo/b2sKFgunf8VjTnkDOy3nN5+EkbIB0WaFUmfPHFyu0w2O2JwJPpamWcR02MfdM2oEvipB/
+        wh1Bj+wFuKrr+ZLuFUYaVHLOTEUhX6p5Dqe3uK0QCyyC4mBXDH1/uXR73TaI17D+fvGXWSsp1Gm0
+        t1mn/1Be+7YK5lodjzU/VNxmlGEhtuJahNpMi2NNjKfu09nZWZMJ7p4lhdABs4inAct1kqG8DqV/
+        0/FQORbcuufPjNRP8RzKFU+DncUGCLh3gVB78LShH1Wo14Mp7mBDeiFzdC1UGe6O6IlDOaWyciaT
+        Q96Kh4f5FrT5aGSZiBOO5w2iwspEIk7wZCcPQJEvwlnR07A99Ij8MzEXCJlgp6SF5zXMdwVSUeVq
+        HTRDDpCUSLRAgyqNuMWjdDKejE/HV6fjmy/n4+nF5XR8/Q1z6go9sO/OOZ/QnKo22QtTkP7bWMEn
+        dKWebwTtvjGp4wQ5xmQ95OceMd3TS/oOIsnh9DtRe5wuy927/XUYbCdThahQp3WPcyMf8Xm8VWMl
+        qi5xOhhccYvHBmqWfqiryzpAxk3kM8loanWNniONVFo9iMSa4VifyQYTV3IhtxZSDbnpFvhHfi+8
+        kFqrttnomwttHkbbsO14ptLwOBf9gKpE2Wo43IZMRGk2ZvANANryYPqWCdyXVMx4ndvIv5WonYqe
+        LBqscEehC5iBel7Ubm07K94g5KrdHikr+s9ouFhRVJH3DqsWgvqzQCGrqFVk/qk5XM9dYN1i/4sb
+        wlaoGtv+RQu6TrfXpAhwtHq8xhGKw5bYNYiHbaH3PnEdv/eJ3/vE731i32mn629Pn7gUdoWG6SCb
+        Dp+3XbZ++g8gZir3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:14 GMT
+      etag:
+      - W/"3063d6084a03fffa98598b32091328de"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589E64:B2E6C2B:5EDF683A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4983'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XbW/iOBD+K1U+0837C0irexE9aT9AVandHj2tkO1MwNSJc7YDSxH//cYBdgt3
+        6jWIj/2Cgp15ZubxzPjJxqlICc7AKYk2oJyew2RZcuMMNo6eE9xgSVLEJApomIfQT30v8zwaE5/2
+        k4zlPvTzfpTQ0EfTSuYw5TkajYaT5C7oG/oovNGCrW7vmT8eTta35SgYlxN/cn+3nizGz6PgIR6/
+        3Kxuh7+tJouv89Hjl3i8mC+ehn+I28e7eDx84qOXm89HcZHGzKWyEe5j/13Sq5vvpKwF4ItQEi4w
+        Birpr7Bb/YRJ4U5OjE018ALv2kuuvf697w2ieOD7T872kLll4eLQJWhNZtb5l4obTsQVxkJqwp5x
+        9WpPec8xCvCdA/NpClkSRkUUUi9kRZH08yiNYuZRSAGKMKDACE1izKxRNuO5MbUeuC6p+acZN/OG
+        2sRdBbXUbgkGj1gquBacXhvQRrv2dzot1zYYDcZFI9fGoN13+0beLuh8x4R2OxSdNYHKTJlsKixb
+        r+csQfGCM2K4rCybu/+AdVkQoaHnKCDabjlNpfmswp2eYx+IaRTyXzVC9JyarIUkaGT/bi+X5hkp
+        zk0ppscsvzre9xzszukZtOoTv2eXVte03f25ajybnw0v5Izbg8Pefq4kDcJ+luILdubEWepnSXw8
+        he6Sr3+OBVs8RDhlovHiwU4SssRyV6eJtYva2zdOo0ExWRmsrLaHGneP/8vyc4QYM7VHacfd/3Wg
+        RdPuSdBvn+rJy4UUQq4Q5TTs41b/tyP3hyUGuXvm1exMFLTcuNLMAdnDlLaWCI6DpDNca7XBeYPz
+        h+cWRyP7CvLOSHs7DGtVYUSbdtq1gA3VTPHaToHuAR5ZI5pUM1Lxl3amdEdDa1vH7SDunGFrhdaw
+        xGLsbr4z27i14kvC1pYaBQz4Esk+E/LEHhHNuraX2wMWhaWeG5iSvLSt2o7c08v1o407V8FHG5/T
+        eB9tfBCB/3EznNPGNVF2CjmDvw4qNQwKPyFpBnkQp1EWeeCFKYPY86MCkiyDENKAMqvMLyQUD1Ki
+        g+e379oOCurdPrffcOhNBa+ekSzkCkRxCYVOFanYHAX6j+81m9or5I7C0Kr9AxYGXCtpgJlXWnm/
+        spfSUBEqjpT03w231zZew6bRUwyN7RKGqpCKQSvNBd4zNkZZFFgFraz63tbQN6urf3p4eyi+/zPm
+        hCS8+tqsbA7bfwDzLMHF8Q4AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:14 GMT
+      etag:
+      - W/"f8336b2f40662119e26dce6e82d9fe71"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589EDB:B2E6CC1:5EDF683A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4982'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589F38:B2E6D32:5EDF683A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4981'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnZC3f5AsU2pIU9sEOgbTBKSVI8jhW1rKNJTfNhvx7JdxC+5bA
+        7ouQdDRzZs4cdEWqpihFnJAqpIHH/NKHJHJxjDELqcsSEvPShaRMAsJ8F81R25VwEKUJypYF2XiJ
+        ZrsGZyd+Xm+5my+Ly1pmXi4Lt9huLsUpf8m8r2H+ujqvl5/Oxelbne2ew/xUn/bLL816twnz5V5k
+        r6sPJvk4NCZxrXWvUsehvXg6Cl2P7Il30hmg75QjQVOluwEWjWALDUorx66Hg7yU1GCgHRPkmAgp
+        DPZAa7WWzeH/Ev6hv4d4In2Ek4667gaUXlFLJZjmP3dstvpFZd+AEQQkFVYS1rGPMN1aLQxierXP
+        PezhBSYLnGxdnAZh6rp7dJujqRIN75BaD2CYr3+sE0UQEz+oAp9hn1cVScogCkKOGUQAle8x4JSR
+        8G2na2tQzt3cRhAJStGjley5FVrQZmbd0lP+Ym5nk1ymxp4O0GqF0u9/G/S9yiU0iqH0wiiIAwzY
+        jziE2A0qIHEMPkQe43Za72DfB9jfzL53c95+zNFPGEQlONWia60rpjOYD6KijYI5GoAqC6GxVeLY
+        GmSO7IbqcTDjaMemsbJfmo6aIHu83X4DhLK/l5gEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      etag:
+      - W/"facf7565039c3cca3b77f38f5fe367c9"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:9589FD6:B2E6DF8:5EDF683B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4980'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["c66f5a42b3d3e9710800b5a1b968cd1e9d946b31"],
+      "message": "Set type to csv", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312",
+      "author": {"name": "Bilbo Baggins", "email": "bilbo@shire.net"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '204'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"e3bc428e956e6be46730cb33b6237cf7199cf2d8","node_id":"MDY6Q29tbWl0MjcwOTc1NDYyOmUzYmM0MjhlOTU2ZTZiZTQ2NzMwY2IzM2I2MjM3Y2Y3MTk5Y2YyZDg=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e3bc428e956e6be46730cb33b6237cf7199cf2d8","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/e3bc428e956e6be46730cb33b6237cf7199cf2d8","author":{"name":"Bilbo
+        Baggins","email":"bilbo@shire.net","date":"2020-06-09T10:45:15Z"},"committer":{"name":"Bilbo
+        Baggins","email":"bilbo@shire.net","date":"2020-06-09T10:45:15Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Set
+        type to csv","parents":[{"sha":"c66f5a42b3d3e9710800b5a1b968cd1e9d946b31","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/c66f5a42b3d3e9710800b5a1b968cd1e9d946b31"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1169'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      etag:
+      - '"8f52ac145d3288ed51abb693ae87f92c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e3bc428e956e6be46730cb33b6237cf7199cf2d8
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A037:B2E6E62:5EDF683B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4979'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngmMCLsmMCkJyWdpUZYn88aiN4jiyH1Qp4r/XUccuHbrc5b7z
+        7rmRCCdST5moBWkS9TIhRPJA+mCgdSa3YiP4q2+8OOvPw4tmz5v38dDvu2MvrnLb2ONOXNXb05fZ
+        NmMGL7HLkEUcUk2pHNz8w6G9qLkOnkYYQh4BzDMhwqxzaoaQMNEp29aPRuYOkGYoX//2CuoMGkl9
+        I8nKPKQ5P63kcqFKU0L1yIp1UaiVZKria20YVKZaclWybIbjABMRvHf4v6Y/PxP9s839/g0GIug8
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:16 GMT
+      etag:
+      - W/"8a450004767ca5bb4a167c58a556e54f"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A0FB:B2E6F56:5EDF683B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4978'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "e3bc428e956e6be46730cb33b6237cf7199cf2d8"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngktME5IZQYVkWNpUZYn88VIbxXEUP6hSxH/vQx27dOhyl/vO
+        u+fKRmhZdc/EHSibeFAJYWQPrI8WGm+plWuZv4Y6yJP5PLyYxX79Ph36XXfs5UVta3d8lhf9tvmy
+        23oi8Dx2BDnEIVWcq8HPPzy6s56bGPgIQ6QRQJqJI8w6r2cICRO/Z9OEySrqADlBdP3bK+oTGGTV
+        lSWnaAiENstsBeVTDrmGZV6IR6OF0HkmCtMWi7I0bWZXZIbTAESQR/D4v6Y/PxP/s83t9g2h6GBQ
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:17 GMT
+      etag:
+      - W/"5e48af31ecb7b989cc3aae951e9b76ef"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A168:B2E6FD0:5EDF683C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4977'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:17 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A2DA:B2E7189:5EDF683D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4976'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHzUdjYLEtsO2iBZIFii2w3YtASbTFWBJVkrLrCPnvfYeU
+        LNl1EsfhMZfEpslnhsOZ4XCakUxH08n1+Ob68uJqcjIqVSoiGhvdfvp19SX/I08+3zzwb38uk3Kx
+        vnv45fLu4a/x3f3vH0aYzAuBmVYYG0XFOuWWG2Hxw6zO86j9tRAYtUqL01zGpzTXsP+vqLRccgva
+        jOdGnIzUqhR6NG1GuZrLEkL2YCCINL26Gl9PJj+d7yi//rK4WX+f/Fbzb1WWfs6X8f3fk9tPyfr2
+        fv4vlnLI4zqqdQ56Zm1lpoz5QfPj2VzarI5rI3SiSitKe5aogtWsE/Zx+eECkLluMc5kGNjBVbIl
+        +eXAGbZ/J5kt8h1lvA5u5f41M5XnagXm7i4OFMs2ADozB5Pl/G0wABqmbCZgWmz3kYwkcebHUt3i
+        htE/+CXhDI5Ni/RYYLscSpKLPTZMi0o5bh2bRMvKSlUere4WBFCl57yUD/xNUEAMWKTo0Yq5xYCI
+        JZz5aIpf3TAXrsmazKZFIuQS5/E28g4GYLuuKLt8GViQTklaEfG0oKTgcsXjCaL3lbGzJwGlYnP4
+        o2mJ/EURoRebhPRsYDvj7gvSPYKI+oL9D8YhgAGDVRZiHYxJrIbhbxtvCRIDj5XmSOLBhGxBGzb8
+        Sk5lBS+CyXIwQDOlwlnewQCVxtTiIN8//FQd07Au2Mq6iH0mPSTEDhfjadgDN0bOSyGCWXwDbFh3
+        CcSal0kWTkTHa5j/5LyGz4NtgVhAxrmKgzFxoTMHbJjJuL8abRRSa5JAvC0BWsyCboF4GwFWB/Qb
+        pz4BN3jc1hYuFEz/jsea9gRyXs5rPg8nYQOkywqlypw/vFihHR6zPRF4Kk21jOuwibln0g58UYT8
+        E+4IemQvwFVdz5d0rzDSoJJzZioK+VLNczi9xW2FWGARFAe7Yuj7y6Xb67ZBvIb194u/zFpJoU6j
+        vc06/Yfy2rdVMNfqeKz5oeI2owwLsRXXItRmWhxrYjx1H8/OzppMcPcsKYQOmEU8DViukwzldSj9
+        m46HyrHg1j1/ZqR+iudQrnga7Cw2QMC9C4Tag6cN/ahCvR5McQcb0guZo2uhynB3RE8cyimVlTOZ
+        HPJWPDzMt6DNRyPLRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4m5QMgEOyUtPK9hviuQiipX
+        66AZcoCkRKIFGlRpxC0epZPxZHw6vjod33w9H08vLqfj6++YU1fogT055/yC5lS1yZ6eckVTkP7b
+        WMEndKWebwTtvjGp4wSIMVkP+blHTPf0kp5AJDmcfidqj9NluXu3vw6D7WSqEBXqtO5xbuQDPo+3
+        aqxE1SVOB4MrbvHYQM3SD3V1WQfIuIl8JhlNra7Rc6SRSqt7kVgzHOsz2WDiSi7k1kKqITfdAv/I
+        74UXUmvVNht9c6HNw2gbth3PVBoe56IfUJUoWw2H25CJKM3GDL4BQFseTN8ygfuSihmvcxv5txK1
+        U9GTRYMV7ih0ATNQz4varW1nxRuEXLXbI2VF/xkNFyuKKvLeYdVCUH8WKGQVtYrMPzWH67kLrFvs
+        f3FD2ApVY9u/aEHX6faaFAGOVo/XOEJx2BK7BvGwLfTeJ67j9z7xe5/4vU/sO+10/e3pE5fCrtAw
+        HWTT4fO2y9aP/wHdnbORFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:17 GMT
+      etag:
+      - W/"0b4b0a5f66866bb54bc7eab13ed06e87"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A355:B2E722C:5EDF683D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4975'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngktME5IZQYVkWNpUZYn88VIbxXEUP6hSxH/vQx27dOhyl/vO
+        u+fKRmhZdc/EHSibeFAJYWQPrI8WGm+plWuZv4Y6yJP5PLyYxX79Ph36XXfs5UVta3d8lhf9tvmy
+        23oi8Dx2BDnEIVWcq8HPPzy6s56bGPgIQ6QRQJqJI8w6r2cICRO/Z9OEySrqADlBdP3bK+oTGGTV
+        lSWnaAiENstsBeVTDrmGZV6IR6OF0HkmCtMWi7I0bWZXZIbTAESQR/D4v6Y/PxP/s83t9g2h6GBQ
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:17 GMT
+      etag:
+      - W/"5e48af31ecb7b989cc3aae951e9b76ef"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A3C7:B2E72AE:5EDF683D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4974'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e3bc428e956e6be46730cb33b6237cf7199cf2d8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTWvjMBT8K0HnJNZHJMeGhaXk0oMbyroszlKCJL/Y6vojWHJLEvLfVyJb2L0l
+        kF5kScN782Y0+IRsLVGKgCm9oEtIuAChYCFihrViTAnKYr2LSZLoHS2XaIq6voStKX1RtirEM02c
+        +tng7E1/rHNNnlbFYd2+HIs283d1s85f6CbfmE3+TJ+O2UdBH48ZfaTZW8YKWrAs/83997BZVd98
+        83FofOPaub1No0juzbwyrh7VXPdtNMC+t1ELTlrXDzBrjJo5sM5GYd1u20MpPQYu8kWRr2iNx26Q
+        Vru22f4/wj/01xBfSG/hlKOr+wGlJ9TJFrz4B9OofvIgq8p01lsCrTTBFBXuv9vaDDDvwHnEqw0F
+        FFM8w2KGk5zgdMFTwjfoPEWXWRx8SXM3gOc+/Y0PkURLXSqdlDHnIo5JySjmwMEnasljyoTCjND7
+        vnCYwUZXc3tLWrBWVsG0H+Am7rCHiesn2r77wfZygM5ZlP76VKWF2HG5oIqVDJKY4CXGikuiErHU
+        JYGkTBZCMXJfVZ+5vYH9brm9mvP8OkXvMJid0dKZvgtRuJzB/xl2srEwRQNIGyA0dtZUnUemKGyk
+        Gwf/Bt3YNMH2Q9NLXxSO5/MfC82S/ZEEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:18 GMT
+      etag:
+      - W/"8f52ac145d3288ed51abb693ae87f92c"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A42F:B2E7326:5EDF683D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4973'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=e3bc428e956e6be46730cb33b6237cf7199cf2d8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T32vbMBDH/xc/t5Fsx7IdGKMJW0lgGese5oRA0I9zrFSWjKU0pKX/e+XGjDbd
+        Q9aNsRdJ3OnuPtx97yHQtIZgFAjqaEP5Ld3AYGuNDi6Chrrq1x5bUe9gjOBS4CyLEhzhPKZpguOU
+        iJQQkREaizRLI15in8rKe18kDIcXwa5VPrZyrrEjhGgjBxvpqh0bcFOjFhpjUQ2OWmdauFSSXTqw
+        zqLuXK/rQ8dpwSFutAPtHafgH1soP0DM+DDKIE8IEAZDksaYszhmJIpTXqZhnvMyEplHq1yt1q+h
+        XgCdg8KUYejcim94PYKvd0Lw7rb4VKjjseg3piPMXitDxQlES/f9bHYW2r7hz2M6pyt/0hB3aDpN
+        llKBb09f2RtgbzbTyQxDMVbTrX/X83shp3Z69WzfLX6EvT1Mltef8aKYKzE5+lfa/zgsi/mdKGbb
+        ZfFFfpVjNpFXPnKcHu/uPdsvihtzzH5TietPd6xQh5X+Gfk92fJ4IfvIvLuLb02+6lYGNDdC6k23
+        HV6mZOhtayX1rQ1GD4EFVf5X2vdq+Rs87xJdt3cviv/bnXt8fAK3hRY9+QQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:18 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A48F:B2E73A4:5EDF683E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4972'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:18 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A4FF:B2E742F:5EDF683E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4971'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHzUdjYLEtsO2iBZIFii2w3YtASbTFWBJVkrLrCPnvfYeU
+        LNl1EsfhMZfEpslnhsOZ4XCakUxH08n1+Ob68uJqcjIqVSoiGhvdfvp19SX/I08+3zzwb38uk3Kx
+        vnv45fLu4a/x3f3vH0aYzAuBmVYYG0XFOuWWG2Hxw6zO86j9tRAYtUqL01zGpzTXsP+vqLRccgva
+        jOdGnIzUqhR6NG1GuZrLEkL2YCCINL26Gl9PJj+d7yi//rK4WX+f/Fbzb1WWfs6X8f3fk9tPyfr2
+        fv4vlnLI4zqqdQ56Zm1lpoz5QfPj2VzarI5rI3SiSitKe5aogtWsE/Zx+eECkLluMc5kGNjBVbIl
+        +eXAGbZ/J5kt8h1lvA5u5f41M5XnagXm7i4OFMs2ADozB5Pl/G0wABqmbCZgWmz3kYwkcebHUt3i
+        htE/+CXhDI5Ni/RYYLscSpKLPTZMi0o5bh2bRMvKSlUere4WBFCl57yUD/xNUEAMWKTo0Yq5xYCI
+        JZz5aIpf3TAXrsmazKZFIuQS5/E28g4GYLuuKLt8GViQTklaEfG0oKTgcsXjCaL3lbGzJwGlYnP4
+        o2mJ/EURoRebhPRsYDvj7gvSPYKI+oL9D8YhgAGDVRZiHYxJrIbhbxtvCRIDj5XmSOLBhGxBGzb8
+        Sk5lBS+CyXIwQDOlwlnewQCVxtTiIN8//FQd07Au2Mq6iH0mPSTEDhfjadgDN0bOSyGCWXwDbFh3
+        CcSal0kWTkTHa5j/5LyGz4NtgVhAxrmKgzFxoTMHbJjJuL8abRRSa5JAvC0BWsyCboF4GwFWB/Qb
+        pz4BN3jc1hYuFEz/jsea9gRyXs5rPg8nYQOkywqlypw/vFihHR6zPRF4Kk21jOuwibln0g58UYT8
+        E+4IemQvwFVdz5d0rzDSoJJzZioK+VLNczi9xW2FWGARFAe7Yuj7y6Xb67ZBvIb194u/zFpJoU6j
+        vc06/Yfy2rdVMNfqeKz5oeI2owwLsRXXItRmWhxrYjx1H8/OzppMcPcsKYQOmEU8DViukwzldSj9
+        m46HyrHg1j1/ZqR+iudQrnga7Cw2QMC9C4Tag6cN/ahCvR5McQcb0guZo2uhynB3RE8cyimVlTOZ
+        HPJWPDzMt6DNRyPLRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4m5QMgEOyUtPK9hviuQiipX
+        66AZcoCkRKIFGlRpxC0epZPxZHw6vjod33w9H08vLqfj6++YU1fogT055/yC5lS1yZ6eckVTkP7b
+        WMEndKWebwTtvjGp4wSIMVkP+blHTPf0kp5AJDmcfidqj9NluXu3vw6D7WSqEBXqtO5xbuQDPo+3
+        aqxE1SVOB4MrbvHYQM3SD3V1WQfIuIl8JhlNra7Rc6SRSqt7kVgzHOsz2WDiSi7k1kKqITfdAv/I
+        74UXUmvVNht9c6HNw2gbth3PVBoe56IfUJUoWw2H25CJKM3GDL4BQFseTN8ygfuSihmvcxv5txK1
+        U9GTRYMV7ih0ATNQz4varW1nxRuEXLXbI2VF/xkNFyuKKvLeYdVCUH8WKGQVtYrMPzWH67kLrFvs
+        f3FD2ApVY9u/aEHX6faaFAGOVo/XOEJx2BK7BvGwLfTeJ67j9z7xe5/4vU/sO+10/e3pE5fCrtAw
+        HWTT4fO2y9aP/wHdnbORFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      etag:
+      - W/"0b4b0a5f66866bb54bc7eab13ed06e87"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A572:B2E74BD:5EDF683E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4970'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VVTW/iMBD9K8hnaBKHJARppVXVSw9pVS3VClZVZDsT4tZxWNtpl6747zvmY5f2
+        VCr2AsTDeOa9eW/ym2jWApmSllkHhgyJ6NpWOjL9TWzDMAAxF2M6gTxJIeUwTrM4FDyOeUrjTNRZ
+        lOeiptUEU3VXQSkrTCqu5ukdzR3/rsLiUbzczkR0czVf37b3r/O2wLNG3c7u6WK2kIvZHb15LV7m
+        9Pq1oNe0eCziOZ3Hxewpwe/14mr55U1frHdNZ3yH+94vpeLd4JItl1Jb/Cu0TCrsgvvzr7aRBi40
+        OIxUzHmwNKThKExHYT6Lwuk4mUbJgmwO2D0P/+HyFqxlS1/+G7iBW69g4LqBsM/YlzOAgQPlEYsE
+        ExUXeZUlSZplURXTMIEEcAqTJKNxysM4opjYGw+0cW5lp0HAVvJiKV3T8wscY2Bg1dmgBYez7QyM
+        lOQjB9bZwH+WZbtGPpgFF2BS4HuwwYdrI11nLL5TnQ1OUJtPAe1K0fUa9RoOyTMYWUvBnOy0Z3P3
+        DCjImikLQ2KAWR8ivbZyqTEyJP4Hc71B/nWv1JCs2Fp1DJP84+Z8MD8BsXGtKt+yfDTejwx2V/QT
+        tNp3dT8trVNhB/u5eiMfnL4bzO6mrTsPkzIoAEumPw7OEWlaJ2xMeVzFkGdROAlDnrCI5+lEVBHk
+        VT5OeRydzzkHeCdUPttUP1xz84AyLpXUT0gWcgWqPsfW4IZp0eDS+Pvy8NCObj5RrH4DHe7Chlem
+        cyDckX/3J3t7g2ZcvXH3zx5XfVVah4a2JbYmdoBB150RsF0XCp7B99jV9fatoh382mrowXv9X4Vz
+        6f8dScERhs0f9bqmQX4HAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      etag:
+      - W/"3b905fa7e5c867ccdc9611bd45f6203f"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A604:B2E755A:5EDF683F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4969'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"xls\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"611492251181a958ff3fb89b5c857f754f7c66c1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"0db3e0dc648ef5a75823501ad0bbebe7de1b0875","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/0db3e0dc648ef5a75823501ad0bbebe7de1b0875"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      etag:
+      - '"da07e5abb3046fbdcd5e221c600f2fa6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A668:B2E75E2:5EDF683F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4968'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e3bc428e956e6be46730cb33b6237cf7199cf2d8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTWvjMBT8K0HnJNZHJMeGhaXk0oMbyroszlKCJL/Y6vojWHJLEvLfVyJb2L0l
+        kF5kScN782Y0+IRsLVGKgCm9oEtIuAChYCFihrViTAnKYr2LSZLoHS2XaIq6voStKX1RtirEM02c
+        +tng7E1/rHNNnlbFYd2+HIs283d1s85f6CbfmE3+TJ+O2UdBH48ZfaTZW8YKWrAs/83997BZVd98
+        83FofOPaub1No0juzbwyrh7VXPdtNMC+t1ELTlrXDzBrjJo5sM5GYd1u20MpPQYu8kWRr2iNx26Q
+        Vru22f4/wj/01xBfSG/hlKOr+wGlJ9TJFrz4B9OofvIgq8p01lsCrTTBFBXuv9vaDDDvwHnEqw0F
+        FFM8w2KGk5zgdMFTwjfoPEWXWRx8SXM3gOc+/Y0PkURLXSqdlDHnIo5JySjmwMEnasljyoTCjND7
+        vnCYwUZXc3tLWrBWVsG0H+Am7rCHiesn2r77wfZygM5ZlP76VKWF2HG5oIqVDJKY4CXGikuiErHU
+        JYGkTBZCMXJfVZ+5vYH9brm9mvP8OkXvMJid0dKZvgtRuJzB/xl2srEwRQNIGyA0dtZUnUemKGyk
+        Gwf/Bt3YNMH2Q9NLXxSO5/MfC82S/ZEEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      etag:
+      - W/"8f52ac145d3288ed51abb693ae87f92c"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A714:B2E76B4:5EDF683F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4967'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["e3bc428e956e6be46730cb33b6237cf7199cf2d8"],
+      "message": "Set type to xls", "tree": "611492251181a958ff3fb89b5c857f754f7c66c1",
+      "author": {"name": "Bob Example", "email": "bob@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '202'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"fd5b056a3b750ac162104776d0ec1e9d6ed2d455","node_id":"MDY6Q29tbWl0MjcwOTc1NDYyOmZkNWIwNTZhM2I3NTBhYzE2MjEwNDc3NmQwZWMxZTlkNmVkMmQ0NTU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fd5b056a3b750ac162104776d0ec1e9d6ed2d455","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fd5b056a3b750ac162104776d0ec1e9d6ed2d455","author":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:45:20Z"},"committer":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:45:20Z"},"tree":{"sha":"611492251181a958ff3fb89b5c857f754f7c66c1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1"},"message":"Set
+        type to xls","parents":[{"sha":"e3bc428e956e6be46730cb33b6237cf7199cf2d8","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e3bc428e956e6be46730cb33b6237cf7199cf2d8","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/e3bc428e956e6be46730cb33b6237cf7199cf2d8"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1165'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:20 GMT
+      etag:
+      - '"cd6425dd8622efa7ad0e0b938ff763f4"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fd5b056a3b750ac162104776d0ec1e9d6ed2d455
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A76D:B2E7723:5EDF683F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4966'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngktME5IZQYVkWNpUZYn88VIbxXEUP6hSxH/vQx27dOhyl/vO
+        u+fKRmhZdc/EHSibeFAJYWQPrI8WGm+plWuZv4Y6yJP5PLyYxX79Ph36XXfs5UVta3d8lhf9tvmy
+        23oi8Dx2BDnEIVWcq8HPPzy6s56bGPgIQ6QRQJqJI8w6r2cICRO/Z9OEySrqADlBdP3bK+oTGGTV
+        lSWnaAiENstsBeVTDrmGZV6IR6OF0HkmCtMWi7I0bWZXZIbTAESQR/D4v6Y/PxP/s83t9g2h6GBQ
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:20 GMT
+      etag:
+      - W/"5e48af31ecb7b989cc3aae951e9b76ef"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A841:B2E7830:5EDF6840
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4965'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "fd5b056a3b750ac162104776d0ec1e9d6ed2d455"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghPAjpoZQYXksrSpyhL541EbxUlkP6hSxH/vQx27dOhyl/vO
+        u+fKEhxZfc/MPWiXedQZIbEH1g8O2uCoVWslX2MT1cl+7l9s+bx+n/b9rjv06qK3jT88qYt523y5
+        bTMReE4dQR5xzDXnegzzj4D+bOZ2iDzBONAIIM0MCWZdMDOEjJnfs23j5DR1gJwguv7tNZgTWGT1
+        lWWvaejohCmE1EtTiULbUi7KYlVV0hVgS3h0EtzCrYQgM5xGIII8YsD/Nf35mfmfbW63b8yEn9J9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:21 GMT
+      etag:
+      - W/"595618257cc15c9c8d8b2e1fbe22c695"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A8AB:B2E78AC:5EDF6840
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4964'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:22 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958A9D6:B2E7A12:5EDF6841
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4963'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHzUdjYLEtsO2iBZIFii2w3YtASbTFWBJVkrLrCPnvfYeU
+        LNl1EsfhMZfEpslnhsOZ4XCakUxH08n1+Ob68uJqcjIqVSoiGhvdfvp19SX/I08+3zzwb38uk3Kx
+        vnv45fLu4a/x3f3vH0aYzAuBmVYYG0XFOuWWG2Hxw6zO86j9tRAYtUqL01zGpzTXsP+vqLRccgva
+        jOdGnIzUqhR6NG1GuZrLEkL2YCCINL26Gl9PJj+d7yi//rK4WX+f/Fbzb1WWfs6X8f3fk9tPyfr2
+        fv4vlnLI4zqqdQ56Zm1lpoz5QfPj2VzarI5rI3SiSitKe5aogtWsE/Zx+eECkLluMc5kGNjBVbIl
+        +eXAGbZ/J5kt8h1lvA5u5f41M5XnagXm7i4OFMs2ADozB5Pl/G0wABqmbCZgWmz3kYwkcebHUt3i
+        htE/+CXhDI5Ni/RYYLscSpKLPTZMi0o5bh2bRMvKSlUere4WBFCl57yUD/xNUEAMWKTo0Yq5xYCI
+        JZz5aIpf3TAXrsmazKZFIuQS5/E28g4GYLuuKLt8GViQTklaEfG0oKTgcsXjCaL3lbGzJwGlYnP4
+        o2mJ/EURoRebhPRsYDvj7gvSPYKI+oL9D8YhgAGDVRZiHYxJrIbhbxtvCRIDj5XmSOLBhGxBGzb8
+        Sk5lBS+CyXIwQDOlwlnewQCVxtTiIN8//FQd07Au2Mq6iH0mPSTEDhfjadgDN0bOSyGCWXwDbFh3
+        CcSal0kWTkTHa5j/5LyGz4NtgVhAxrmKgzFxoTMHbJjJuL8abRRSa5JAvC0BWsyCboF4GwFWB/Qb
+        pz4BN3jc1hYuFEz/jsea9gRyXs5rPg8nYQOkywqlypw/vFihHR6zPRF4Kk21jOuwibln0g58UYT8
+        E+4IemQvwFVdz5d0rzDSoJJzZioK+VLNczi9xW2FWGARFAe7Yuj7y6Xb67ZBvIb194u/zFpJoU6j
+        vc06/Yfy2rdVMNfqeKz5oeI2owwLsRXXItRmWhxrYjx1H8/OzppMcPcsKYQOmEU8DViukwzldSj9
+        m46HyrHg1j1/ZqR+iudQrnga7Cw2QMC9C4Tag6cN/ahCvR5McQcb0guZo2uhynB3RE8cyimVlTOZ
+        HPJWPDzMt6DNRyPLRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4m5QMgEOyUtPK9hviuQiipX
+        66AZcoCkRKIFGlRpxC0epZPxZHw6vjod33w9H08vLqfj6++YU1fogT055/yG5lS1yZ6cMjmnKUj/
+        bazgE7pSzzeCdt+Y1HECxJish/zcI6Z7eklPIJIcTr8Ttcfpsty921+HwXYyVYgKdVr3ODfyAZ/H
+        WzVWouoSp4PBFbd4bKBm6Ye6uqwDZNxEPpOMplbX6DnSSKXVvUisGY71mWwwcSUXcmsh1ZCbboF/
+        5PfCC6m1apuNvrnQ5mG0DduOZyoNj3PRD6hKlK2Gw23IRJRmYwbfAKAtD6ZvmcB9ScWM17mN/FuJ
+        2qnoyaLBCncUuoAZqOdF7da2s+INQq7a7ZGyov+MhosVRRV577BqIag/CxSyilpF5p+aw/XcBdYt
+        9r+4IWyFqrHtX7Sg63R7TYoAR6vHaxyhOGyJXYN42BZ67xPX8Xuf+L1P/N4n9p12uv729IlLYVdo
+        mA6y6fB522Xrx/8AzVI60hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:22 GMT
+      etag:
+      - W/"b8f2e09aee8d5eebf745aa0cb36d4a46"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958AAA5:B2E7B1B:5EDF6842
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4962'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits?path=datapackage.json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZbW/aSBD+K8ifSe1de/0SqbpeRU7KBztCB8lBVUW76zUY/ILsBQIo/72zJlwa
+        miY2555UiS+JsT0zO7Mzz84z/rLTyinVLrUoJMwgNjWZQwzKkY2RYTmOHRqCI+GFtghxaBGidbUs
+        D8V9HIKQ3xvZfexJdpcY/oyvbwYcBb3R5iYdz4O763UwGE99fG0Gg8/T0fYK+7OrddDjZpD21+M7
+        /2E8SOZBejv3074RDIYfQTnP0zSW2uVOo0s5zQt1ldFUgLXPOetcPdB0kQh4UaQ0TuAuy9knsb/7
+        AYThSUileh0b2Lgw7AvDGyDj0iKX2BhrjwcLUvwC1akoSzpRxv8WsiM3C9GReechKWFVshDw4BBu
+        GyHLw5gg5CLqETeKzIi5HiPcJU7kECtyuG1zBILLQrk5lXJRXuo6XcQfJrGcLpnyVi/EIi/1VEha
+        yrwQF0nMLqQoZamrv/f36QaiQUshdRDS1RpKvbZtCFaLxvc7W+oNMk2JiEze83yZQU4YXW0lijiK
+        OZVxnqlo7n8LSMaIJqXoaoWgpXqkLbMynmTwpKupCyqXBcQ/WyZJV1vQTZJTEFI/H9tz8wQXpzJN
+        7l9G+bvtrbOxe6MnhLU8sntyajV1W3/aV1UWz1We5JNYbRwU9DzLGTY914EXFNAQ10GuTV5CT9++
+        /SdI+GxoBdsrK5hV8EFXkO7FsWPVzdJ4KpxlKQqeZxIyq6qhpf6k/4/VRwt0TIonLRXGvVeBSlup
+        Hy367V09ejnKkyRfg5bjZb8s9R8N6f9KwiL313E2OVELSO70XE4FRA9celSBiAFIGqurpHaAN4A/
+        caj0lBD9QoSNNT3JwbLWGaxoV6FdpXDJSl7EC4UCzRf4Qhq05cWEZvG2wpTm2kBa5XEFxI09rKRA
+        WqwgGZuL78V2+qKIV5RvVGgKwUW8gmCfqPJIHjSqYwzqYAhJoUIfS3FPw1SVagW5xyfquYwbZ8G5
+        jE8pvHMZH5rAV06GU8p4QQuFQtrll0OXKkzGLewKj9jCZsKyHdPgzDSZjU2HRw7yPB7h0AVcaKlR
+        PLQSDSy/fdY26KBq23z8+tg9IUR1eNNwO0p94FLT5GYwxOPBOB4P+jjY+usRvt4ClwIO5ZsjPDL9
+        wZzA/824N3mPN8UJyzuf6QT6q+qwOTAndf9TOY0L8SETEp78jDkh8nPm1Jby17kTL1fqCHrBnRBF
+        nPKQcS90CLEdB4UmNoggAhIV6BM2bWaYCLeXlc/cqbbt9kiFMn5CWfyu3Kl2FXaBE7fEnRrYPFCX
+        tw/5+rS86c6+xp32pHavqZprHFjuMZ7DSCEi1MLMDE3hOchwDYMRiphnuzxUYx7PspnZ4tTh4F4D
+        y63tam2b3+N5baF6czAfB+kIjQb9zWgWzH08JEBW1ze9P9ej2e3Uv7smwWw6G/f+Sm7u+iTojWN/
+        e/Uenv/HORhCP0fzdlQ/Y/l1FsuYJh01hVpQPofpWGefEz/AuuMI1zatyDIBvXkU2V5oORbhBhOO
+        EJGJmeCU2WoC2VKz8QzrtW3/GlhvkHS/K6w3cPH/B4D9UPh9Ct4c1uu6/Rqs77Qzl377mH2F+Jy5
+        9JlLq/HjeSR2nmw/zcfPk+3zZNt14OPBi8m46j/fnWz/OBIzcYRs6rjwOZw4lmsZwoBRmCAGsiJh
+        u64whYMZV1+oW+pSDxSqgeXWOqjaNoFCff0GVJ8fOEwgAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:22 GMT
+      etag:
+      - W/"81caf362c40b0fe2c4fe0b288148471e"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958AB2B:B2E7BBF:5EDF6842
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4961'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:23 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958AB94:B2E7C48:5EDF6842
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4960'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHzUdjYLEtsO2iBZIFii2w3YtASbTFWBJVkrLrCPnvfYeU
+        LNl1EsfhMZfEpslnhsOZ4XCakUxH08n1+Ob68uJqcjIqVSoiGhvdfvp19SX/I08+3zzwb38uk3Kx
+        vnv45fLu4a/x3f3vH0aYzAuBmVYYG0XFOuWWG2Hxw6zO86j9tRAYtUqL01zGpzTXsP+vqLRccgva
+        jOdGnIzUqhR6NG1GuZrLEkL2YCCINL26Gl9PJj+d7yi//rK4WX+f/Fbzb1WWfs6X8f3fk9tPyfr2
+        fv4vlnLI4zqqdQ56Zm1lpoz5QfPj2VzarI5rI3SiSitKe5aogtWsE/Zx+eECkLluMc5kGNjBVbIl
+        +eXAGbZ/J5kt8h1lvA5u5f41M5XnagXm7i4OFMs2ADozB5Pl/G0wABqmbCZgWmz3kYwkcebHUt3i
+        htE/+CXhDI5Ni/RYYLscSpKLPTZMi0o5bh2bRMvKSlUere4WBFCl57yUD/xNUEAMWKTo0Yq5xYCI
+        JZz5aIpf3TAXrsmazKZFIuQS5/E28g4GYLuuKLt8GViQTklaEfG0oKTgcsXjCaL3lbGzJwGlYnP4
+        o2mJ/EURoRebhPRsYDvj7gvSPYKI+oL9D8YhgAGDVRZiHYxJrIbhbxtvCRIDj5XmSOLBhGxBGzb8
+        Sk5lBS+CyXIwQDOlwlnewQCVxtTiIN8//FQd07Au2Mq6iH0mPSTEDhfjadgDN0bOSyGCWXwDbFh3
+        CcSal0kWTkTHa5j/5LyGz4NtgVhAxrmKgzFxoTMHbJjJuL8abRRSa5JAvC0BWsyCboF4GwFWB/Qb
+        pz4BN3jc1hYuFEz/jsea9gRyXs5rPg8nYQOkywqlypw/vFihHR6zPRF4Kk21jOuwibln0g58UYT8
+        E+4IemQvwFVdz5d0rzDSoJJzZioK+VLNczi9xW2FWGARFAe7Yuj7y6Xb67ZBvIb194u/zFpJoU6j
+        vc06/Yfy2rdVMNfqeKz5oeI2owwLsRXXItRmWhxrYjx1H8/OzppMcPcsKYQOmEU8DViukwzldSj9
+        m46HyrHg1j1/ZqR+iudQrnga7Cw2QMC9C4Tag6cN/ahCvR5McQcb0guZo2uhynB3RE8cyimVlTOZ
+        HPJWPDzMt6DNRyPLRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4m5QMgEOyUtPK9hviuQiipX
+        66AZcoCkRKIFGlRpxC0epZPxZHw6vjod33w9H08vLqfj6++YU1fogT055/yG5lS1yZ6cMjmnKUj/
+        bazgE7pSzzeCdt+Y1HECxJish/zcI6Z7eklPIJIcTr8Ttcfpsty921+HwXYyVYgKdVr3ODfyAZ/H
+        WzVWouoSp4PBFbd4bKBm6Ye6uqwDZNxEPpOMplbX6DnSSKXVvUisGY71mWwwcSUXcmsh1ZCbboF/
+        5PfCC6m1apuNvrnQ5mG0DduOZyoNj3PRD6hKlK2Gw23IRJRmYwbfAKAtD6ZvmcB9ScWM17mN/FuJ
+        2qnoyaLBCncUuoAZqOdF7da2s+INQq7a7ZGyov+MhosVRRV577BqIag/CxSyilpF5p+aw/XcBdYt
+        9r+4IWyFqrHtX7Sg63R7TYoAR6vHaxyhOGyJXYN42BZ67xPX8Xuf+L1P/N4n9p12uv729IlLYVdo
+        mA6y6fB522Xrx/8AzVI60hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:45:23 GMT
+      etag:
+      - W/"b8f2e09aee8d5eebf745aa0cb36d4a46"
+      last-modified:
+      - Tue, 09 Jun 2020 10:45:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958AC16:B2E7CE2:5EDF6843
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4959'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 09 Jun 2020 10:45:24 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D5B2:32669:958AC85:B2E7D7A:5EDF6843
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4958'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_list_multiple_revisions.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_list_multiple_revisions.yaml
@@ -1,0 +1,3620 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:46 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4244E00:4EBF2BD:5ED66002
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3720'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:47 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4244E37:4EBF2EA:5ED66002
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3719'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821277,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEyNzc=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:19:47Z","updated_at":"2020-06-02T14:19:47Z","pushed_at":"2020-06-02T14:19:48Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:48 GMT
+      etag:
+      - '"6828c1761391124cf537bd83f60f69ad"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4244E79:4EBF346:5ED66003
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3718'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"72b2b014b3f5e950c9c717399a10371a5c725e7b","node_id":"MDY6Q29tbWl0MjY4ODIxMjc3OjcyYjJiMDE0YjNmNWU5NTBjOWM3MTczOTlhMTAzNzFhNWM3MjVlN2I=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/72b2b014b3f5e950c9c717399a10371a5c725e7b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/72b2b014b3f5e950c9c717399a10371a5c725e7b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:48Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:48Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:49 GMT
+      etag:
+      - '"30459f57a7983a963f5c23d3c67f63e0"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245051:4EBF580:5ED66004
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3717'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aMBT+K1WeaXPhEkCadlE3qZOgmsbWsWlCjnNCzBw7sx06QP3vOyeka+Fh
+        a6rurS8osfN9/s7Vh52nWAHe2CuYdWC8jsd1UQjnjXeezRluxFESJUHYS7pZH0b9gI94HMbd0YiF
+        QTcOWZ/HUR/iBKFKp7AQKYIm5/PBh2jkkisZTFbz3uX5xa/JincvV3wzX70Xk/O3wXw1LaZXn/rT
+        2ZvV5dWkO5nx7eVM5pPZ6+10+y6f0trqs5xGFy8OdLHK5dqQwkb7x5zlzJy8XRut8EsomJAoAvXj
+        8hnQ8qslLZ6hcfhByhyZHAVRcBoMToNoFvbG4WjcG371bm49QN74b0cUYC1bkogLJZxgUmzhBGWx
+        EwOltsJps0GhzgB+cxuJMAtGaRZ143gY9eKw1x9CGkUjFidJb8hj3BmmcRcCBFaGHJA7V9qx77NS
+        nC2Fy6uEHODXR/gFOAy5NnAqRXLqwDrr0+9iUWxIiQXnI8gnDdZ/8Nnovyc8fJ+M1m+RhAQB5RZc
+        VwrTOOh4azAiE5w5gemB3ty/A+ZpxqSFjmeAWdryKmXFUuFOx6MH5iqD/leVlB2vZBupGYLo9ebp
+        zHyEibkr5OLQy/fC+5DA7g99hFvt0bmPTq22ZvtNXC3G5q4BSL0UFDib11WOe9R+Bv3+oHvYjj4M
+        Pn+ZSr6ah9PZfEsca8xxc2xNvWijploqC4Zr5TCd6sKp/Jr55fpFDxmWpuGoO96/io64rH+n8+8x
+        vPsu01Lqa8QeSz2s6QN6/w8IVe2fhVq2J0DQztcuB/QTyr8howX2iTZMNWCHnQQ7i0iJwqKLDaRt
+        SBoIirlWqGNXt7Caq0osN6Kk0m4l6wCIRNosmRLbuke0IkIgpWTdU9uYVAMQCGvMrlbIPWLnl0as
+        Gd+QGwxwEGv0aXu2IyiSuU1JF9MnjDh5WDhYsLSgMqvb5fEF+VyCzbX6XILtKue5BPeXFjazg+p9
+        UAmWzFDf8MbfvmNBLqRQP/AFJ0WQ2VNMfolhiuc4+P35X0AX1j3mlgMHTZG3XCi4NNoBd/dmsGal
+        GdFAsUQeTGg/K0GXBt4ErrILlMb3BoPKtOFQj3wS2x9p1FmGTqxv7l+Nj+7OxBP+3qcfPh4fOQk7
+        cm0V2XDzG5rrAHtZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:49 GMT
+      etag:
+      - W/"1814c91fe91aea1dbe4970beea554b76"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:424514D:4EBF6B2:5ED66005
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3716'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:50 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:424518A:4EBF6FF:5ED66005
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3715'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/72b2b014b3f5e950c9c717399a10371a5c725e7b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY6bMBD9lchnEoyBNSBVaqtspVSCqCptlFZVZGAIRgYi26yaRPn3HTc9tLdd
+        qb1YeB4z782b8ZWYTpCMcFaxigZRFbYxpDGt05oHPExTEdCQByKuOYuBV8Qj49TAQTaYlK/3D59Y
+        aqudonm/j7brzc+8r8NtX5/3/UeZrx/pvi+GYvclLsr3/XaXh3lZX7al6vLy3aW4fOgKF+u/qoJt
+        3mDxWSss3Fl7Mpnvi5NcHaXt5mpVT4Ov4TQZfwArjJ00LJWslhaMNb47D4fh3AjEwPqY5GPGIBF7
+        RWudHdThbwl/0L+E+E76Gk4x227SJLuSUQyAzX/uRCf04vFJTyM6AoOQzhOcE4ZX4MJvjy7oPMEf
+        sGeXxiijS/qwpKwMoixIsyj5Rm4euSuy8B8prAZUcP29SkFL06ZlIecJi3gQxQk0jKWCV1WU1ByR
+        pOEh0H87bafB+C/mRmMGMEYcnXWbUVoplLzAwi3Q4teeSVyxM2o8CQ2jNST7/sMjT6BlK2thJc4G
+        O77fAR9DK5QBj2gQxkFkHo08joh4xH0IO2ukGmelXMmzmgQmuevt9gzmA9oWhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:50 GMT
+      etag:
+      - W/"c8d96973e6e7c212ed7618da57417f60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42451EF:4EBF782:5ED66006
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3714'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["72b2b014b3f5e950c9c717399a10371a5c725e7b"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"2a1837153f1226faa5c71844c98c15efa6ed4113","node_id":"MDY6Q29tbWl0MjY4ODIxMjc3OjJhMTgzNzE1M2YxMjI2ZmFhNWM3MTg0NGM5OGMxNWVmYTZlZDQxMTM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2a1837153f1226faa5c71844c98c15efa6ed4113","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/2a1837153f1226faa5c71844c98c15efa6ed4113","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:50Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:50Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"72b2b014b3f5e950c9c717399a10371a5c725e7b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/72b2b014b3f5e950c9c717399a10371a5c725e7b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/72b2b014b3f5e950c9c717399a10371a5c725e7b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:50 GMT
+      etag:
+      - '"a31f97b6a83a12bca00664ed8f188e62"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2a1837153f1226faa5c71844c98c15efa6ed4113
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245235:4EBF7D5:5ED66006
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3713'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy07DMBBF/8VrWufRYCXrqgUkqyuC6CbyY4oTxXFkTytC1X9nKpZsWLC5mztn
+        7rmyCCfW3DNxB8om7lVCiOyBTcFC11tq5VY+vvrWy+F9c9g+f8rBlIfpZTxO8qL2rTs+yYt+233Z
+        fbsQeI4jQQ5xTg3nau7XHz26s16b4HmEOdAIIM2ECKux1yuEhInfs+v8YhV1gJwguv7tFfQABllz
+        ZckpGhKFLnSWb3R5qqCuMlMbkYuyrlWelSJXlRFFBUKTGS4zEEEevsf/Nf35mfifbW63b+4Hzvl9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:51 GMT
+      etag:
+      - W/"2e60bd8be15a494832987feaacd9c96b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42452DF:4EBF882:5ED66006
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3712'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "2a1837153f1226faa5c71844c98c15efa6ed4113"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnguV8kWZGUJAspqYqS+TYL7WjOI7iB2qK+O99qGOXDl3uct95
+        99zYDB2rHhm5BWUi9yoizOyJjcFA4wy1ciuLV1972b9np+3hU/Y6PY3H4TzKq9rX9vwir+3b7svs
+        64XAyzwQZBGnWHGuJrf+cGgv7VoHz2eYAo0A0kyYYTW4doUQMfJHNo1fjKIOkBNE17+9QtuDRlbd
+        WLSKhhIlynQj8rQTSVJ0SuV6I8os08+lFjl0qgCTCZGSGS4TEEEe3uH/mv78jPzPNvf7N3+DiUh9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      etag:
+      - W/"dfe3d604ff77a58a1f5b46cce2c16cbc"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245319:4EBF8F3:5ED66007
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3711'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42453D6:4EBF9D1:5ED66008
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3710'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTcLETfNhYLE97HaBAtkARQ+7exEoiZYYS6JKUnYdIf+975CS
+        JbvexHF4zCWxafKZ4XBmOJx2ItPJbHp1czO9mF5fn0wqlYqIxiZ3nz6v7os/i+TL7SP/9tcyqRbr
+        rw/Z5d3D5/XXx+TDBJN5KTDTCmOjqFyn3HIjLH6YN0URdb+WAqNWaXFayPiU5hr2/xW1lktuQZvz
+        woiTiVpVQk9m7aRQmawgZA8GgkjTq6vz6+n05mJH+fX94nb9Y/pHw7/VefqlWMYP36d3n5L13UP2
+        L5ZyyOM6anQBem5tbWaM+UHz61kmbd7EjRE6UZUVlT1LVMka1gv7uPxwCUimO4wzGQZ2cLXsSH45
+        cIbt30luy2JHGa+DW7l/zVwVhVqBubuLA8WyDYDOzMFklb0NBkDLlM0FTIvtPpGRJM78WKpb3DL6
+        B78knMGxaZEeC+yWQ0lysaeWaVErx21ik2hZW6mqo9XdggCqdMYr+cjfBAXEgEWKHq2YWwyIWMKZ
+        j6b41S1z4ZqsyWxaJEIucR5vI+9gALbrmrLL/ciCdErSioinJSUFlyueThC9r4ydPQkoFZvDn8wq
+        5C+KCL3YJKRnA9sZd1+Q7hFE1BfsfzAOAQwYrLIQ62BMYrUMf7t4S5AYeKw0RxIPJmQL2rLxV3Iq
+        K3gZTJaDAZorFc7yDgaoNKYRB/n+4afqmIb1wVY1Zewz6SEhdrgYT8MeuDEyq4QIZvENsGX9JRBr
+        XiV5OBE9r2X+k/MangXbArGAjAsVB2PiQmcO2DKTc3812iik1iSBeFsCtJgH3QLxNgKsDug3Tn0C
+        bvC4rS1cKJj+PY+13QkUvMoanoWTsAHSZYVSJeOPL1Zoh8fsQASeSlMt4yZsYh6YtANfFCH/hDuC
+        ATkIcFXX8yXdK4w0quScmcpSvlTzHE7vcFshFlgExcGuGPr+cun2um0Qr2XD/eIvs05SqNPobrNe
+        /7G87m0VzLV6Hmt/qbnNKcNCbM21CLWZDsfaGE/dp7OzszYX3D1LSqEDZhFPA5brJEd5HUr/tueh
+        ciy5dc+fOamf4jlUKJ4GO4sNEHDvAqH24GljP6pRrwdT3MHG9FIW6FqoKtwdMRDHcipl5Vwmh7wV
+        Dw/zLWj70cgqEScczxtEhZWJRJzgyU4egCJfhLOip2F76BH5Z2IhEDLBTkkLz2uZ7wqkoi7UOmiG
+        HCEpkWiBBlUacYtH6fR8en56fnV6Pv374nJ2cTu7vP6BOU2NHthP5/w2pTl1Y/IXpiD9d7GCT+hK
+        Pd8I2n1jUscJcozJB8jvA2K2p5f0E0RSwOl3ovY4XZa7d/vrMNhOrkpRo07rH+dGPuLz+VaNlaim
+        wulgcMUtHhuoWYahvi7rATk3kc8kk5nVDXqONFJr9SASa8ZjQyYbTVzJhdxaSDXkplvgH/mD8FJq
+        rbpmo28udHkYbcOu45lKw+NCDAOqFlWn4XgbMhGV2ZjBNwBoy6PpWyZwX1Ix501hI/9WonYqerJo
+        sMIdhS5hBup5Ubu166x4g5Cr9nukrOg/o+FiRVlH3jusWgjqzwKFrKJWkfmn4XA9d4H1i/0vbghb
+        oWps+xct6DrdXpMiwNHq8RpHKA47Yt8gHreF3vvETfzeJ37vE7/3iX2nna6/PX3iStgVGqajbDp+
+        3vbZ+uk//OD+SRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      etag:
+      - W/"8b5605a8b9f4ca686c66f22b6a1aede3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245423:4EBFA2A:5ED66008
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3709'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnguV8kWZGUJAspqYqS+TYL7WjOI7iB2qK+O99qGOXDl3uct95
+        99zYDB2rHhm5BWUi9yoizOyJjcFA4wy1ciuLV1972b9np+3hU/Y6PY3H4TzKq9rX9vwir+3b7svs
+        64XAyzwQZBGnWHGuJrf+cGgv7VoHz2eYAo0A0kyYYTW4doUQMfJHNo1fjKIOkBNE17+9QtuDRlbd
+        WLSKhhIlynQj8rQTSVJ0SuV6I8os08+lFjl0qgCTCZGSGS4TEEEe3uH/mv78jPzPNvf7N3+DiUh9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      etag:
+      - W/"dfe3d604ff77a58a1f5b46cce2c16cbc"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245460:4EBFA87:5ED66008
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3708'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2a1837153f1226faa5c71844c98c15efa6ed4113
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU247aMBD9FeRnILZzI5Eq9YHtikoBrYqKoKrQOEyIaS4odlbsIv69Y9Gutm+s
+        RF+i+EzGZ+bMmZyZKYGlTIKY+LEI/UJIGRUAYR6LSRDkySQXIRYQ4S4QwmdD1rQ73OodJWXTdfQk
+        E6tWFc8O62AxnZ2yQ+4vDl/LbLl/nb8+iEyuCZvJTf2lnK8yn3A+f8zCxWN2mq++1+vlptpMn07Z
+        MvtEl/ddRReX1h5N6nlw1OO9tmWvxnlbex0eW+PVaMHYtsNRpdXIorHGc8/ttn7ZAcXQepTkUUat
+        KfaB1kpbV9t/S3hHfwvxlfQjnNDbsu1YemYN1EjNfyuhhG7w8Ny1DSmCNWinCc2J4DE6+PPegU4T
+        +oB6dmmSSz7i0YjLpQhSkaQh37DLkF0rsvgfKWyHVMH5j5XiGCeRHxSBr7ifF0WU7II4CHOuMEYs
+        fKkwBxWF9522q8F4N3OTMDUaA3sn3azRVkM1cO45Qv6L0MFVNqrxCB021rD0x1uDUknFRaD8IsQk
+        5HlCuxL7SQKC0w651ZEhxuq+Df61c3w7+93sfDPn5eeQPWOnC52D1eRfcsX1jPTDKKAyOGQdgnEh
+        1jdG7xuKDJl7Adt3NI6mryon+0vVAiW54+XyG9cxbvioBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:53 GMT
+      etag:
+      - W/"a31f97b6a83a12bca00664ed8f188e62"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42454A1:4EBFACC:5ED66008
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3707'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=2a1837153f1226faa5c71844c98c15efa6ed4113
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv29iy46/AKI3ZigPrWHcxJxSCPo5tpbJkLKUhK/3vO24D69Jd
+        ZN0Yu5A46EjnfXjP0YOnaQfezBPU0Z7yO9rAZGON9s68nrr21xnbUkxkkGZc5FSkOeRhGLEgS2KS
+        JrEQkEAaB3mQZywJsJSV31AkT8687aDwaetcb2e+T3s5aaRrt2zCTecP0Bvrd+CodWaAcyXZuQPr
+        rD/u63W3HzEtOJ8b7UBj4pj7YoD6XUhJFqUkjmoShklNacxTkk2nPM84iaGmCYgpIRGSta5T65+h
+        XgCdgsKUYf6piq94EQH1jgjebAuW8kce6/9Gc4TZaWWoOIIY6O7Qm62F4WD4U5tOceVPDHH7fhzJ
+        WipAew7KeAA705TFYrv8SlS5wbgj8erqQ7CsrpUoSltePuX3q+r6XlSLzar6KD/JOSvkZXOry2Ke
+        jlFZjGuxW1Y35rnKTSuu3t+zSv14+SXe8Ggpn+/P81s9RtXnHiNEAs2NkLpBJobjmEzxbK2kvrPe
+        7MGzoOr/asZxKv4Gz5uGa/xfL8T/7d96fPwO0mCp8uAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:53 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42454E0:4EBFB1F:5ED66009
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3706'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:53 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245513:4EBFB69:5ED66009
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3705'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTcLETfNhYLE97HaBAtkARQ+7exEoiZYYS6JKUnYdIf+975CS
+        JbvexHF4zCWxafKZ4XBmOJx2ItPJbHp1czO9mF5fn0wqlYqIxiZ3nz6v7os/i+TL7SP/9tcyqRbr
+        rw/Z5d3D5/XXx+TDBJN5KTDTCmOjqFyn3HIjLH6YN0URdb+WAqNWaXFayPiU5hr2/xW1lktuQZvz
+        woiTiVpVQk9m7aRQmawgZA8GgkjTq6vz6+n05mJH+fX94nb9Y/pHw7/VefqlWMYP36d3n5L13UP2
+        L5ZyyOM6anQBem5tbWaM+UHz61kmbd7EjRE6UZUVlT1LVMka1gv7uPxwCUimO4wzGQZ2cLXsSH45
+        cIbt30luy2JHGa+DW7l/zVwVhVqBubuLA8WyDYDOzMFklb0NBkDLlM0FTIvtPpGRJM78WKpb3DL6
+        B78knMGxaZEeC+yWQ0lysaeWaVErx21ik2hZW6mqo9XdggCqdMYr+cjfBAXEgEWKHq2YWwyIWMKZ
+        j6b41S1z4ZqsyWxaJEIucR5vI+9gALbrmrLL/ciCdErSioinJSUFlyueThC9r4ydPQkoFZvDn8wq
+        5C+KCL3YJKRnA9sZd1+Q7hFE1BfsfzAOAQwYrLIQ62BMYrUMf7t4S5AYeKw0RxIPJmQL2rLxV3Iq
+        K3gZTJaDAZorFc7yDgaoNKYRB/n+4afqmIb1wVY1Zewz6SEhdrgYT8MeuDEyq4QIZvENsGX9JRBr
+        XiV5OBE9r2X+k/MangXbArGAjAsVB2PiQmcO2DKTc3812iik1iSBeFsCtJgH3QLxNgKsDug3Tn0C
+        bvC4rS1cKJj+PY+13QkUvMoanoWTsAHSZYVSJeOPL1Zoh8fsQASeSlMt4yZsYh6YtANfFCH/hDuC
+        ATkIcFXX8yXdK4w0quScmcpSvlTzHE7vcFshFlgExcGuGPr+cun2um0Qr2XD/eIvs05SqNPobrNe
+        /7G87m0VzLV6Hmt/qbnNKcNCbM21CLWZDsfaGE/dp7OzszYX3D1LSqEDZhFPA5brJEd5HUr/tueh
+        ciy5dc+fOamf4jlUKJ4GO4sNEHDvAqH24GljP6pRrwdT3MHG9FIW6FqoKtwdMRDHcipl5Vwmh7wV
+        Dw/zLWj70cgqEScczxtEhZWJRJzgyU4egCJfhLOip2F76BH5Z2IhEDLBTkkLz2uZ7wqkoi7UOmiG
+        HCEpkWiBBlUacYtH6fR8en56fnV6Pv374nJ2cTu7vP6BOU2NHthP5/w2pTl1Y/IXpiD9d7GCT+hK
+        Pd8I2n1jUscJcozJB8jvA2K2p5f0E0RSwOl3ovY4XZa7d/vrMNhOrkpRo07rH+dGPuLz+VaNlaim
+        wulgcMUtHhuoWYahvi7rATk3kc8kk5nVDXqONFJr9SASa8ZjQyYbTVzJhdxaSDXkplvgH/mD8FJq
+        rbpmo28udHkYbcOu45lKw+NCDAOqFlWn4XgbMhGV2ZjBNwBoy6PpWyZwX1Ix501hI/9WonYqerJo
+        sMIdhS5hBup5Ubu166x4g5Cr9nukrOg/o+FiRVlH3jusWgjqzwKFrKJWkfmn4XA9d4H1i/0vbghb
+        oWps+xct6DrdXpMiwNHq8RpHKA47Yt8gHreF3vvETfzeJ37vE7/3iX2nna6/PX3iStgVGqajbDp+
+        3vbZ+uk//OD+SRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:53 GMT
+      etag:
+      - W/"8b5605a8b9f4ca686c66f22b6a1aede3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:424554C:4EBFBA3:5ED66009
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3704'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bSBD9FYNn2dxJS0CQOTgJHIAyjGjikQeB0GwVyXaaS7qbim1B/z5VFL1I
+        B0c0PDdfBKnJev3q1aq1VbESrIlVMm1AWSOL12UpjDVZW7pg+MBj7qkfu6GfuZ4XZYyFPHZPg4CP
+        T7kbQsYiWAau66NpVS9hIZZolJzNo0tvbNIr6SQ38+Di7Pw2ueH+xc3XIpnl99P7T27izfHs3Lsu
+        PxfTq8THc2f6JQkvviS306vv5Xx2La/PLm+TWfJhhxdrTVErYthz/1awgqmjTytVV/gmlExIJIH8
+        8fgE6PivnA5P0Dl8YckMuew5nnPsRMeON3ODiTuehM61tXlQgNT4364oQWuWE4nzShjB5BFyYg3j
+        P/H0qA/ByDIK8J2HSMQxnEZ+kAV+6vg8y6LxMoiDkDspxACZ76XAWRqF6GGrSIDCmEZPbJs14iQX
+        pmhTEsBW0NTaLsFgyGsFx1Kkxwa00TZ9LhblHZHRYGw0somDtg++G/V7w8u3Smh7QBKSCVRmweu2
+        wjR2RtYKlMgEZ0ZgeqCa29+AeZoxqWFkKWCaHlltpUVe4ZORRV+YaRXqX7VSjqyG3cmaoRH93Lyd
+        m69wsTClXOyq/Cy8hwR2e+krZNV79746tYa6bfdx1RibpwYg61xQ4HTRVTk+o/YThWHk77ajy+j7
+        P1PJb+budDa/J4wV5rja96Y71F5fLa0GxevKYDp1hdPaHfLH1YcAEXLVY3Qd709FR1jafuL5cgyf
+        3stqKevfaLtPdbemd+DtRyNktf0uqnw4ABqt7doUgDoh/Q05LbBPDEHqDNbYSbCziCVBaJRYwXII
+        SG+CZH5XyGPdtbAOq001V6Kh0h5Ea8cQgWqVs0rcdz1iEBAaUkp2PXWIS50BGsIKs2uQ5dZibTdK
+        rBi/IxkUcBAr1HQ42p4pgpm7hgbT3xhxUlgYWLBlSWXWtcv9Aflegv1YfS/BYZXzXoLboYXNbKd6
+        DyrBhinqG9bk38ft0Eu91HGD1M9CGIcOH+OeHvvjMXMd3N9pbfdCiFOEf6MF7WGEx4ff/PLUG7C5
+        HHzn5gc2rIUU1U8UC7UCmb3FZpwqVvECF+PH/03k2jPkgQsZbdkPWEi4UbUBbp7tqP1Jv8JCxVK5
+        s8H+agUNVZyUptULpMa3DkOV1YpDtxJLHA/Esc4yzIJus7ntcugH7bNPN7w8xw7/+7AnEk6szivy
+        YfMfS3lqBHkOAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:54 GMT
+      etag:
+      - W/"08ba57257c062e383073f04a1e454926"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:424558D:4EBFBF6:5ED66009
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3703'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:54 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42455CA:4EBFC46:5ED6600A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3702'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2a1837153f1226faa5c71844c98c15efa6ed4113
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU247aMBD9FeRnILZzI5Eq9YHtikoBrYqKoKrQOEyIaS4odlbsIv69Y9Gutm+s
+        RF+i+EzGZ+bMmZyZKYGlTIKY+LEI/UJIGRUAYR6LSRDkySQXIRYQ4S4QwmdD1rQ73OodJWXTdfQk
+        E6tWFc8O62AxnZ2yQ+4vDl/LbLl/nb8+iEyuCZvJTf2lnK8yn3A+f8zCxWN2mq++1+vlptpMn07Z
+        MvtEl/ddRReX1h5N6nlw1OO9tmWvxnlbex0eW+PVaMHYtsNRpdXIorHGc8/ttn7ZAcXQepTkUUat
+        KfaB1kpbV9t/S3hHfwvxlfQjnNDbsu1YemYN1EjNfyuhhG7w8Ny1DSmCNWinCc2J4DE6+PPegU4T
+        +oB6dmmSSz7i0YjLpQhSkaQh37DLkF0rsvgfKWyHVMH5j5XiGCeRHxSBr7ifF0WU7II4CHOuMEYs
+        fKkwBxWF9522q8F4N3OTMDUaA3sn3azRVkM1cO45Qv6L0MFVNqrxCB021rD0x1uDUknFRaD8IsQk
+        5HlCuxL7SQKC0w651ZEhxuq+Df61c3w7+93sfDPn5eeQPWOnC52D1eRfcsX1jPTDKKAyOGQdgnEh
+        1jdG7xuKDJl7Adt3NI6mryon+0vVAiW54+XyG9cxbvioBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      etag:
+      - W/"a31f97b6a83a12bca00664ed8f188e62"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245666:4EBFCF8:5ED6600A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3701'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["2a1837153f1226faa5c71844c98c15efa6ed4113"],
+      "message": "Set type to csv", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"b59437cf5542b83a3699099a70a69b50e2468cc3","node_id":"MDY6Q29tbWl0MjY4ODIxMjc3OmI1OTQzN2NmNTU0MmI4M2EzNjk5MDk5YTcwYTY5YjUwZTI0NjhjYzM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59437cf5542b83a3699099a70a69b50e2468cc3","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b59437cf5542b83a3699099a70a69b50e2468cc3","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:55Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:55Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Set
+        type to csv","parents":[{"sha":"2a1837153f1226faa5c71844c98c15efa6ed4113","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2a1837153f1226faa5c71844c98c15efa6ed4113","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/2a1837153f1226faa5c71844c98c15efa6ed4113"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1181'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      etag:
+      - '"c8ece7ba23f07470b007bba1368853b7"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59437cf5542b83a3699099a70a69b50e2468cc3
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:424569F:4EBFD4B:5ED6600B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3700'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnguV8kWZGUJAspqYqS+TYL7WjOI7iB2qK+O99qGOXDl3uct95
+        99zYDB2rHhm5BWUi9yoizOyJjcFA4wy1ciuLV1972b9np+3hU/Y6PY3H4TzKq9rX9vwir+3b7svs
+        64XAyzwQZBGnWHGuJrf+cGgv7VoHz2eYAo0A0kyYYTW4doUQMfJHNo1fjKIOkBNE17+9QtuDRlbd
+        WLSKhhIlynQj8rQTSVJ0SuV6I8os08+lFjl0qgCTCZGSGS4TEEEe3uH/mv78jPzPNvf7N3+DiUh9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      etag:
+      - W/"dfe3d604ff77a58a1f5b46cce2c16cbc"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:54 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245704:4EBFDD0:5ED6600B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3699'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "b59437cf5542b83a3699099a70a69b50e2468cc3"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4tnwBH5AGdGpUWymJqqLJHtPGpHcRzZD9QU8d/7UMcuHbrc5b7z
+        7rmxCGdWPzJxC6pL3KuEENmCjaGD1nXUyp2sXn3jZf9eHHcvn7I3+XE8DKdRXtW+sadnedVvT1/d
+        vpkJvMSBIIs4pZpzNbnVh0N70SsTPI8wBRoBpJkQYTk4vURImPgj29bPnaIOkBNE17+9gu7BIKtv
+        LFlFQ7oURb4x57Is1nqbq7wSIhNCbTJVCV1msC6qrTE5meE8ARHk4R3+r+nPz8T/bHO/fwPa4wbB
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:56 GMT
+      etag:
+      - W/"39c353634667d15d94eb48b8bf6761a6"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:424575B:4EBFE24:5ED6600B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3698'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:56 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245825:4EBFF2F:5ED6600C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3697'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJmHipsnGwGJ72O0CBbIBih529yJQEi0xlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47kelkNr368GF6Mb2+PplUKhURjU1uP39Z3RV/FsnXmwf+/a9lUi3W
+        3+6zy9v7L+tvD8nHCSbzUmCmFcZGUblOueVGWPwwb4oi6n4tBUat0uK0kPEpzTXs/ytqLZfcgjbn
+        hREnE7WqhJ7M2kmhMllByB4MBJGmV1fn19Pph4sd5dd3i5v1z+kfDf9e5+nXYhnf/5jefk7Wt/fZ
+        v1jKIY/rqNEF6Lm1tZkx5gfNr2eZtHkTN0boRFVWVPYsUSVrWC/s0/LjJSCZ7jDOZBjYwdWyI/nl
+        wBm2fye5LYsdZbwObuX+NXNVFGoF5u4uDhTLNgA6MweTVfY2GAAtUzYXMC22+0hGkjjzY6luccvo
+        H/yScAbHpkV6LLBbDiXJxR5bpkWtHLeJTaJlbaWqjlZ3CwKo0hmv5AN/ExQQAxYperRibjEgYgln
+        PpriV7fMhWuyJrNpkQi5xHm8jbyDAdiua8oudyML0ilJKyKelpQUXK54PEH0vjJ29iSgVGwOfzKr
+        kL8oIvRik5CeDWxn3H1BukcQUV+w/8E4BDBgsMpCrIMxidUy/O3iLUFi4LHSHEk8mJAtaMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGHOT7h5+qYxrWB1vVlLHPpIeE2OFiPA174MbIrBIimMU3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4m0J0GIedAvE2wiwOqDfOPUJ
+        uMHjtrZwoWD69zzWdidQ8CpreBZOwgZIlxVKlYw/vFihHR6zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdz5d0rzDSqJJzZipL+VLNczi9w22FWGARFAe7Yuj7y6Xb67ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9peY2pwwLsTXXItRmOhxrYzx1H8/OztpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/5qR+iudQoXga7Cw2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlXOZHPJW
+        PDzMt6DtJyOrRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQ66AZ
+        coSkRKIFGlRpxC0epdPz6fnp+dXp+fTvi8vZxc3s8von5jQ1emBPzvntkubUjcmfnnJFU5D+u1jB
+        J3Slnm8E7b4xqeMEiDH5APl9QMz29JKeQCQFnH4nao/TZbl7t78Og+3kqhQ16rT+cW7kAz6fb9VY
+        iWoqnA4GV9zisYGaZRjq67IekHMT+UwymVndoOdII7VW9yKxZjw2ZLLRxJVcyK2FVENuugX+kT8I
+        L6XWqms2+uZCl4fRNuw6nqk0PC7EMKBqUXUajrchE1GZjRl8A4C2PJq+ZQL3JRVz3hQ28m8laqei
+        J4sGK9xR6BJmoJ4XtVu7zoo3CLlqv0fKiv4zGi5WlHXkvcOqhaD+LFDIKmoVmX8aDtdzF1i/2P/i
+        hrAVqsa2f9GCrtPtNSkCHK0er3GE4rAj9g3icVvovU/cxO994vc+8Xuf2Hfa6frb0yeuhF2hYTrK
+        puPnbZ+tH/8DARtnLxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:57 GMT
+      etag:
+      - W/"920bad0756511cfc3b5576e324cb5744"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:54 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245872:4EBFF88:5ED6600C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3696'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4tnwBH5AGdGpUWymJqqLJHtPGpHcRzZD9QU8d/7UMcuHbrc5b7z
+        7rmxCGdWPzJxC6pL3KuEENmCjaGD1nXUyp2sXn3jZf9eHHcvn7I3+XE8DKdRXtW+sadnedVvT1/d
+        vpkJvMSBIIs4pZpzNbnVh0N70SsTPI8wBRoBpJkQYTk4vURImPgj29bPnaIOkBNE17+9gu7BIKtv
+        LFlFQ7oURb4x57Is1nqbq7wSIhNCbTJVCV1msC6qrTE5meE8ARHk4R3+r+nPz8T/bHO/fwPa4wbB
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:57 GMT
+      etag:
+      - W/"39c353634667d15d94eb48b8bf6761a6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42458C0:4EBFFED:5ED6600D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3695'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59437cf5542b83a3699099a70a69b50e2468cc3
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJJZky19Q6CF7yMEJS70UbylhLI9je/0RLDnbJOS/V9q00N42
+        sHsx0oye3ps3Y12IqoDEJBeR5wayFMLjeeiC60cRjSIIKPhRLihyzw+ldMmc9EOBu7owoGSV+Y88
+        0vn3liZN5m1X619JI91tt2bb9PG84Ztukz7RpFt7CX84b5oXkaxeRJbK1yzNRNY8vT6na7ppqiY7
+        J1/M5dPYmosrrQ8qdhw41Mt9raspX8qhc0Y8DMrpUIPSw4iLts4XGpVWjv3udt2pAJND7RiQYxBd
+        bXJ3lFbprt39L+Ef+vcQ30jv4YRJV8NI4gvpoUNT/LcKKhhnD8dx6I0j2EFtPTF9MuEl2vDXvQ1a
+        T8wBU7OFccrpgvoLylPmxSyKhXgm1zm5KdL4iRR6RKPg8meUGDAJsshlVARC+EHACpdTgQIxEqEI
+        uOvn1GX8Y7ttNSjn3dzGmA6Vgv2b46hn+nTAmR5mUh2NsAOM2GtF4h9/q+LAQjdgwi0Z534JIGTA
+        Qs+TUSiZwBJ8LDzG7A/yCTN8B/uHzfC7Oa8/5+SIY13WEnRthtaMwm2P5pUooVU4JyOCsiky9are
+        9yYzJ3YBehpND/qpba3tp3YAA7Lb6/U3SdD1a50EAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:57 GMT
+      etag:
+      - W/"c8ece7ba23f07470b007bba1368853b7"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245909:4EC0040:5ED6600D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3694'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b59437cf5542b83a3699099a70a69b50e2468cc3
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft5HiB9kKjNGErSSwjHUv5oRA0JNjpbJkLKUhLf3ulRoz2rQv
+        sjLG3kjiTnf34+5/D5EmjYhGESeOtITdko0YbK3R0UXUEle/77E18Q5KEaw4LIo4gzHECckzmOSI
+        5wjxApGE50Ueswr6VFbe+yLDYXoR7TrlY2vnWjsCgLRysJGu3tEBMw3oRGssaIQj1plOXCpJL52w
+        zoJwrtfNIXBa4QAz2gntHafgnztRfaIZTpOcVVmWxrRISIIwhhiTHBKEaQZFnKKCscSj1a5R69dQ
+        L4DOQaHKUHBuxTe8HsHXOyH4cFt8KhB4LPiD6XCz18oQfgLRkX0/m50VXd/w5zGd1ZUzR/BeQ9yh
+        DZqspBK+PX1lbxB7s5lOZlCUYzXd+nczv+dyaqdXz/bd4tewtw+z5fVXuCjnik+O/pX2Pw7Lcn7H
+        y9l2WX6T3+WYTuSVjxznxzu8Z/tFeWOO2W9qfv3ljpbqsNK/I39mW5YsZB+Jw13+aPEqrIzQzHCp
+        N2E7vExR6m1rJfWtjUYPkRWq+q+079XyN3g+JLqwdy+K/9ude3x8AhX6IQn5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:57 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245950:4EC009C:5ED6600D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3693'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:58 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42459A2:4EC0101:5ED6600D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3692'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJmHipsnGwGJ72O0CBbIBih529yJQEi0xlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47kelkNr368GF6Mb2+PplUKhURjU1uP39Z3RV/FsnXmwf+/a9lUi3W
+        3+6zy9v7L+tvD8nHCSbzUmCmFcZGUblOueVGWPwwb4oi6n4tBUat0uK0kPEpzTXs/ytqLZfcgjbn
+        hREnE7WqhJ7M2kmhMllByB4MBJGmV1fn19Pph4sd5dd3i5v1z+kfDf9e5+nXYhnf/5jefk7Wt/fZ
+        v1jKIY/rqNEF6Lm1tZkx5gfNr2eZtHkTN0boRFVWVPYsUSVrWC/s0/LjJSCZ7jDOZBjYwdWyI/nl
+        wBm2fye5LYsdZbwObuX+NXNVFGoF5u4uDhTLNgA6MweTVfY2GAAtUzYXMC22+0hGkjjzY6luccvo
+        H/yScAbHpkV6LLBbDiXJxR5bpkWtHLeJTaJlbaWqjlZ3CwKo0hmv5AN/ExQQAxYperRibjEgYgln
+        PpriV7fMhWuyJrNpkQi5xHm8jbyDAdiua8oudyML0ilJKyKelpQUXK54PEH0vjJ29iSgVGwOfzKr
+        kL8oIvRik5CeDWxn3H1BukcQUV+w/8E4BDBgsMpCrIMxidUy/O3iLUFi4LHSHEk8mJAtaMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGHOT7h5+qYxrWB1vVlLHPpIeE2OFiPA174MbIrBIimMU3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4m0J0GIedAvE2wiwOqDfOPUJ
+        uMHjtrZwoWD69zzWdidQ8CpreBZOwgZIlxVKlYw/vFihHR6zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdz5d0rzDSqJJzZipL+VLNczi9w22FWGARFAe7Yuj7y6Xb67ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9peY2pwwLsTXXItRmOhxrYzx1H8/OztpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/5qR+iudQoXga7Cw2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlXOZHPJW
+        PDzMt6DtJyOrRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQ66AZ
+        coSkRKIFGlRpxC0epdPz6fnp+dXp+fTvi8vZxc3s8von5jQ1emBPzvntkubUjcmfnnJFU5D+u1jB
+        J3Slnm8E7b4xqeMEiDH5APl9QMz29JKeQCQFnH4nao/TZbl7t78Og+3kqhQ16rT+cW7kAz6fb9VY
+        iWoqnA4GV9zisYGaZRjq67IekHMT+UwymVndoOdII7VW9yKxZjw2ZLLRxJVcyK2FVENuugX+kT8I
+        L6XWqms2+uZCl4fRNuw6nqk0PC7EMKBqUXUajrchE1GZjRl8A4C2PJq+ZQL3JRVz3hQ28m8laqei
+        J4sGK9xR6BJmoJ4XtVu7zoo3CLlqv0fKiv4zGi5WlHXkvcOqhaD+LFDIKmoVmX8aDtdzF1i/2P/i
+        hrAVqsa2f9GCrtPtNSkCHK0er3GE4rAj9g3icVvovU/cxO994vc+8Xuf2Hfa6frb0yeuhF2hYTrK
+        puPnbZ+tH/8DARtnLxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:58 GMT
+      etag:
+      - W/"920bad0756511cfc3b5576e324cb5744"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:54 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245A24:4EC01A3:5ED6600E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3691'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTXPaMBD9KxmfSfwpg5nptIf0kANkMiFtnU6HkeU1FrEtV5JJAsN/78pAEzik
+        OENvuTBG8nt6u9ovr6yKlmANrZIqDdLqWUyUJdfWcGWpnOJGQqLA77OMkMBLBj71wyhyooj2HRpG
+        CXHAC8IBYz5CK5HClKcIGl3G4Y0X6eR74YzmcXB9efU0mjP/urxyryc3y7E3LseTO2dUXgUj7+ty
+        PH8go8sHEk/YYzyJSTy/e7yfXDnjeT6Pl6NPe7poo3MhjcKt9tuc5lSefV1IUeGbUFJeoAjUj8sX
+        YJa/zMziBRqHL6RUG5M9x3POnfDc8SZuMHSjISH31nrnAeON/3ZECUrRmRFxC/pMP9dwpsUZUwtU
+        pyXgxs79LnUZZWnCorRPSNjvu6nvOQQIQEQGpO/5YeL4rofARhqrc61rNbRtWvOLGdd5kxirbQm1
+        UHYJGu9ZSDgveHKuQWllm9/ptHxGr1AF2kaQbTQo++iz0WknPHwTgcruEHkGApWeMtFUGLtOz1qA
+        5BlnVHOMCfTm5j9gcGa0UNCzJFBltqymUnxW4U7PMg9UNxL9XzVF0bNq+lwIiiDzd306M99hYq7L
+        Yrrv5VfXe8zFbg59h1vVwbnvDq2uZtvbe1V4Ny9ZX4gZNxen8ja1cc/UnBCzw9+vQTfhtx/jgs1j
+        dzyJl4ZjgTEuD61pF5W3zZZGgWSi0hhObeI0dsv8efEpQIaZ3HK0Ze5fSWe4lP2i8+07fHkvE0Uh
+        HhF7KHU/p/fo7b8gVLV55tWsOwGCVrbQOaCfUP7aGM2xTnRhagErrCRYWXhqKBS6WELahWQLQTGP
+        FepYtSWs5WoSxSSvTWp3krUHRCIhZ7Tiy7ZGdCJCoAnJtqZ2MakFIBAWGF2dkBvEyq4lX1D2bNwg
+        gQFfoE+7sx1Akcy0IAzoO7xx42GuYUrT0qRZWy4Pu+JHCm7b6kcKdsucjxTcNC0sZnvZe1QK1lSa
+        umENf+6mQ4+6A7/vEj9zPS/MKCWs7w6CgEUD5hLIaAhp4LpmOD/RgLZr4R1OfrvrdZhcjj5z/QsL
+        1rTg1QM6C30FRXaKyTiRtGI5DsZ/P5aMaa+YOw5kZsrecaHgWgoNTL+aUbcr2xEWKpoUexPs74ab
+        poqdUjdqitLYxmCoMiEZtCNxge3BaBRZhlHQTjZPbQz9MvPsywlv97HjPx8OnIQdq7XK2LD+A4lf
+        saduDgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:58 GMT
+      etag:
+      - W/"6dc8f21a4f9de6a8b1ee221d628af8b5"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245A6D:4EC01FA:5ED6600E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3690'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"xls\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"611492251181a958ff3fb89b5c857f754f7c66c1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"0db3e0dc648ef5a75823501ad0bbebe7de1b0875","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/0db3e0dc648ef5a75823501ad0bbebe7de1b0875"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:59 GMT
+      etag:
+      - '"da07e5abb3046fbdcd5e221c600f2fa6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245AAC:4EC024D:5ED6600E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3689'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59437cf5542b83a3699099a70a69b50e2468cc3
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJJZky19Q6CF7yMEJS70UbylhLI9je/0RLDnbJOS/V9q00N42
+        sHsx0oye3ps3Y12IqoDEJBeR5wayFMLjeeiC60cRjSIIKPhRLihyzw+ldMmc9EOBu7owoGSV+Y88
+        0vn3liZN5m1X619JI91tt2bb9PG84Ztukz7RpFt7CX84b5oXkaxeRJbK1yzNRNY8vT6na7ppqiY7
+        J1/M5dPYmosrrQ8qdhw41Mt9raspX8qhc0Y8DMrpUIPSw4iLts4XGpVWjv3udt2pAJND7RiQYxBd
+        bXJ3lFbprt39L+Ef+vcQ30jv4YRJV8NI4gvpoUNT/LcKKhhnD8dx6I0j2EFtPTF9MuEl2vDXvQ1a
+        T8wBU7OFccrpgvoLylPmxSyKhXgm1zm5KdL4iRR6RKPg8meUGDAJsshlVARC+EHACpdTgQIxEqEI
+        uOvn1GX8Y7ttNSjn3dzGmA6Vgv2b46hn+nTAmR5mUh2NsAOM2GtF4h9/q+LAQjdgwi0Z534JIGTA
+        Qs+TUSiZwBJ8LDzG7A/yCTN8B/uHzfC7Oa8/5+SIY13WEnRthtaMwm2P5pUooVU4JyOCsiky9are
+        9yYzJ3YBehpND/qpba3tp3YAA7Lb6/U3SdD1a50EAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:59 GMT
+      etag:
+      - W/"c8ece7ba23f07470b007bba1368853b7"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245B27:4EC02DC:5ED6600F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3688'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["b59437cf5542b83a3699099a70a69b50e2468cc3"],
+      "message": "Set type to xls", "tree": "611492251181a958ff3fb89b5c857f754f7c66c1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"092fb6a49fbb76f1dc413aafca75c58c0da6a700","node_id":"MDY6Q29tbWl0MjY4ODIxMjc3OjA5MmZiNmE0OWZiYjc2ZjFkYzQxM2FhZmNhNzVjNThjMGRhNmE3MDA=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/092fb6a49fbb76f1dc413aafca75c58c0da6a700","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/092fb6a49fbb76f1dc413aafca75c58c0da6a700","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:59Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:59Z"},"tree":{"sha":"611492251181a958ff3fb89b5c857f754f7c66c1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/611492251181a958ff3fb89b5c857f754f7c66c1"},"message":"Set
+        type to xls","parents":[{"sha":"b59437cf5542b83a3699099a70a69b50e2468cc3","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59437cf5542b83a3699099a70a69b50e2468cc3","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b59437cf5542b83a3699099a70a69b50e2468cc3"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1181'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:59 GMT
+      etag:
+      - '"27f6a6d2b87ae772a4fbc3f2b3501708"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/092fb6a49fbb76f1dc413aafca75c58c0da6a700
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245B55:4EC0324:5ED6600F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3687'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4tnwBH5AGdGpUWymJqqLJHtPGpHcRzZD9QU8d/7UMcuHbrc5b7z
+        7rmxCGdWPzJxC6pL3KuEENmCjaGD1nXUyp2sXn3jZf9eHHcvn7I3+XE8DKdRXtW+sadnedVvT1/d
+        vpkJvMSBIIs4pZpzNbnVh0N70SsTPI8wBRoBpJkQYTk4vURImPgj29bPnaIOkBNE17+9gu7BIKtv
+        LFlFQ7oURb4x57Is1nqbq7wSIhNCbTJVCV1msC6qrTE5meE8ARHk4R3+r+nPz8T/bHO/fwPa4wbB
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:00 GMT
+      etag:
+      - W/"39c353634667d15d94eb48b8bf6761a6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245BC2:4EC03A1:5ED6600F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3686'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "092fb6a49fbb76f1dc413aafca75c58c0da6a700"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWqc0TWjmigKS1YkgukRn+4ITxXFkXytC1f/OVYwsDCxveffd
+        +y4iYiuqWybpEGySHhJhFHdiDBabznKrdqp49bVX/Xt+2D1/qt6sD+PLcBzVGfa1Oz6ps357/LL7
+        embwFAeGHNGUKilh6pYfHbmTXprgZcQp8AgSz4SIi6HTC8JESd6yafxsgTskyRBf//YKukdDorqI
+        5ICHsu19qwvIt63WZdGurMlXa4DWQLkxmweTWSigzDI2o3lCJtjDd/S/pj8/k/yzzfX6DYBCiIJ9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:01 GMT
+      etag:
+      - W/"a2abe2acbeea969bf2a161009b9edf26"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245C03:4EC03FD:5ED66010
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3685'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:01 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245D7C:4EC05A7:5ED66011
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3684'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHTfNhYLE97HaBAtkARQ+7exEoiZaYSKJKUnYdIf+975CS
+        JbvexHF4zCWxafKZ4XBmOJx2ItPJfHZ5fT07n11dnUwqlYqIxia3nz6v7oo/i+TLzSP/9tcyqR7W
+        X++zi9v7z+uvj8mHCSbzUmCmFcZGUblOueVGWPywaIoi6n4tBUat0uK0kPEpzTXs/ytqLZfcgrbg
+        hREnE7WqhJ7M20mhMllByB4MBJGml5fTq9ns+nxH+fXdw836x+yPhn+r8/RLsYzvv89uPyXr2/vs
+        XyzlkMd11OgC9Nza2swZ84Pm17NM2ryJGyN0oiorKnuWqJI1rBf2cfnhApBMdxhnMgzs4GrZkfxy
+        4Azbv5PclsWOMl4Ht3L/moUqCrUCc3cXB4plGwCdmYPJKnsbDICWKZsLmBbbfSIjSZz5sVS3uGX0
+        D35JOINj0yI9Ftgth5LkYk8t06JWjtvEJtGytlJVR6u7BQFU6YxX8pG/CQqIAYsUPVoxtxgQsYQz
+        H03xq1vmwjVZk9m0SIRc4jzeRt7BAGzXNWWXu5EF6ZSkFRFPS0oKLlc8nSB6Xxk7exJQKjaHP5lX
+        yF8UEfphk5CeDWxn3H1BukcQUV+w/8E4BDBgsMqDWAdjEqtl+NvFW4LEwGOlOZJ4MCFb0JaNv5JT
+        WcHLYLIcDNBcqXCWdzBApTGNOMj3Dz9VxzSsD7aqKWOfSQ8JscPFeBr2wI2RWSVEMItvgC3rL4FY
+        8yrJw4noeS3zn5zX8CzYFogFZFyoOBgTFzpzwJaZnPur0UYhtSYJxNsSoMUi6BaItxFgdUC/ceoT
+        cIPHbW3hQsH073ms7U6g4FXW8CychA2QLiuUKhl/fLFCOzxmByLwVJpqGTdhE/PApB34ogj5J9wR
+        DMhBgKu6ni/pXmGkUSXnzFSW8qWa53B6h9sKscAiKA52xdD3l0u3122DeC0b7hd/mXWSQp1Gd5v1
+        +o/ldW+rYK7V81j7S81tThkWYmuuRajNdDjWxnjqPp2dnbW54O5ZUgodMIt4GrBcJznK61D6tz0P
+        lWPJrXv+LEj9FM+hQvE02FlsgIB7Fwi1B08b+1GNej2Y4g42ppeyQNdCVeHuiIE4llMpKxcyOeSt
+        eHiYb0Hbj0ZWiTjheN4gKqxMJOIET3byABT5IpwVPQ3bQ4/IPxMLgZAJdkpaeF7LfFcgFXWh1kEz
+        5AhJiUQLNKjSiFs8SmfT2fR0enk6nf19fjE/v5lfXP3AnKZGD+ync367pjl1Y/L9U2bT+fScpiD9
+        d7GCT+hKPd8I2n1jUscJEGPyAfL7gJjv6SX9BJEUcPqdqD1Ol+Xu3f46DLaTq1LUqNP6x7mRj/g8
+        3aqxEtVUOB0MrrjFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kVizXhsyGSjiSv5ILcWUg256Rb4
+        R/4gvJRaq67Z6JsLXR5G27DreKbS8LgQw4CqRdVpON6GTERlNmbwDQDa8mj6lgncl1QseFPYyL+V
+        qJ2KniwarHBHoUuYgXpe1G7tOiveIOSq/R4pK/rPaLhYUdaR9w6rHgT1Z4FCVlGryPzTcLieu8D6
+        xf4XN4StUDW2/YsWdJ1ur0kR4Gj1eI0jFIcdsW8Qj9tC733iJn7vE7/3id/7xL7TTtffnj5xJewK
+        DdNRNh0/b/ts/fQf1cdD9xUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:01 GMT
+      etag:
+      - W/"6ac969530a81c94bb7b130d3516101af"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245DF6:4EC0650:5ED66011
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3683'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits?path=datapackage.json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1abW+jOBD+KxGf04INhhBpdbdSX5SToOpe2h5ZrSJjTIDyEoGTton6329MmmvT
+        nrpQJZUq8aUihnn1zHgeT3+ulSqiylDRbBz6JjXs0PctM0QBM5BOacioRRgZMC2gJrU0TekreRHw
+        aRwAkXPimZfYFv5NqjmJZ1ycjO6dhOkXyXfiZJPYzU61i5tJ7CUMT5KzW291ee/gs2iSuZG7uk7c
+        cZQ45z8i+E53Tr5/A+asyLJYKMO1QhciKkr5lNOMg7S/IxrRsne6LIscvuQZjVNYBv1h+ZjL5T9n
+        cvEYmMAHARWSDGtYO9LMIw2PkTFE9pDYE+VxK0nwA4rIeFXRWa07Fz3xMOc9UfTu0wq0EyWHF1v3
+        mwgZNsYEoQGiNhmEoR76A9snbECs0CJGaDHTZAgIF6W0OhJiXg1Vlc7j41ksooUvrVZLPi8qNeOC
+        VqIo+VEa+0eCV6JS5d/pNHsAr9CKCxWIVKlDpTaWDU7bo/DNTldqi8iTJDwXU1YscogRra8seRmH
+        MaMihpgAb25+cwjOkKYV7yslp5V8pSzyKp7l8KavyAcqFiX4P1+kaV+Z04e0oEAkfz7uz8wPmBiJ
+        LJ3uevnF9jbZ2I3QD7i1eiX3w6HV1mz1aV9lWjxnfVrMYrlxVVSnNryTNcckxNR3a9Clef2Pm7LE
+        Q+7YW0keS4jx8rU19WKFn7JlUfGSFbmAcKoTZ6HWnP9YfjOAw6x84lGXud8lneRVqc96vr+Hz9+F
+        RZoWd0D7WtXdnN5hr/5HBFptnuN81p4BEK3VQkQc/ATqP0qjY6gTbTjVBGuoJFBZ4kCyqMDFJQ/a
+        MHkiAWXuctBjXZewmtfCr1gZz2Vqt1JrhxAYFeWM5vGqrhGtGAGhDMm6prYxqSYAQr6E6GpFuaFY
+        q/MyXlL2IN1QcsbjJfi0PbdXpMBMHkEQ0Few49LDseBTGmQyzepy+fpU7FLw6VjtUrBd5nQpuDm0
+        oJjtZG+jFJzTUtYNZfhz2x36xDZ0i4WEGNgf6FQ3bVuzbejHqQk9osaxYQ4Y04H9nhq07RHeQvL7
+        p16LzqWxzMdfj/0PuKgBfslG6GJ8uXKxm7njK83JRoaDT1duckuck1vijdmdN/aIl1zdTcYjzU2i
+        xFs5n4VfyOHxy0bE/+MXVi1lHO/gF0QRoyzwmR1Y0EdZFgp0rBFOOAc0Qyysm76mI7y/CH3GL41l
+        76+xl8I/kCJfFb80zsg+4NI94ZcWMrfw4f0erTk0bruzHX5599Tpmqeueerwy/udWXeF0F0hvLhE
+        2tzjftErhLf4BVM00C1E9BBhbIaUEmahgWEwe8AQ4SE1eWAgdAD80kLy3jqXxjJf4pfGRM3mL39F
+        zni2clenyMEezGRGeJKdRe6No8O65p475OLcuXdvrjNvPEknJzCXGX8aftEOj182Ip7xyyiPRUzT
+        npx+zCm7halMb9PmvYEylsUHpm6Ehg6IhYWhaQeGZRCm+dziPNSxzxn1TXIIKNNY9mGgTIsg/KpQ
+        poWJn18QNkPJ318at4cyTc3uoEwHZbpRDIwb1W4U001DW83uumno9p9Qdi98vvI09C2UsbCPfQ0Z
+        vh4SuNrWmA1QxtJhGIM0gDgS2WDCLX9/3eH2NrKF5L11Lo1lApT59S9cH8fjTCYAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:02 GMT
+      etag:
+      - W/"e5de80d1f1425c66eb2a40e6d25a67f5"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245ECD:4EC0733:5ED66011
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3682'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:02 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245F46:4EC07F7:5ED66012
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3681'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHTfNhYLE97HaBAtkARQ+7exEoiZaYSKJKUnYdIf+975CS
+        JbvexHF4zCWxafKZ4XBmOJx2ItPJfHZ5fT07n11dnUwqlYqIxia3nz6v7oo/i+TLzSP/9tcyqR7W
+        X++zi9v7z+uvj8mHCSbzUmCmFcZGUblOueVGWPywaIoi6n4tBUat0uK0kPEpzTXs/ytqLZfcgrbg
+        hREnE7WqhJ7M20mhMllByB4MBJGml5fTq9ns+nxH+fXdw836x+yPhn+r8/RLsYzvv89uPyXr2/vs
+        XyzlkMd11OgC9Nza2swZ84Pm17NM2ryJGyN0oiorKnuWqJI1rBf2cfnhApBMdxhnMgzs4GrZkfxy
+        4Azbv5PclsWOMl4Ht3L/moUqCrUCc3cXB4plGwCdmYPJKnsbDICWKZsLmBbbfSIjSZz5sVS3uGX0
+        D35JOINj0yI9Ftgth5LkYk8t06JWjtvEJtGytlJVR6u7BQFU6YxX8pG/CQqIAYsUPVoxtxgQsYQz
+        H03xq1vmwjVZk9m0SIRc4jzeRt7BAGzXNWWXu5EF6ZSkFRFPS0oKLlc8nSB6Xxk7exJQKjaHP5lX
+        yF8UEfphk5CeDWxn3H1BukcQUV+w/8E4BDBgsMqDWAdjEqtl+NvFW4LEwGOlOZJ4MCFb0JaNv5JT
+        WcHLYLIcDNBcqXCWdzBApTGNOMj3Dz9VxzSsD7aqKWOfSQ8JscPFeBr2wI2RWSVEMItvgC3rL4FY
+        8yrJw4noeS3zn5zX8CzYFogFZFyoOBgTFzpzwJaZnPur0UYhtSYJxNsSoMUi6BaItxFgdUC/ceoT
+        cIPHbW3hQsH073ms7U6g4FXW8CychA2QLiuUKhl/fLFCOzxmByLwVJpqGTdhE/PApB34ogj5J9wR
+        DMhBgKu6ni/pXmGkUSXnzFSW8qWa53B6h9sKscAiKA52xdD3l0u3122DeC0b7hd/mXWSQp1Gd5v1
+        +o/ldW+rYK7V81j7S81tThkWYmuuRajNdDjWxnjqPp2dnbW54O5ZUgodMIt4GrBcJznK61D6tz0P
+        lWPJrXv+LEj9FM+hQvE02FlsgIB7Fwi1B08b+1GNej2Y4g42ppeyQNdCVeHuiIE4llMpKxcyOeSt
+        eHiYb0Hbj0ZWiTjheN4gKqxMJOIET3byABT5IpwVPQ3bQ4/IPxMLgZAJdkpaeF7LfFcgFXWh1kEz
+        5AhJiUQLNKjSiFs8SmfT2fR0enk6nf19fjE/v5lfXP3AnKZGD+ync367pjl1Y/L9U2bT+fScpiD9
+        d7GCT+hKPd8I2n1jUscJEGPyAfL7gJjv6SX9BJEUcPqdqD1Ol+Xu3f46DLaTq1LUqNP6x7mRj/g8
+        3aqxEtVUOB0MrrjFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kVizXhsyGSjiSv5ILcWUg256Rb4
+        R/4gvJRaq67Z6JsLXR5G27DreKbS8LgQw4CqRdVpON6GTERlNmbwDQDa8mj6lgncl1QseFPYyL+V
+        qJ2KniwarHBHoUuYgXpe1G7tOiveIOSq/R4pK/rPaLhYUdaR9w6rHgT1Z4FCVlGryPzTcLieu8D6
+        xf4XN4StUDW2/YsWdJ1ur0kR4Gj1eI0jFIcdsW8Qj9tC733iJn7vE7/3id/7xL7TTtffnj5xJewK
+        DdNRNh0/b/ts/fQf1cdD9xUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:03 GMT
+      etag:
+      - W/"6ac969530a81c94bb7b130d3516101af"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:4245FF9:4EC08C7:5ED66012
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3680'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:20:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C919:3CF32:42460B5:4EC09B4:5ED66013
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3679'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_list_multiple_revisions_different_packages.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_list_multiple_revisions_different_packages.yaml
@@ -1,0 +1,4894 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:04 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F6E3D:C5766E7:5ED66013
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3678'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:04 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F6EB7:C576748:5ED66014
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3677'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821364,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEzNjQ=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:20:04Z","updated_at":"2020-06-02T14:20:04Z","pushed_at":"2020-06-02T14:20:05Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:06 GMT
+      etag:
+      - '"697a130de0b3804242a98938a62f6f29"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F6F47:C5767EE:5ED66014
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3676'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"dcc4393cfd0718886b8f27cbd05efcd4be24aaf5","node_id":"MDY6Q29tbWl0MjY4ODIxMzY0OmRjYzQzOTNjZmQwNzE4ODg2YjhmMjdjYmQwNWVmY2Q0YmUyNGFhZjU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/dcc4393cfd0718886b8f27cbd05efcd4be24aaf5","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/dcc4393cfd0718886b8f27cbd05efcd4be24aaf5","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:06Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:06Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:07 GMT
+      etag:
+      - '"0775e208efbc542eda0e65b8bcdaa1f4"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F72E2:C576C40:5ED66016
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3675'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bMBD9lUBnJ5JleYmBoj10QQ9x4DZpqxSFQVEjiS5FqiTlxDby752RlSb2
+        oY2C9JaLIZF6wzdvFo63nmIleFOvZNaB8Xoe12UpnDfderZguJFyHg1OBzxLg3F/MpmMkkkWjnmS
+        BkPIeBolEEaMZUOEKp3CQqQIOnsbj+bhqUu+yuBsGUfnbz/enG3i4Lz8tIw38835xWx5Vc6vZ5t3
+        uJeH8bIoz5bpMqa1r1/KOJwHcXm5nn14X1wtL1/t8WK1K7Qhhi33zwUrmDl6tzJa4ZdQMiGRBPLH
+        5ROg5Tc5LZ6gc/hByhy5HAZhcByMjoPwoh9Nw2AajK682zsFSI3/dkQJ1rKcSHxUwgkmxQaOkBY7
+        MlBpK5w2ayTqDOA3d5HoZ8FpmoWD8XgSRuN+NJxAGoanbJwk0YSPcWeSjgcQILA2JEDhXGWnvs8q
+        cZILV9QJCeA3R/glOAy5NnAsRXLswDrr0+9iUa6JiQXnI8gnDtZ/9Nmo3zMevktG63dIQoKAcguu
+        a4VpHPS8FRiRCc6cwPRANXfvgHmaMWmh5xlglra8WlmRK9zpefTAXG1Qf1VL2fMqtpaaIYheb5/P
+        zSe4WLhSLvZVfhDexwR2d+gTZLUH5z45tbq67bdxtRib+wYgdS4ocLZoqhz3qP2MhsPRYL8dzUdf
+        vs0kX8b92UW8IRsrzHFz6E2zaMO2WmoLhmvlMJ2awqn9xvLr1asILeSmtdF0vH8VHdmy/j3Pv8fw
+        /rtMS6mvEXtIdb+m98z7f0DIavcsVN7dAIK2vnYFoE5I/5acFtgnulhqAFvsJNhZREomLEpsIO1i
+        pIUgmWuFPLZNC2ts1YnlRlRU2p1o7QHRkDY5U2LT9IhOhhBIKdn01C4uNQAEwgqzqxNyh9j6lREr
+        xtckgwEOYoWadrd2AEVjbl3RxXSJESeFhYMFS0sqs6ZdHl6QLyXYXqsvJditcl5KcHdpYTPbq95H
+        lWDFDPUNb/r9BxbkQgr1E19wUgSZPcfklximeIGD35//BXRhPbDcceCgKfLOFhKujHbA3YMZrF1p
+        RzRQLJF7E9qvWtClgTeBq+0CqfGdw6AybTg0I5/E9kccdZahiM3NfdNqdH8mnvD3Pv348fhAJOzI
+        jVfkw+1vmcz+pFkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:07 GMT
+      etag:
+      - W/"8f4c1e683d0350e7532f783bd0d34163"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7530:C576EFC:5ED66017
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3674'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:07 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F759F:C576F8F:5ED66017
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3673'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/dcc4393cfd0718886b8f27cbd05efcd4be24aaf5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY6bMBD9lchnEhyHBIJUqYfdVntIorS7XZGqigY8gBGGyDbbhij/3nHTQ3vb
+        ldqLhecx8968GV+YrYGlTBZFtFgvilLyeJ4kySpPShEXueRLLAsZ5SgigHLJAtb1Eo9KUtLmLlvt
+        xdrlzy3fNFm0u3v4sRkzvtOfmmzcj7vHbXPQ++/b8Z6wSmRNrTeNbDIfe/6iM7HnmX46bz9+qA/N
+        0zsqPpiWCtfOnWwahnBSs0q5eshnRa9Dg6fehhodWNcbnLYqnzq0zob+PB71WQJh6EJKCilDK8Le
+        0FrtdHv8W8If9K8hvpG+hRMGV/eGpRfWgUZq/nMNNZjJ/YvpO3IENSjvCc2JwjP04feVD3pP6Afq
+        2acJLviUr6ZcPM6jVPCUrw7sGrCbIof/kcIZJAWX36s0L/lalmIRx4mI4nm0TFAKsYY4z6OkiAlJ
+        ZLxA/m+n7TXY8NXcZIxGa6Hy1j10yilo1YgTv0CTX3umaMXOpPEEBjtnWfr1W8Be0KhSFeAUzYY6
+        vt2RHkMJrcWAGQTrITZ0VlUdIQHzH+AGQ1Td0La+5LntgZL89Xr9CYATPcmEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:08 GMT
+      etag:
+      - W/"8055c3db92c0c54b13e275310c52d535"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:06 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7672:C57707F:5ED66017
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3672'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["dcc4393cfd0718886b8f27cbd05efcd4be24aaf5"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"071601c8f9059267fb2e4fd0d5254dcc0584f19a","node_id":"MDY6Q29tbWl0MjY4ODIxMzY0OjA3MTYwMWM4ZjkwNTkyNjdmYjJlNGZkMGQ1MjU0ZGNjMDU4NGYxOWE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/071601c8f9059267fb2e4fd0d5254dcc0584f19a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/071601c8f9059267fb2e4fd0d5254dcc0584f19a","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:08Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:08Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"dcc4393cfd0718886b8f27cbd05efcd4be24aaf5","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/dcc4393cfd0718886b8f27cbd05efcd4be24aaf5","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/dcc4393cfd0718886b8f27cbd05efcd4be24aaf5"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:08 GMT
+      etag:
+      - '"c009e97ffc9ed126aeb57c106fccae1f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/071601c8f9059267fb2e4fd0d5254dcc0584f19a
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F76E2:C577111:5ED66018
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3671'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnglMIkGZGBSpZTE0FS+SP59oojiP7gRoQ/70PdezSoctd7jvv
+        nhtLYFn9yMwdSJN5kBkhsSfWRwOtN9SKtVi+hyaI06Hcr3df4noo9v1bd+zFRW4ad9yKi/p4vZpN
+        MxJ4Th1BDnHINedy8NNPj+6spjoGnmCINAJIMzHBpPNqgpAx80e2bRiNpA6QE0TXv72iOoFGVt9Y
+        dpKGjNbl/GWurSlWz1VVLVVlZyutTLEAq02pYFZKaRdkhuMARJBH8Pi/pj8/M/+zzf3+DZPgIUF9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:08 GMT
+      etag:
+      - W/"425b3ce4587a1aae7d2bc9fbe4fde311"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:06 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F77A7:C577207:5ED66018
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3670'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "071601c8f9059267fb2e4fd0d5254dcc0584f19a"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngp0oCSQzKlDJYmoqWCInvtRGcRzZB2pA/Pce6tilQ5e3vPvu
+        fXcWoGfVMyM3oHTkTkWEwF7Y6DU0VlMrN7J4d7WT52N22Oy/5O0oDuPbcBrlVW1rc9rJa/vxetPb
+        eibwEgaCDOIUK87VZJefFs2lXXbe8QCTpxFAmvEBFoNtFwgRI39m07hZK+oAOUF0/dvLt2fokFV3
+        Fo2iIbFKCpF0674UeZkWq75NIeu10HmaZ7rrRL7O+qRUZIbzBESQh7P4v6Y/PyP/s83j8Q0AzvhV
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:09 GMT
+      etag:
+      - W/"880f10aba3c6142fa7f9e0b65e64c09f"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7804:C577274:5ED66018
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3669'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:09 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7965:C57742B:5ED66019
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3668'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__otherdataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821384,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEzODQ=","name":"test__otherdataset","full_name":"metastore-lib-tests/test__otherdataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__otherdataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/deployments","created_at":"2020-06-02T14:20:10Z","updated_at":"2020-06-02T14:20:10Z","pushed_at":"2020-06-02T14:20:11Z","git_url":"git://github.com/metastore-lib-tests/test__otherdataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__otherdataset.git","clone_url":"https://github.com/metastore-lib-tests/test__otherdataset.git","svn_url":"https://github.com/metastore-lib-tests/test__otherdataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '7043'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      etag:
+      - '"f2f8521e38078414bd5e0c1d7f38d74a"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F79DD:C5774BA:5ED66019
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3667'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__otherdataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md"}},"commit":{"sha":"37c1cc591de53c162436d39fc3f0e3ada9ae15d5","node_id":"MDY6Q29tbWl0MjY4ODIxMzg0OjM3YzFjYzU5MWRlNTNjMTYyNDM2ZDM5ZmMzZjBlM2FkYTlhZTE1ZDU=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/37c1cc591de53c162436d39fc3f0e3ada9ae15d5","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/37c1cc591de53c162436d39fc3f0e3ada9ae15d5","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:11Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:11Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1815'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:12 GMT
+      etag:
+      - '"08cef060cc21eb5499db8b01f819bf0e"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7CCC:C577843:5ED6601B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3666'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1Xy27bOBT9lUBrJ3pZdmygaDFwC3QhF51x2rEHhUBTVxJditSQlFPbyL/3klaa
+        2Is26mR22RgSqXN47pPXB0+QGrypVxNtQHkDj8q6ZsabHjxdEdyIxzSkNJmEOSQxDUfRMB7l8aSg
+        cRFATHIyIRAmeYJQIXPIWI6gdLYcfYwmZv2ZB+lmOfwwe/8t3ZfBh00aL/fvNsv9TZJ+/pPPF/NN
+        ulju5rM0Ws3SZFWn+9XmD55G774uF7xaLd6Gq9nNqxNdpDWVVFZhp/2vilREXbzdKinwS6gJ4ygC
+        9ePyFdjlN6VdvELj8IOcGGtyFETBZTC6DKJFOJxGwTQMV97dvQesN/63I2rQmpRWxHvBDCOc7eEC
+        ZZELBY3UzEi1Q6FGAX5zH4mwCCZ5EcXj8XU0HIfD5BryKJqQ8Xo9vKZj3LnOxzEECGyVdUBlTKOn
+        vk8adlUyU7Vr6wDfHeHXYDDkUsElZ+tLA9po3/5mmTQVKCtGg/ER51sZ2n/y8ejC5z3/mJLa75GK
+        FgLCZFS2ApM5GHhbUKxglBiGSYI+Pb4DZmtBuIaBp4Bou+W1QrNS4M7Asw/EtAqjIFrOB15DdlwS
+        BNnXu2e19DesrEzNs1NfP4rzEyN8PPc3nKvPjv4vadbXeL8LsMYgPfQDLktmI6grV/S4Z7vRKElG
+        8Wl3+jj69Pec080ynC+We8uxxXxX5wa5RR11xdNqUFQKg3nl6qj1HfPr7ashMpSq43AN8Fc1aLm0
+        /6Dz55F8+K6QnMtbxJ5LPS3xE3r/BwhVHZ+ZKPsTIOjgu+aQWf47azTDttGHyQEO2FWw0bDcUmh0
+        sYK8D0kHQTG3AnUcXEdzXO1aU8UaW+O9ZJ0AkUiqkgi2d82iFxECbUq6FtvHJAdAIGwxu3ohj4iD
+        3yi2JXRn3aCAAtuiT/uznUGRzOwae0/dYMSth5mBjOS1LTPXN8/vy5cS7G7ZlxLsVzkvJXi8tLCZ
+        nVTvk0qwIcr2DW/6zxcsyIwz8RVfcHAEXjzTILhWRNAK58Af/xTsnfWIvP/kYefKezqU3ShpgJpH
+        I1m30k1sIMianwxs/7bMXh14H5hWZ6iOHs0GUUhFwU2AHJuglSmLAl3p7u9vnacezsQTft6te83M
+        Z67C1uwMs2bcfQc6+inwcQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:12 GMT
+      etag:
+      - W/"138a339be757823371d054e106c40f95"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7E7E:C577A52:5ED6601C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3665'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"otherdataset\",
+      \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"05b0607cc662220661603d446d71eef5c4719212","size":99,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/05b0607cc662220661603d446d71eef5c4719212"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '686'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:13 GMT
+      etag:
+      - '"af7fbe6e808b96cd8a71d201501f97eb"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7EFF:C577AD7:5ED6601C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3664'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/37c1cc591de53c162436d39fc3f0e3ada9ae15d5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY6bMBD9lcjnJBgDISBVqqrsSnsgq7ZZraCqogGG4NRAZJtVQ5R/33HTQ3vb
+        ldqLhecx8968GV+YaYGlLIgrv6qixK8xCip/JcJgVQdJUwUNxwBqSAD9qI7YnPVDjXtZU1K2yVef
+        RWLLZ8WzYx4+bh5+ZtOBPx6zIJ/uj/n0FGXPX9R2tz1mu/y83WSi2GRR0WVTcfykMnH/I9+pttjd
+        +cXm6QMVH7Wiwq21J5N6Hpzk8iBtO5bLaug8jafBeB1aMHbQuFCyXFg01nju3O8H26KugWC0HuV5
+        lNRJgt/RXWs7tf9bxR8K3sh9430PLYy2HTRLL6yHDsmCry20oGd3L3royRfsQDpnaFoUXqILfzy4
+        oHOGfqC2XZrggi/4asHFzg9TwVPfL9h1zm6KLP5HCquRFFx+L5Tf8KRuRBDHaxHGfhitsRYigbgs
+        w3UVE7Ku4wD5P5+5k2G8N9OTNx0aAwfn3kMvrQQlJ5y5NZr9WjhJu3YmmSfQ2FvD0m/f5+wFtWxk
+        BVbSeKjp2x3pVTSgDM6ZRjAOYmNv5KEnZM7cB9hRE1U/KuVKntUAlOSu1+srVjUkpo0DAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:13 GMT
+      etag:
+      - W/"3fb79b5ec74332122af051d39a347437"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F7FC2:C577BB3:5ED6601D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3663'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["37c1cc591de53c162436d39fc3f0e3ada9ae15d5"],
+      "message": "Initial datapackage commit", "tree": "fa0f09c21c1c7f2607347dd929f58fc34575b5fc"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4","node_id":"MDY6Q29tbWl0MjY4ODIxMzg0OjYxY2U2ZTNiZDgwYWEwZTRlYTliYzQxMTg2MjJkNGE0YjI5NWZhZTQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:13Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:13Z"},"tree":{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc"},"message":"Initial
+        datapackage commit","parents":[{"sha":"37c1cc591de53c162436d39fc3f0e3ada9ae15d5","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/37c1cc591de53c162436d39fc3f0e3ada9ae15d5","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/37c1cc591de53c162436d39fc3f0e3ada9ae15d5"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1207'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:13 GMT
+      etag:
+      - '"aa1b94a3b09e12404f81ec51a0117184"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F803B:C577C60:5ED6601D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3662'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBRF/8UzYFKToGRGpUWymBoES+TYL9gojiP7gQqIf+ehjl06dLnL1bn3
+        3FmEjlWvTNyCMol7lRAim7AhGGicoVauZPHlay9P+8V29fktb8f5dtj0h0Fe1Lq2hw95aXfvN7Ou
+        rwSeY0+QRRxTxbka3ezo0J7bmQ6eRxgDnQDSTYgw7V07RUiY+CubJqCFaBTVgJw4An6rhfYEGll1
+        Z8kq+hJLnWmdl5mBXOiseFuIwoiy06Kbg1BGlQqy3OQkh9cRiCAV7/DfZX9mE/+z0OPxBJRnRxaD
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:14 GMT
+      etag:
+      - W/"9ca98f93ededa07d3e7f815dcfb5f7c7"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8115:C577D6F:5ED6601E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3661'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBRF/8VzwUnqRpAZlbaSxdRUZYme4wc2iuPIfqAC4t/7UMcuHbrc5erc
+        e64i4U4098zSIdgsA2TCJB7EGC123nKrV7p+D23Qh0+1Wb1+6cu+2Ixvw3bUJ1i3bvuiT+bj+WLX
+        7ZnBYxoYckRTbqSEyc/3ntzRzPsYZMIp8gkS38SEs8GbGWGmLO/ZdZEcJgtcI0nmGPitFs0BexLN
+        VWQH/FWXPdb4aOyiAChQISxNr8pyUVeVVaBMtXzaASqWo/OETLBK8PTvsj+zWf5Z6Hb7BgAla+uD
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:15 GMT
+      etag:
+      - W/"d15a80af6baf835ec5e488e80f446376"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F818C:C577DFF:5ED6601E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3660'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:15 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F831A:C577FD0:5ED6601F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3659'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdLEwGJ72O0CBbJBix529yJQEi3RlkSVpOw6Qt69/5CS
+        LbtO4jg85pLYNPnNcDgzHE47kuloOrm+uZlcfri+OhtVKhURjY3uPn9Z3Rd/FMnX2wf+/a9lUi3W
+        3+bZ1d38y8O3+Z8fR5jMS4GZVhgbReU65ZYbYfHDrCmKqPu1FBi1SovzQsbnNNew/6+otVxyC9qM
+        F0acjdSqEno0bUeFymQFIQcwEESaXl+Pf51Mbi73lF/fL27XPye/N/x7nadfi2U8/zG5+5ys7+bZ
+        v1jKIY/rqNEF6Lm1tZky5gfNh4tM2ryJGyN0oiorKnuRqJI1rBf2afnxCpBMdxhnMgzs4WrZkfxy
+        4Aw7vJPclsWeMl4Ht/LwmpkqCrUCc38XR4plGwCdmYPJKnsbDICWKZsLmBbbfSQjSZz5qVS3uGX0
+        D35JOINj0yI9Fdgth5LkYo8t06JWjtvEJtGytlJVJ6u7AwFU6YxX8oG/CQqIAYsUPVkxtxgQsYQz
+        n0zxq1vmwjVZk9m0SIRc4jzeRt7DAGzXNWWX+4EF6ZSkFRFPS0oKLlc8niF6Xxk7BxJQKjaHP5pW
+        yF8UEXqxSUjPBrYz7qEgPSCIqC/Y/2gcAhgwWGUh1sGYxGoZ/nbxliAx8FhpjiQeTMgOtGXDr+RU
+        VvAymCwHAzRXKpzlHQxQaUwjjvL940/VMQ3rg61qythn0mNC7HgxnoY9cGNkVgkRzOIbYMv6SyDW
+        vErycCJ6Xsv8J+c1PAu2BWIBGRcqDsbEhc4csGUm5/5qtFFIrUkC8XYEaDELugXibQRYHdBvnPoE
+        3OBxW1u4UDD9ex5ruxMoeJU1PAsnYQOkywqlSsYfXqzQjo/ZLRF4Kk21jJuwiXnLpB34ogj5J9wR
+        bJFbAa7qer6ke4WRBpWcM1NZypdqnuPpHW4nxAKLoDjYF0PfXy7dXrcN4rVse7/4y6yTFOo0utus
+        138or3tbBXOtnsfaX2puc8qwEFtzLUJtpsOxNsZT9/Hi4qLNBXfPklLogFnE04DlOslRXofSv+15
+        qBxLbt3zZ0bqp3gOFYqnwc5iAwTcu0CoPXja0I9q1OvBFHewIb2UBboWqgp3R2yJQzmVsnImk2Pe
+        iseH+Q60/WRklYgzjucNosLKRCJO8GQnD0CRL8JZ0dOwPfSI/DOxEAiZYKekhee1zHcFUlEXah00
+        Qw6QlEi0QIMqjbjFo3QynozPx9fn48nfl1fTyXg6vvqJOU2NHtiTcy4vaU7dmPzJKeNbmoL038UK
+        PqEr9XwjaP+NSR0nQIzJt5DftojpgV7SE4ikgNPvRe1puiz37/bXYbCdXJWiRp3WP86NfMDn8U6N
+        laimwulgcMUtHhuoWbZDfV3WA3JuIp9JRlOrG/QcaaTWai4Sa4Zj20w2mLiSC7mzkGrITbfAP/K3
+        wkupteqajb650OVhtA27jmcqDY8LsR1Qtag6DYfbkImozMYMvgFAWx5M3zGB+5KKGW8KG/m3ErVT
+        0ZNFgxXuKHQJM1DPi9qtXWfFG4Rctd8jZUX/GQ0XK8o68t5h1UJQfxYoZBW1isw/DYfruQusX+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYEfsG8bAt9N4nbuL3PvF7n/i9T+w77XT9HegTV8Ku0DAd
+        ZNPh87bP1o//AZNR8t4VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:15 GMT
+      etag:
+      - W/"ed6f93d91b10c5fe391b928b72600a20"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F838E:C578063:5ED6601F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3658'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngp0oCSQzKlDJYmoqWCInvtRGcRzZB2pA/Pce6tilQ5e3vPvu
+        fXcWoGfVMyM3oHTkTkWEwF7Y6DU0VlMrN7J4d7WT52N22Oy/5O0oDuPbcBrlVW1rc9rJa/vxetPb
+        eibwEgaCDOIUK87VZJefFs2lXXbe8QCTpxFAmvEBFoNtFwgRI39m07hZK+oAOUF0/dvLt2fokFV3
+        Fo2iIbFKCpF0674UeZkWq75NIeu10HmaZ7rrRL7O+qRUZIbzBESQh7P4v6Y/PyP/s83j8Q0AzvhV
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:15 GMT
+      etag:
+      - W/"880f10aba3c6142fa7f9e0b65e64c09f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8408:C5780ED:5ED6601F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3657'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/071601c8f9059267fb2e4fd0d5254dcc0584f19a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJFZs+QqFFrKELThh6S7BKSXI9iiW40uQ5N1NQ/59R6QL7VsC
+        6YuRZjQ6c84c60R0xUlCaDgL6KyIREz92A1CkbvARElL3/VZWRTUj5iYxZyMSdeXsJUlFqXzLHhy
+        Y5OvG5rWGVvNH9/T3xld1d+89Dl7S9cp29T7t+Xz/risyzarvzfLxWafLp5maf1CN4tlnc5f2HKR
+        va/WD1/w8kE1eHFlzEEnjsMPcrqTphryadG3joJDr50WDNemVzBpZD4xoI127He7bY8lxxwYB4sc
+        rGgl5m6gVpm22f7bwl/w1wBfQG/B5IOpekWSE+l4C0j+R8UrrkYPr6rvUBFoubSa4JwwPAUb/rqz
+        QasJHkDOtsylLp3QYELd5xlLXJrQaEPOY3LpyMB/hDAKsIPTHyuFIUSBxwTzcuoVQgRxyULmFzSH
+        EEB4bg4FzwP/vtO2PWjnamwUpgWt+c5K99hJI3kzsu458GKP0dFFNuzxwBV0RpPk5ydB/B2YFyO1
+        Eq0VRVGQR8INi7ykPoiiZDm4jHNxZ4Kfdr4B/W52vhrz/GtMXkFJIQtuJPoXXXHZAz4YgjcaxkQB
+        1zZFhk7LXYeZMbELbgaF4+iGprGyH5ueY5Hdns8f45hIM6gEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:16 GMT
+      etag:
+      - W/"c009e97ffc9ed126aeb57c106fccae1f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F846E:C578166:5ED6601F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3656'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=071601c8f9059267fb2e4fd0d5254dcc0584f19a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv20h2I9sKjNGYrTiwjnUXc0Ih6OPYVipLxlIastL/PrkNrMt2
+        kXVj7ELioCOd9+E9Rw+RYR1Es0gyz3om7lgDk42zJjqLeubbX2dcy0IihywXkjKZUaBJcsFxnpI4
+        S4mUkEJGMMU05ykOpZz6GkRoehZtBx2ett73boYQ69WkUb7d8omwHRqgtw514JnzdoBzrfi5B+cd
+        Gvf1utuPmA48EtZ4MCFxzP12gPoNzuIUxyKvKSY0SbOaJzCtJZYkIVMpBCb5tI4pC2St7/T6R6gX
+        QKegcG05OlXxJ96AEPSOCF5tSyiFRh6HfqM50u6MtkweQQxsd+jN1sFwMPypTae48ieG+H0/jmSt
+        NAR7DsrhAHa2KYvFdvkl1uUmxF1MVlfv8bK61rIoXXn5lN+vqut7WS02q+qD+qjmvFCXza0pi3k2
+        RmUxrsVuWd3Y5yo3rbx6d88r/f3lZ7IRF0v1fH9Ob80YVZ/6EAUkMMJKZZrAxMM4ptNwttbK3Llo
+        9hA50PV/NeNhKv4Gz6uGa/xfL8T/7d96fPwGGYqQJOAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:16 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F84D9:C5781E8:5ED66020
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3655'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:16 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8561:C57827E:5ED66020
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3654'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdLEwGJ72O0CBbJBix529yJQEi3RlkSVpOw6Qt69/5CS
+        LbtO4jg85pLYNPnNcDgzHE47kuloOrm+uZlcfri+OhtVKhURjY3uPn9Z3Rd/FMnX2wf+/a9lUi3W
+        3+bZ1d38y8O3+Z8fR5jMS4GZVhgbReU65ZYbYfHDrCmKqPu1FBi1SovzQsbnNNew/6+otVxyC9qM
+        F0acjdSqEno0bUeFymQFIQcwEESaXl+Pf51Mbi73lF/fL27XPye/N/x7nadfi2U8/zG5+5ys7+bZ
+        v1jKIY/rqNEF6Lm1tZky5gfNh4tM2ryJGyN0oiorKnuRqJI1rBf2afnxCpBMdxhnMgzs4WrZkfxy
+        4Aw7vJPclsWeMl4Ht/LwmpkqCrUCc38XR4plGwCdmYPJKnsbDICWKZsLmBbbfSQjSZz5qVS3uGX0
+        D35JOINj0yI9Fdgth5LkYo8t06JWjtvEJtGytlJVJ6u7AwFU6YxX8oG/CQqIAYsUPVkxtxgQsYQz
+        n0zxq1vmwjVZk9m0SIRc4jzeRt7DAGzXNWWX+4EF6ZSkFRFPS0oKLlc8niF6Xxk7BxJQKjaHP5pW
+        yF8UEXqxSUjPBrYz7qEgPSCIqC/Y/2gcAhgwWGUh1sGYxGoZ/nbxliAx8FhpjiQeTMgOtGXDr+RU
+        VvAymCwHAzRXKpzlHQxQaUwjjvL940/VMQ3rg61qythn0mNC7HgxnoY9cGNkVgkRzOIbYMv6SyDW
+        vErycCJ6Xsv8J+c1PAu2BWIBGRcqDsbEhc4csGUm5/5qtFFIrUkC8XYEaDELugXibQRYHdBvnPoE
+        3OBxW1u4UDD9ex5ruxMoeJU1PAsnYQOkywqlSsYfXqzQjo/ZLRF4Kk21jJuwiXnLpB34ogj5J9wR
+        bJFbAa7qer6ke4WRBpWcM1NZypdqnuPpHW4nxAKLoDjYF0PfXy7dXrcN4rVse7/4y6yTFOo0utus
+        138or3tbBXOtnsfaX2puc8qwEFtzLUJtpsOxNsZT9/Hi4qLNBXfPklLogFnE04DlOslRXofSv+15
+        qBxLbt3zZ0bqp3gOFYqnwc5iAwTcu0CoPXja0I9q1OvBFHewIb2UBboWqgp3R2yJQzmVsnImk2Pe
+        iseH+Q60/WRklYgzjucNosLKRCJO8GQnD0CRL8JZ0dOwPfSI/DOxEAiZYKekhee1zHcFUlEXah00
+        Qw6QlEi0QIMqjbjFo3QynozPx9fn48nfl1fTyXg6vvqJOU2NHtiTcy4vaU7dmPzJKeNbmoL038UK
+        PqEr9XwjaP+NSR0nQIzJt5DftojpgV7SE4ikgNPvRe1puiz37/bXYbCdXJWiRp3WP86NfMDn8U6N
+        laimwulgcMUtHhuoWbZDfV3WA3JuIp9JRlOrG/QcaaTWai4Sa4Zj20w2mLiSC7mzkGrITbfAP/K3
+        wkupteqajb650OVhtA27jmcqDY8LsR1Qtag6DYfbkImozMYMvgFAWx5M3zGB+5KKGW8KG/m3ErVT
+        0ZNFgxXuKHQJM1DPi9qtXWfFG4Rctd8jZUX/GQ0XK8o68t5h1UJQfxYoZBW1isw/DYfruQusX+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYEfsG8bAt9N4nbuL3PvF7n/i9T+w77XT9HegTV8Ku0DAd
+        ZNPh87bP1o//AZNR8t4VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:16 GMT
+      etag:
+      - W/"ed6f93d91b10c5fe391b928b72600a20"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F85D4:C578318:5ED66020
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3653'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW0/jOBT+KyjPhbhpkl4kNLsSCLFSitDCsGU1qhznuHHrXNZ2CqXqf5/jNB1o
+        H5gGsW+8VK2T7/g737l27eQ0A2fkZFQbUE7HYUWWCeOM1o5OKT4g/W5IumzAhyQYemGfxx74PCFJ
+        4AV+whgJBj7vDilC8yKBqUgQFF1MwltvaOIHSaL5xL+5uH6OXibkZv5nL7qbPEUPkf84XzyN7xar
+        8TzJJvO/5PjqcRFd3Xaj+T15vBrPo4t7f3w1eb55uDzf40UrkxbKMmy4/53SlKqTy6UqcnwTMiok
+        kkD+eHwG9viPmT08Q+fwhYQa67JHPHJKwlPi3XX9kUdGZPDobHYKWDX+tysy0JrOLInrXBhB5Qly
+        oiVlCzw9aULQcYwCfGcXiX4fBmHP534vJj3GeThM/L4fMBJDH4D3vBgYjcMAPayUFSA1ptQj16Wl
+        OJsJk1axFcBVUBbazcBgyAsFp1LEpwa00a79nE6zlSWjwbgIci0H7R59N+r3iZdvldBuiyS0EMjN
+        lBVVjmlMOs4SlOCCUSMwPVDN7W/APOVUaug4Cqi2j5wq12KW45OOY79QUynUP6+k7DglXcmCIsj+
+        3Hyemx9wMTWZnO6r/Ca8xwR2e+kHZNUH9344tdq67TZx1Rib1wYgi5mwgdNpXeX4zLafMAjC3n47
+        ug2//zOWbD7pju8mL9bGEnNcHXpTH2qvqZZKg2JFbjCd6sKp3Nryt+W5jxZmqrFRd7zfFZ21pd1X
+        nu/H8PU9XkhZPCH2kOp+Te+Zd3+BkNX2u8hn7Q0gaO0WJgXUCelvrNMC+0QbSzVgjZ0EO4tIrAmN
+        EitI2hhpIEjmKUce67qF1baqWDMlSlvarWjtAdFQoWY0Fy91j2hlCIE2Jeue2salGoBAWGJ2tUJu
+        EWu3VGJJ2crKoICBWKKm7a0dQNGYWZV2MN1jxK3CwsCUJpkts7pdHg7IrxJsxupXCbarnK8S3A4t
+        bGZ71XtUCZZU2b7hjP7dbYe4ivu9Ie6FCS5Lg8EgjAfc67M4IQFwlvgxeD6l/BO3w90Ib3Hz+1Ov
+        xeZy9J2bH9iwplLkCxQLtQLJP2MzjhXNWYqL8a//Tda1N5ZbLmR2y97ZQsKlKgww82ZHbU6aFRZy
+        Gsu9Dfa/StihipPSVHqK1NjWYch5oRjUK7HE8WA5FpxjktWbzXOdQz/sPvt6w/tz7Pi/Dwci4cSq
+        vbI+bH4Cdd2ur3kOAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:17 GMT
+      etag:
+      - W/"53a2c4fe9d63cdffd37b8e007f04317e"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8648:C57839E:5ED66020
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3652'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:17 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F86D9:C57843A:5ED66021
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3651'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/071601c8f9059267fb2e4fd0d5254dcc0584f19a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJFZs+QqFFrKELThh6S7BKSXI9iiW40uQ5N1NQ/59R6QL7VsC
+        6YuRZjQ6c84c60R0xUlCaDgL6KyIREz92A1CkbvARElL3/VZWRTUj5iYxZyMSdeXsJUlFqXzLHhy
+        Y5OvG5rWGVvNH9/T3xld1d+89Dl7S9cp29T7t+Xz/risyzarvzfLxWafLp5maf1CN4tlnc5f2HKR
+        va/WD1/w8kE1eHFlzEEnjsMPcrqTphryadG3joJDr50WDNemVzBpZD4xoI127He7bY8lxxwYB4sc
+        rGgl5m6gVpm22f7bwl/w1wBfQG/B5IOpekWSE+l4C0j+R8UrrkYPr6rvUBFoubSa4JwwPAUb/rqz
+        QasJHkDOtsylLp3QYELd5xlLXJrQaEPOY3LpyMB/hDAKsIPTHyuFIUSBxwTzcuoVQgRxyULmFzSH
+        EEB4bg4FzwP/vtO2PWjnamwUpgWt+c5K99hJI3kzsu458GKP0dFFNuzxwBV0RpPk5ydB/B2YFyO1
+        Eq0VRVGQR8INi7ykPoiiZDm4jHNxZ4Kfdr4B/W52vhrz/GtMXkFJIQtuJPoXXXHZAz4YgjcaxkQB
+        1zZFhk7LXYeZMbELbgaF4+iGprGyH5ueY5Hdns8f45hIM6gEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:18 GMT
+      etag:
+      - W/"c009e97ffc9ed126aeb57c106fccae1f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8839:C5785EE:5ED66021
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3650'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["071601c8f9059267fb2e4fd0d5254dcc0584f19a"],
+      "message": "Set type to csv", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"687c4a3867649087bac5c82afe040af4a82c0474","node_id":"MDY6Q29tbWl0MjY4ODIxMzY0OjY4N2M0YTM4Njc2NDkwODdiYWM1YzgyYWZlMDQwYWY0YTgyYzA0NzQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/687c4a3867649087bac5c82afe040af4a82c0474","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/687c4a3867649087bac5c82afe040af4a82c0474","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:18Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:18Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Set
+        type to csv","parents":[{"sha":"071601c8f9059267fb2e4fd0d5254dcc0584f19a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/071601c8f9059267fb2e4fd0d5254dcc0584f19a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/071601c8f9059267fb2e4fd0d5254dcc0584f19a"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1181'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:18 GMT
+      etag:
+      - '"fea3e582460d06678814422094b36aca"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/687c4a3867649087bac5c82afe040af4a82c0474
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F88A1:C578655:5ED66022
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3649'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngp0oCSQzKlDJYmoqWCInvtRGcRzZB2pA/Pce6tilQ5e3vPvu
+        fXcWoGfVMyM3oHTkTkWEwF7Y6DU0VlMrN7J4d7WT52N22Oy/5O0oDuPbcBrlVW1rc9rJa/vxetPb
+        eibwEgaCDOIUK87VZJefFs2lXXbe8QCTpxFAmvEBFoNtFwgRI39m07hZK+oAOUF0/dvLt2fokFV3
+        Fo2iIbFKCpF0674UeZkWq75NIeu10HmaZ7rrRL7O+qRUZIbzBESQh7P4v6Y/PyP/s83j8Q0AzvhV
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:18 GMT
+      etag:
+      - W/"880f10aba3c6142fa7f9e0b65e64c09f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F895C:C578744:5ED66022
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3648'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "687c4a3867649087bac5c82afe040af4a82c0474"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWkfFJCFz1QKS1YmgdokuzgW7iuPIvlakVf87VzGyMLC85d13
+        77uKiL2o7pmkReiS9JAIo3gQY+iwcR23eq3zd197fdyr3fr1S1/22W58Gw6jPsO2tocXfW4/Npdu
+        W88MnuLAkCWaUiUlTG756cie2qUJXkacAo8g8UyIuBhcuyBMlOQ9m8bPHXCHJBni699eoT2iIVFd
+        RbLAQ3lZGAWPZV7k6jkrixbMkylX0GOmMugVlCuTqUKxGc0TMsEe3tH/mv78TPLPNrfbN+GqZO19
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:19 GMT
+      etag:
+      - W/"e0e53f8fe99e93f35df5cebf91e4b5b2"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F89B8:C5787B4:5ED66022
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3647'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:19 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8B21:C578960:5ED66023
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3646'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHG2SzBhbbw24XKJAGLXrY7kWgJFpiLIkqSdl1hPz3vkNK
+        lmw4H3Z4zCWxafIZDskZDt92ItPJfHZ9czO7/HBzdTapVCoiapvcfv22vit+L5Lvnx74j79WSbXc
+        /HGfXd3ef3u4+/rn5wk681KgpxXGRpGyudApt9wIi98WTVFEXYdSoNUqLc4LGZ9Td8MODqq1XHEL
+        5oIXRpxN1LoSejJvJ4XKZAVTB0iwRfO9vp5+nM1uLvdc2NwtP21+zn5r+I86T78Xq/j+n9nt12Rz
+        e5/9h6Ec9riOGl2AnltbmzljvtF8uMikzZu4MUInqrKisheJKlnDemNfVp+vAMl0h3ELh4Y9XC07
+        kh8OnGGHPcltWexNxs/BjTw8ZqGKQq3B3PfilWbZFkDb5mCyyt4GA6Bl7kREtHqPtEgS234q1Q1u
+        Gf3D6SScwbZpkZ4K7IZjknTEHlumRa0ct4lNomVtpapOnu4OBFClM17JB/4mKCAGLJroyRNzgwER
+        Kxzmkyl+dMtcuCYbWjYtEiFX2I+3kfcwANtNTTnmbrSCtEvSioinJSUFlysezxC9R8bO4RyUiu3+
+        T+YVshgFhV5uc9Kzse3W91CcHrZF4Bd24RgiIhk8LM9SbEJiCdcy/O1iL0GS4LHSHDk9pJ0dbsvG
+        X+mMWcHLkOYcD9xcqaC74HjgSmMa8aqAOGqTHdawPgirpox9hn1N6B1lyQPhCTdGZpUQIVd/y2xZ
+        f0XEmldJHtRKj2yZ/+TOEc9COkI4UONCxSGxuPeZY7bM5NzfoDYKPHcyQsgdG1osQjtCyK0Nq8Oe
+        JOcEMbcWcLtbHKqQXvRI1na7UfAqa3gW1MiWSVccCpyMP7xY1x0V0QMUFqim1TJugmfxAUt++IIK
+        OSrodgzUwYYr2p6vCI9brVEt6NarLOVLVdNRBjriTvSFt0LxsW+Jvr9cAh7tDCFbNlxJ/grsjAXc
+        me4O7L0Ym+xeaiEPW49k7S81tznlYliuuRYBXeqIrI3xgn68uLhoc8HdU6cUOmya8UCQuU5yVO0B
+        vWh7JErRklv3sFqQEykeWoXiach92TLB9ycioCceOD5ZNR4DIafveGMDpSygjagq6J0yQMemKmXl
+        QiaveZEelQR2uO0XI6tEnHE8ohAtViYS8QNtgA4EXhAi6HJ6IJyEKuWfpIVAKIXcMS08smVehEhF
+        XahN6EQ6olKm0QKSWBpxi2fwbDqbnk+vz6ezvy+v5rPp/HL6E32aGsLb030+Up+6MfnTXa6oCy6K
+        LoDwCTrY89LTgSctyVzgGJMPnF8HyvyAgPU0JSkQCXsBffKMVvt1wdEk+JWrUtQo+XpdwMgHfJ7u
+        1GqJairsFBrX3OIxg6pnaOrrux6QcxP5PDOZW91A8aSWWqt7kVgzbhtS3ajjWi7lzkAqR7dChRcX
+        BuOl1Fp1UqfXNbpcDdGy01tTaXhciKFB1aLqZjh2QyaiMttl8KoDuTzqvrME7ksqFrwpbOQfYiTm
+        QhSGvIujKXSJZSDFjcTeTtfxC0LHtveREqb/DLnHirKO/BmxailIHQYKqUatI/Nvw3EG3T3XD/a/
+        uCa4QpXc7i9a0MW7OyZFvENo8jOOUFt2xF6eHotS7yp1E7+r1O8q9btK7XV+ugcPqNSVsGuotKNs
+        On4g99n68X+YT0FZmRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:20 GMT
+      etag:
+      - W/"f19daf79d7fa4ed5b66f2ee201a6f7cf"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8B93:C5789EE:5ED66023
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3645'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBRF/8VzwUnqRpAZlbaSxdRUZYme4wc2iuPIfqAC4t/7UMcuHbrc5erc
+        e64i4U4098zSIdgsA2TCJB7EGC123nKrV7p+D23Qh0+1Wb1+6cu+2Ixvw3bUJ1i3bvuiT+bj+WLX
+        7ZnBYxoYckRTbqSEyc/3ntzRzPsYZMIp8gkS38SEs8GbGWGmLO/ZdZEcJgtcI0nmGPitFs0BexLN
+        VWQH/FWXPdb4aOyiAChQISxNr8pyUVeVVaBMtXzaASqWo/OETLBK8PTvsj+zWf5Z6Hb7BgAla+uD
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:20 GMT
+      etag:
+      - W/"d15a80af6baf835ec5e488e80f446376"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8C0F:C578A8D:5ED66024
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3644'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW4vaQBT+KzLPaiaTiyZQ6INSLOhim0WSUuQkOUnGzUUyk1274n/vGexC+6Zg
+        X0LmnJz5LucjZ6YqYCHz7Qx9dNJ8zgE4ughBmrm2PfeFyF1wUxF4BaDLxqztctzLnIbWi9jfikCn
+        u5qvD7H7tFid1u8lfzrEp1g8iyTayGRRvsW75VsSfavjqJbx+/a0jkqxPnx92XxZ8viw8ja7pEqi
+        7Se6fOhrurjS+qhCy4KjnJZSV0M6zbrG6vHYKatBDUp3PU5qmU40Kq0s89zvO11hnwO1UVs0Z9FQ
+        I6l9h7pKN/X+XxZ/MbgR+4p7DywMuup6Fp5ZCw2SBd8rqKAfLV/7riVfsAFpnKFtUXmKpvy5NEXj
+        DH1Ass2Y4IJPuD/hIrLdUPDQdhJ2GbMrI43/EUL3SAzOfwJVAC94kAk7s7NZIXw+c9xZngciKLx5
+        kTmuN/NSr8gevnNDQ1k3w5M3DSoFpXFv1UotoR6ZDB0he6Hq6Ooc0TxCj61WLPzxodGZkbjMC+wc
+        PSezfeE6fu4EpK7g6EAOAaDt5d7DNX7k+g4Cj8z1zbCXn2P2ir0sZAZaUpApHtcz0v+jgFrhmPUI
+        yrTY0CpZttQZM/MCeuhpKe1Q18b8X3UHNGSOl8tv1r8f0rcEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:20 GMT
+      etag:
+      - W/"aa1b94a3b09e12404f81ec51a0117184"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8C6D:C578AFD:5ED66024
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3643'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/datapackage.json?ref=61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft5HsOEodGKMNW0hgHWthc0Ig6OEcK5UlYykNWel336kNrMv2
+        IlvH2Bvp0Onuftz97yGxvIFklCgeeMvlHV9Db+OdTc6Slof61x5fc3TQgaCMDqVkLMsyyljKaF/l
+        OVPDFKAayHyYFlmaYSqvv2KRojhLtp3B0DqE1o8I4a3urXWot6InXUM6aJ0nDQTug+vg3GhxHsAH
+        T+K5WrlQQxdJPQQinQ1g0XeM/raD6g1LJTDoC3VBOaeQAy+EzNP0AllVznORFYOKQ45wdWjM6keu
+        F0wn0gjjBDm16E/ISIEljyBe0xzMRiKSJ78xJeV21jiujjg6vjsMaeuhO7T9aV4n9uY1bQn7Nsqz
+        0gawSYfi+AA7t56OZ9v5l9RMN2g3BeWTz/vF5D2dl9dGjad+evn0Z78or+9VOdssyg/6o74SSzvW
+        l+i5Gj7f0Z7t5uWNe850U6vJu3tRmu+Rt4ON7M91/L+0GFlEq/zUFsu4KWClU9qukUugNllU1cpo
+        e+eT0UPiwVT/m+ZRH38J6Y+UFlfuRf1/vm6Pj98AIecPwvkEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:20 GMT
+      etag:
+      - W/"05b0607cc662220661603d446d71eef5c4719212"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8CC0:C578B6C:5ED66024
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3642'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:21 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8D2B:C578BF2:5ED66024
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3641'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdKsgcX2kO0CBdKgRQ+7exEoiZYYS6JKUnYdIe/ef0jJ
+        kg1vEjs85pLYNPkNh+QMh387kelkPru+uZldfri5OptUKhURtU3ubr+s74s/iuTrx0f+7e9VUi03
+        fz5kV3cPXx7vb//6NEFnXgr0tMLYKFI2Fzrllhth8duiKYqo61AKtFqlxXkh43PqbtjBQbWWK27B
+        XPDCiLOJWldCT+btpFCZrGDqAAm2aL7X19NfZ7Obyz0XNvfLj5sfs98b/q3O06/FKn74Pru7TTZ3
+        D9l/GMphj+uo0QXoubW1mTPmG82Hi0zavIkbI3SiKisqe5GokjWsN/Z59ekKkEx3GLdwaNjD1bIj
+        +eHAGXbYk9yWxd5k/BzcyMNjFqoo1BrMfS9eaZZtAbRtDiar7G0wAFrmTkREq/dEiySx7adS3eCW
+        0T+cTsIZbJsW6anAbjgmSUfsqWVa1Mpxm9gkWtZWqurk6e5AAFU645V85G+CAmLAoomePDE3GBCx
+        wmE+meJHt8yFa7KhZdMiEXKF/XgbeQ8DsN3UlGPuRytIuyStiHhaUlJwueLpDNF7ZOwczkGp2O7/
+        ZF4hi1FQ6OU2Jz0b2259D8XpYVsEfmEXjiEiksHD8izFJiSWcC3D3y72EiQJHivNkdND2tnhtmz8
+        lc6YFbwMac7xwM2VCroLjgeuNKYRrwqIozbZYQ3rg7Bqythn2NeE3lGWPBCecGNkVgkRcvW3zJb1
+        V0SseZXkQa30yJb5T+4c8SykI4QDNS5UHBKLe585ZstMzv0NaqPAcycjhNyxocUitCOE3NqwOuxJ
+        ck4Qc2sBt7vFoQrpRY9kbbcbBa+yhmdBjWyZdMWhwMn444t13VERPUBhgWpaLeMmeBYfsOSHL6iQ
+        o4Jux0AdbLii7fmK8LjVGtWCbr3KUr5UNR1loCPuRF94KxQf+5bo+8sl4NHOELJlw5Xkr8DOWMCd
+        6e7A3ouxye6lFvKw9UjW/lJzm1MuhuWaaxHQpY7I2hgv6KeLi4s2F9w9dUqhw6YZDwSZ6yRH1R7Q
+        i7ZHohQtuXUPqwU5keKhVSiehtyXLRN8fyICeuKB45NV4zEQcvqONzZQygLaiKqC3ikDdGyqUlYu
+        ZPKaF+lRSWCH2342skrEGccjCtFiZSIRP9AG6EDgBSGCLqcHwkmoUv5JWgiEUsgd08IjW+ZFiFTU
+        hdqETqQjKmUaLSCJpRG3eAbPprPp+fT6fDr75/JqPpvOL6c/0KepIby90KduTP7zLjPC4KLoAgif
+        oIM9Lz0deNKSzAWOMfnA+W2gzA8IWD+nJAUiYS+gT57Rar8uOJoEv3JViholX68LGPmIz9OdWi1R
+        TYWdQuOaWzxmUPUMTX191wNybiKfZyZzqxsontRSa/UgEmvGbUOqG3Vcy6XcGUjl6Fao8OLCYLyU
+        WqtO6vS6RperIVp2emsqDY8LMTSoWlTdDMduyERUZrsMXnUgl0fdd5bAfUnFgjeFjfxDjMRciMKQ
+        d88mtdAlloEUNxJ7O13HLwgd295HSpj+M+QeK8o68mfEqqUgdRgopBq1jsy/DccZdPdcP9j/4prg
+        ClVyu79oQRfv7pgU8Q6hyc84Qm3ZEXt5eixKvavUTfyuUr+r1O8qtdf56R48oFJXwq6h0o6y6fiB
+        3Gfrp/8B0jCNo5kbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:21 GMT
+      etag:
+      - W/"4ffa657203e0335577fc1bf35c17c02b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8DAB:C578C89:5ED66025
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3640'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aSBT+K5GfSXw3MVLVfUhUpRJU2aWbNasKjcfH9pDBdmfG5IL473uOgSbw
+        kMbd9C0vCMb+vvnO/bC2KrYEa2QtmTagrIHF6+VSGGu0tnTJ8EHkcojAT7NzhzEHAmBxygPXPY88
+        LwtYkHpxmDMIEFrVGcxFhqDxRRJde7FJb6QzXiTBl4ur+/Fj4XxZJPeJ99WbTSdidlHcJTeXd7Pp
+        nzKZSpE8Xt+Pp4U3Xny+nXy6dJLFVTi5mZWz6fWHA12sNWWtSOFO+18lK5k6uVypusI3YcmERBGo
+        H4/PgI7/KOjwDI3DFzJmyGTP8ZxTJzp1vKkbjDxn5Poza7P3AHnjt12xBK1ZQSKuKmEEkyeoiTWM
+        3+LpyS4EA8sowHf2kciZkzsx91zu8mHuRc7QD4ZZFntxHp7n3A/CYZiGOUcLW0UOKI1p9Mi2WSPO
+        CmHKNiUH2AqaWttLMBjyWsGpFOmpAW20TZ/zeW1KUKRHg7ERZ5MMbb/6enTh296/9Ye2e6QiQaAy
+        c163FSazM7BWoEQuODMCkwR9uv0NmK05kxoGlgKm6ZHVVloUFT4ZWPSFmVZhFKpWyoHVsAdZMwTR
+        z82bWvoLVpZmKeeHvn4W51dGeHvvLzhXH139f9Ksr/H2LsAag/TUD2RdCIqgLruix2fUjaIwjPzD
+        7nQd/f3PRPJF4k6mySNxrDDf1bFB3aH2dsXTalC8rgzmVVdHrd0xf1x9oOZXqB1H1wB/VoPEpe0n
+        nS9H8um9vJayvkPssdTDEj+gt3+AUNX2u6iK/gQIWttdc5gT/4aMFtg2+jB1gDV2FWw0IiMKjS5W
+        kPUh2UFQzF2FOtZdR+u42lRzJRqq8V6yDoBIVKuCVeKxaxa9iBBIKdm12D4mdQAEwgqzqxdyi1jb
+        jRIrxh/IDQo4iBX6tD/bERTJzENDc+orRpw8LAzMWbakMuv65vG8fC/B3ZR9L8F+lfNegtuhhc3s
+        oHpfVYINU9Q3rNG/+2XRH+KWyMPYzSD0uRt5gR9lfoxrYu6AzzIWM3DDLET6t1vW9lO8x+UvD75+
+        K8yrr918w7Y1l6K6RZehx0Dmb7Qup4pVvMRt+cf/KTLwGXn//Yy27z0dym5UbYCbZ4vr7mS310LF
+        Unmw1n5vBQ1YnJqm1XNUx7dmQ5XXikO3J0scFSSzznPMiG7Lue/y6RstuU83vDzTev2zOHIVDrDO
+        MDJj8x86MrRrlw4AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:21 GMT
+      etag:
+      - W/"aa3f66cdf047fbd950e2c9b73039101e"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8E24:C578D1B:5ED66025
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3639'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"xls\", \n  \"name\":
+      \"otherdataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "fa0f09c21c1c7f2607347dd929f58fc34575b5fc"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '285'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"b7eb071da269ad95ae1ae538e9742ab5578a1325","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/b7eb071da269ad95ae1ae538e9742ab5578a1325","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"3d8621658ce4905281210bb86f0ae5907cdf8fbc","size":117,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/3d8621658ce4905281210bb86f0ae5907cdf8fbc"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '687'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:22 GMT
+      etag:
+      - '"0f4395e1cda5bf83d018636722db0267"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/b7eb071da269ad95ae1ae538e9742ab5578a1325
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8E8E:C578D9E:5ED66025
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3638'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW4vaQBT+KzLPaiaTiyZQ6INSLOhim0WSUuQkOUnGzUUyk1274n/vGexC+6Zg
+        X0LmnJz5LucjZ6YqYCHz7Qx9dNJ8zgE4ughBmrm2PfeFyF1wUxF4BaDLxqztctzLnIbWi9jfikCn
+        u5qvD7H7tFid1u8lfzrEp1g8iyTayGRRvsW75VsSfavjqJbx+/a0jkqxPnx92XxZ8viw8ja7pEqi
+        7Se6fOhrurjS+qhCy4KjnJZSV0M6zbrG6vHYKatBDUp3PU5qmU40Kq0s89zvO11hnwO1UVs0Z9FQ
+        I6l9h7pKN/X+XxZ/MbgR+4p7DywMuup6Fp5ZCw2SBd8rqKAfLV/7riVfsAFpnKFtUXmKpvy5NEXj
+        DH1Ass2Y4IJPuD/hIrLdUPDQdhJ2GbMrI43/EUL3SAzOfwJVAC94kAk7s7NZIXw+c9xZngciKLx5
+        kTmuN/NSr8gevnNDQ1k3w5M3DSoFpXFv1UotoR6ZDB0he6Hq6Ooc0TxCj61WLPzxodGZkbjMC+wc
+        PSezfeE6fu4EpK7g6EAOAaDt5d7DNX7k+g4Cj8z1zbCXn2P2ir0sZAZaUpApHtcz0v+jgFrhmPUI
+        yrTY0CpZttQZM/MCeuhpKe1Q18b8X3UHNGSOl8tv1r8f0rcEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:22 GMT
+      etag:
+      - W/"aa1b94a3b09e12404f81ec51a0117184"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8F6F:C578E84:5ED66026
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3637'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4"],
+      "message": "Set type to xls", "tree": "b7eb071da269ad95ae1ae538e9742ab5578a1325"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"6d0e2a86b7c66742942253cd398d6b1ae48bdb2b","node_id":"MDY6Q29tbWl0MjY4ODIxMzg0OjZkMGUyYTg2YjdjNjY3NDI5NDIyNTNjZDM5OGQ2YjFhZTQ4YmRiMmI=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/6d0e2a86b7c66742942253cd398d6b1ae48bdb2b","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/6d0e2a86b7c66742942253cd398d6b1ae48bdb2b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:22Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:22Z"},"tree":{"sha":"b7eb071da269ad95ae1ae538e9742ab5578a1325","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/b7eb071da269ad95ae1ae538e9742ab5578a1325"},"message":"Set
+        type to xls","parents":[{"sha":"61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/61ce6e3bd80aa0e4ea9bc4118622d4a4b295fae4"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1196'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:22 GMT
+      etag:
+      - '"e43defddb870aa51424b36641531da83"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/6d0e2a86b7c66742942253cd398d6b1ae48bdb2b
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F8FCE:C578F24:5ED66026
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3636'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBRF/8VzwUnqRpAZlbaSxdRUZYme4wc2iuPIfqAC4t/7UMcuHbrc5erc
+        e64i4U4098zSIdgsA2TCJB7EGC123nKrV7p+D23Qh0+1Wb1+6cu+2Ixvw3bUJ1i3bvuiT+bj+WLX
+        7ZnBYxoYckRTbqSEyc/3ntzRzPsYZMIp8gkS38SEs8GbGWGmLO/ZdZEcJgtcI0nmGPitFs0BexLN
+        VWQH/FWXPdb4aOyiAChQISxNr8pyUVeVVaBMtXzaASqWo/OETLBK8PTvsj+zWf5Z6Hb7BgAla+uD
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:23 GMT
+      etag:
+      - W/"d15a80af6baf835ec5e488e80f446376"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F90AB:C57903A:5ED66026
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3635'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "6d0e2a86b7c66742942253cd398d6b1ae48bdb2b"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4tnwNQEEzKj0laymEhVlsiOH9gojiP7gfgQ/70PdezSoctdrs69
+        584S7Fn1zMwdaJt50BkhsRHro4XGW2rVSsltqIM6fhWb1ftF3Q7TTf/R7Xp11uva7d7U2Xy+3uy6
+        vhJ4Sh1BDnHIFed68JODR3cykzYGnmCIdAJINzHBuPNmjJAx82c2TUQHyWqqATlxBPxWi+YILbLq
+        zrLT9CXtFIQupVm0Ui4KsSyEmM9aO1uWVpoXDUVprBGG5PA6ABGkEjz+u+zPbOZ/Fno8vgFVlmWA
+        gwEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:23 GMT
+      etag:
+      - W/"e9d64b8a925f1a22e31ff06294bdd6e3"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F910E:C5790B1:5ED66027
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3634'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:24 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F9271:C579259:5ED66027
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3633'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ72O0CBbJBix529yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFl7f3ISXH66vziaVTHlEY5O7z1/W98UfRfL19oF9/2uVVMvN
+        t0V2dbf48vBt8efHCSazkmOm4dpEUblJmWGaG/wwb4oi6n4tOUaNVPy8EPE5zdXB/1fUSqyYAW3O
+        Cs3PJnJdcTWZtZNCZqKCkAMYCCJNr6+nv4bhzeWe8pv75e3mZ/h7w77Xefq1WMWLH+Hd52Rzt8j+
+        xVIGeUxFjSpAz42p9SwI3KD+cJEJkzdxo7lKZGV4ZS4SWQZN0Av7tPp4BUimOow1GQb2cLXoSG45
+        cDo4vJPclMWeMk4Hu/LwmrksCrkGc38XR4oNtgA6MwsTVfY2GABtIE3OYVps95GMJHDmp1Lt4jag
+        f/BLwmkcm+LpqcBuOZQkF3tsA8VrablNrBMlaiNkdbK6OxBApcpYJR7Ym6CAaLBI0ZMVs4sB4Ss4
+        88kUt7oNbLgmGzKb4gkXK5zH28h7GIDNpqbscj+yIJ2SMDxiaUlJweaKxzNE7ytj50ACSvn28Cez
+        CvmLIkIttwnp2cC2xj0UpAcEEfUF+x+NQwADBqss+cYbk1htgL9dvCVIDCyWiiGJexOyA22D8Vdy
+        KsNZ6U2WhQGaS+nP8hYGqNC64Uf5/vGnapk66IOtasrYZdJjQux4MY6GPTCtRVZx7s3iW2Ab9JdA
+        rFiV5P5E9Lw2cJ+s17DM2xaIBWRcyNgbExd6YIFtoHPmrkYT+dSaJBBvR4Dic69bIN5WgFEe/caq
+        T8AtHre1gQt507/nBW13AgWrsoZl/iRsgXRZoVTJ2MOLFdrxMTsQgafSVIm48ZuYBybtwBVFyD/+
+        jmBADgJs1fV8SfcKI40qOWumshQv1TzH0zvcToh5FkFxsC+Gvr9cur1uG8Rrg+F+cZdZJ8nXaXS3
+        Wa//WF73tvLmWj0vaH+pmckpw0JszRT3tZkOF7QxnrqPFxcXbc6ZfZaUXHnMIo4GLFNJjvLal/5t
+        z0PlWDJjnz9zUj/Fc6iQLPV2Flsg4M4FfO3B0cZ+VKNe96a4hY3ppSjQtZCVvztiII7lVNKIuUiO
+        eSseH+Y70PaTFlXCzxieN4gKIxKBOMGTnTwART73Z0VHw/bQI3LPxIIjZLydkuKO1wauK5DyupAb
+        rxlyhKREojgaVGnEDB6l4TScnk+vz6fh35dXs3A6m179xJymRg/syTnhJc2pG50/OeXylqYg/Xex
+        gk/oSj3fCNp/Y1LHCRCt8wHy24CYHeglPYFICjj9XtSepstq/25/HQbbyWXJa9Rp/eNciwd8nu7U
+        WIlsKpwOBtfM4LGBmmUY6uuyHpAzHblMMpkZ1aDnSCO1kgueGD0eGzLZaOJaLMXOQqoht90C98gf
+        hJdCKdk1G11zocvDaBt2Hc9UaBYXfBiQNa86DcfbEAmv9NYMrgFAWx5N3zGB/ZLyOWsKE7m3ErVT
+        0ZNFgxXuyFUJM1DPi9qtXWfFGYRctd8jZUX3GQ0Xw8s6ct5h5JJTfxYoZBW5jvQ/DYPr2QusX+x+
+        sUPYClVju78oTtfp7poUAY5Wj9M4QnHYEfsG8bgt9N4nbuL3PvF7n/i9T+w67XT9HegTV9ys0TAd
+        ZdPx87bP1o//ATtosOQVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:24 GMT
+      etag:
+      - W/"2ecdd494c4eb6e9e5bfe91da103f9066"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F92EC:C5792FB:5ED66028
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3632'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits?path=datapackage.json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1YbaviOBT+K9LP3tv0vQrD7oDDZRbay2W969ZhkDRNNdoXSVIdFf/7nFRdRxdc
+        K87CgF+kpn3OOTk5b0++bDQxwVpXc32P2NjyXc+1O8j3Ykwc4ps4pchGOLWxbxJke7bW1ooyoSOW
+        ACjoRe6b2ZHxIEPBNLJfe5+/BesIvcJzaAYo6gd2OCVm2JstX3sJiwaBEa3Hq2gwzILe2zIaRPAN
+        /F9/ROH67QMIJ2WeM6l1Nxqu5KTk6qnAOQVtf07wBPPWpwUvC/iS5phlsAz2w/IzVcu/j9XiMwiB
+        DxIsFcxEJnpC7hMy+4bdNVHX8Ifa9qBJ0p+oIqdC4HFtO5UtuZrTlixbRCzAOskpvDi438AGwSSJ
+        SSfxHMf1PCOxTORQh9KO4zueabkxsgwTgBVXu55IORddXcdz9jxmclLFatc6p/NS6DmVWMiS06eM
+        xU+SCil09Tsa5SvwChZU6gDSlQ1Cv1o3OO2OyncnLfQGkacgtJAjUlYFxAhqawvKWcoIlgxiAry5
+        +08hOFOcCdrWOMVCvdKqQrBxAW/amnrAsuLg/6LKsrY2x6usxABSf7f32+YNW5zIPBudevmH473m
+        YHdKb3CrONN7c2g13ba+P1cBZ3PM+qwcM3VwYlKnNrxTNceF7LBOa9Cb+9ffYUamkRH2o7WSsYAY
+        5+e7qReFuc+WSlBOykJCONWJU+m15N8WH1SJG/O9jLrM/VfSKVlCP9p5+QyP36VllpVLwJ6beprT
+        J+L1f0Bg1e6ZFePmAgC00Us5oeAnMH+rNs2gTjSRVAM2UEmgsrBEiRDgYk6TJkL2EDBmWYAdm7qE
+        1bKqWBDO5iq1G5l1AgRBJR/jgq3rGtFIEABVSNY1tcmWagAA6QKiqxFyh9joc84WmKyUGzgllC3A
+        p82lnUFBmGpBENDvcOLKw0zSEU5ylWZ1uTzvio8U3LfVRwo2y5xHCu6aFhSzk+y9KgXnmKu6oXW/
+        HKZD5BkuMoifdpDTMV0vjU1qpwlKHNOxE0KQ49up0cEg/k4D2qGFN9B8ues1mFyu1rn9um3f4KJr
+        +MtHK+hHy2AQ2MPpbBn2Z6twmuTR9I8sfBnOgpc3I5i+o+FLOA1673b4En17HXz6n/gL+vn8Za/i
+        yF8+F0wynLUUe5hjMgNW09rFiArpEyrjedR3LTu1LWAsJE3dTgK80SEoph6lqWXGlODYde4XrEcq
+        c7Xu+834SvkN2bIfeX85KnN1craBot6JyjTQeWASl8e161ly05N9UJmLDegxRz3mqAeVuTykPW4T
+        HrcJP9wn7a50f9HbhH9TGWArttWBuTCBru77vhv7qemROIHL7pQkdkxNG+P0jtPhoYU30Hy3yeVq
+        nUBlvn4HD9FX6owZAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:24 GMT
+      etag:
+      - W/"b554090522663a33603a638890c93be6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F9370:C57939C:5ED66028
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3631'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:24 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F93E9:C579429:5ED66028
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3630'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHCbJZA4vtIdsFCqRBix62exEoiZaYSKJKUnYdIf+975CS
+        JRvOhx0ec0lsmnyGQ3KGw7edyHQyn11dX8/OL64vTyaVSkVEbZPbm2+ru+L3Ivn++ZH/+GuZVA/r
+        P+6zy9v7b493N39+maAzLwV6WmFsFCmbC51yy42w+G3RFEXUdSgFWq3S4rSQ8Sl1N2zvoFrLJbdg
+        LnhhxMlErSqhJ/N2UqhMVjC1hwRbNN+rq+mn2ez6fMeF9d3D5/XP2W8N/1Hn6fdiGd//M7u9Sda3
+        99l/GMphj+uo0QXoubW1mTPmG83FWSZt3sSNETpRlRWVPUtUyRrWG/u6/HIJSKY7jFs4NOzgatmR
+        /HDgDNvvSW7LYmcyfg5u5P4xC1UUagXmrhdvNMs2ANo2B5NV9j4YAC1zJyKi1XuiRZLY9mOpbnDL
+        6B9OJ+EMtk2L9FhgNxyTpCP21DItauW4TWwSLWsrVXX0dLcggCqd8Uo+8ndBATFg0USPnpgbDIhY
+        4jAfTfGjW+bCNVnTsmmRCLnEfryPvIMB2K5ryjF3oxWkXZJWRDwtKSm4XPF0gug9MHb256BUbPZ/
+        Mq+QxSgo9MMmJ70Y225998XpflsEfmUXDiEiksHD8jyIdUgs4VqGv13sJUgSPFaaI6eHtLPFbdn4
+        K50xK3gZ0pzjgZsrFXQXHA9caUwj3hQQB22ywxrWB2HVlLHPsG8JvYMseSA84cbIrBIi5OpvmC3r
+        r4hY8yrJg1rpkS3zn9w54llIRwgHalyoOCQW9z5zzJaZnPsb1EaB505GCLllQ4tFaEcIubFhddiT
+        5Jwg5sYCbneLQxXSix7J2m43Cl5lDc+CGtkw6YpDgZPxx1fruoMieoDCAtW0WsZN8Cw+YMkPX1Ah
+        RwXdjoE62HBF28sV4WGrNaoF3XqVpXytajrIQEfcir7wVig+di3R99dLwIOdIWTLhivJX4GdsYA7
+        092BvRdjk91LLeRh65Gs/aXmNqdcDMs11yKgSx2RtTFe0E9nZ2dtLrh76pRCh00zHggy10mOqj2g
+        F22PRClacuseVgtyIsVDq1A8DbkvGyb4/kQE9MQDxyerxmMg5PQdb2yglAW0EVUFvVMG6NhUpaxc
+        yOQtL9KDksAWt/1qZJWIE45HFKLFykQifqAN0IHAC0IEXU4PhJNQpfyTtBAIpZA7poVHtsyLEKmo
+        C7UOnUhHVMo0WkASSyNu8QyeTWfT0+nV6XT29/nlfDadn09/ok9TQ3h7vs8n6lM3Jn+2y+yCuuCi
+        6AIIn6CDvSw97XnSkswFjjH5wPl1oMz3CFjPU5ICkbAT0EfPaLlbFxxMgl+5KkWNkq/XBYx8xOfp
+        Vq2WqKbCTqFxxS0eM6h6hqa+vusBOTeRzzOTudUNFE9qqbW6F4k147Yh1Y06ruSD3BpI5ehGqPDi
+        wmC8lFqrTur0ukaXqyFadnprKg2PCzE0qFpU3QzHbshEVGazDF51IJdH3beWwH1JxYI3hY38Q4zE
+        XIjCkHdxNIUusQykuJHY2+k6fkHo2PY+UsL0nyH3WFHWkT8jVj0IUoeBQqpRq8j823CcQXfP9YP9
+        L64JrlAlt/2LFnTxbo9JEe8QmvyMI9SWHbGXp8ei1IdK3cQfKvWHSv2hUnudn+7BPSp1JewKKu0o
+        m44fyH22fvofK25u+pkbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:25 GMT
+      etag:
+      - W/"7d0b19f2a59b6504da8457b57cfef345"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F945F:C5794AE:5ED66028
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3629'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/commits?path=datapackage.json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZbW/iOBD+KyifaZM4bwRptfeBXtWToGKPXi+sVshxnMQ0L8h2aCniv9840LKw
+        Epf02JNW4gMo2JlnxuOZ8Tzm61oTKdb6mhsZFOGeG3rEdT0b+TZCjkUiy+9FbmhiavfCKESh1tWK
+        MqIzFoHQcBC4Y+TL8DEzhvPAvh/cvQxfE+N+Pn0a3j6sgkmCgnk0H80DazS4c+CzGk1G8+lg6Nzf
+        jmHu93Q6GdtB/oUN87tPAE7KPGdS6681XMm05OqpwDkFbX+mOMW8c7PkZQFv0hyzDIbBfhi+pmr4
+        t0QNXgMIvBBhqcSQgYwrw70y0MS0+8joIzTVNm+aJP2JKnIqBE5q26nsyNWCdmTZeckEWCc5hYk3
+        94ceDQ3PjDByfRz5DqbgcsfqUR/2AoeO4/WwaSEHBCuuVp1KuRB9XccLdp0wmVahWrXO6aIUek4l
+        FrLk9Cpj4ZWkQgpdfc9mpUwpB8dgQaUOcroyQ+iN1YPfzqt/u99CbxF/SoQWckbKqoBIMbraknIW
+        M4Ilg8gAn25/UwjRGGeCdjVOsVBTWlUIlhQw09XUA5YVh10oqizragu8ykoMQurn5qwr/cAqU5ln
+        s0Nff7fPDXd4q/cDzhVHqv9LmLVdvL7bYJUl+yKQlQlTOyjSOtNhTpUg13Fc67Akjd2//h5lZB6Y
+        o0nwqjCWEO/8eEH1oEC75KkE5aQsJMRVnUeVXiN/Xn6yASHhO4y66v1bDiosoe/tPL2T+/fiMsvK
+        Z5A9NvUwxQ/g9XchsGr7zIqkPQAIrfW6OMwU/kYtmkHZaINUC6yhqkChYZGCEOBiTqM2IDsRMOa5
+        ADvWdUWrsapQEM4WKsdbmXUgCEAlT3DBXuti0QoIBFVI1iW2zZJqARCkS4iuVpJbibW+4GyJyUq5
+        gVNC2RJ82h7tSBTA1IkEAf0AO648zCSd4ShXaVbXzeND8pKCu1P2koLtMueSgttDC4rZQfY2SsEF
+        5qpuaP2v7726SahLrTDqGRgb1KbYD4ltmj0XocjGdoh8J4aOHeDP16y9n+LNlZ8++Fq2ME3Vbr5t
+        uh9wVBNSE7wE6AFNJyM2HSTPwePN83TyJQsmGQtexy9DIDvD+R9Po9sbI5gD2XmcKnLzP5Ea0/rp
+        pGanYk9q7gomGc46ik8sMHkCqtPZhokK7AN+E2MjNnyCTGISL0au4Vm2F0U+8mOnFxPLdjwndGJy
+        1pDd85vG6s/a9Sv9H0ibXfv7S/KbplnaBQJ7Rn7TXO0btzjdwLWi0W23+MJvTp5Kl+bq0lxd+M3p
+        zu1yxXC5Yvjukml77fuLXjH8yG8sD7pE4vhmBFfgxHSRbbnwRwS0ibFBLRxhH67Hnei8l+Fvp3gL
+        5edsYRqrBX7z7R/b4GIythkAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:25 GMT
+      etag:
+      - W/"de92966b675f8883d0a864b12e7720c2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:22 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F94B8:C579526:5ED66029
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3628'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:26 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F9522:C5795AD:5ED66029
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3627'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHCdKsgcX2kO0CBdKgRQ+7exEoiZaYSKJKUnYdIf+975CS
+        JRvOhx0ec0lsmnyGQ3KGw7edyHQyn11dX8/OL64vTyaVSkVEbZPbm6+ru+KPIvn26ZF//3uZVA/r
+        P++zy9v7r493N399nqAzLwV6WmFsFCmbC51yy42w+G3RFEXUdSgFWq3S4rSQ8Sl1N2zvoFrLJbdg
+        LnhhxMlErSqhJ/N2UqhMVjC1hwRbNN+rq+mvs9n1+Y4L67uHT+ufs98b/r3O02/FMr7/Mbu9Sda3
+        99l/GMphj+uo0QXoubW1mTPmG83FWSZt3sSNETpRlRWVPUtUyRrWG/uy/HwJSKY7jFs4NOzgatmR
+        /HDgDNvvSW7LYmcyfg5u5P4xC1UUagXmrhdvNMs2ANo2B5NV9j4YAC1zJyKi1XuiRZLY9mOpbnDL
+        6B9OJ+EMtk2L9FhgNxyTpCP21DItauW4TWwSLWsrVXX0dLcggCqd8Uo+8ndBATFg0USPnpgbDIhY
+        4jAfTfGjW+bCNVnTsmmRCLnEfryPvIMB2K5ryjF3oxWkXZJWRDwtKSm4XPF0gug9MHb256BUbPZ/
+        Mq+QxSgo9MMmJ70Y225998XpflsEfmUXDiEiksHD8jyIdUgs4VqGv13sJUgSPFaaI6eHtLPFbdn4
+        K50xK3gZ0pzjgZsrFXQXHA9caUwj3hQQB22ywxrWB2HVlLHPsG8JvYMseSA84cbIrBIi5OpvmC3r
+        r4hY8yrJg1rpkS3zn9w54llIRwgHalyoOCQW9z5zzJaZnPsb1EaB505GCLllQ4tFaEcIubFhddiT
+        5Jwg5sYCbneLQxXSix7J2m43Cl5lDc+CGtkw6YpDgZPxx1fruoMieoDCAtW0WsZN8Cw+YMkPX1Ah
+        RwXdjoE62HBF28sV4WGrNaoF3XqVpXytajrIQEfcir7wVig+di3R99dLwIOdIWTLhivJX4GdsYA7
+        092BvRdjk91LLeRh65Gs/aXmNqdcDMs11yKgSx2RtTFe0E9nZ2dtLrh76pRCh00zHggy10mOqj2g
+        F22PRClacuseVgtyIsVDq1A8DbkvGyb4/kQE9MQDxyerxmMg5PQdb2yglAW0EVUFvVMG6NhUpaxc
+        yOQtL9KDksAWt/1iZJWIE45HFKLFykQifqAN0IHAC0IEXU4PhJNQpfyTtBAIpZA7poVHtsyLEKmo
+        C7UOnUhHVMo0WkASSyNu8QyeTWfT0+nV6XT2z/nlfDadn09/ok9TQ3h7ts/sivrUjcmf73JBXXBR
+        dAGET9DBXpae9jxpSeYCx5h84Pw2UOZ7BKznKUmBSNgJ6KNntNytCw4mwa9claJGydfrAkY+4vN0
+        q1ZLVFNhp9C44haPGVQ9Q1Nf3/WAnJvI55nJ3OoGiie11Frdi8SacduQ6kYdV/JBbg2kcnQjVHhx
+        YTBeSq1VJ3V6XaPL1RAtO701lYbHhRgaVC2qboZjN2QiKrNZBq86kMuj7ltL4L6kYsGbwkb+IUZi
+        LkRhyLs4mkKXWAZS3Ejs7XQdvyB0bHsfKWH6z5B7rCjryJ8Rqx4EqcNAIdWoVWT+bTjOoLvn+sH+
+        F9cEV6iS2/5FC7p4t8ekiHcITX7GEWrLjtjL02NR6kOlbuIPlfpDpf5Qqb3OT/fgHpW6EnYFlXaU
+        TccP5D5bP/0PagE1jZkbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:26 GMT
+      etag:
+      - W/"b33fd7ed140c2aec8a7d33e72fd3ee16"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:26 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F9660:C57973D:5ED6602A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3626'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:20:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F96D1:C5797BE:5ED6602A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3625'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:27 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F97AD:C5798D5:5ED6602B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3624'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ72O0CBbJBix529yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFl7f3ISXH66vziaVTHlEY5O7z1/W98UfRfL19oF9/2uVVMvN
+        t0V2dbf48vBt8efHCSazkmOm4dpEUblJmWGaG/wwb4oi6n4tOUaNVPy8EPE5zdXB/1fUSqyYAW3O
+        Cs3PJnJdcTWZtZNCZqKCkAMYCCJNr6+nv4bhzeWe8pv75e3mZ/h7w77Xefq1WMWLH+Hd52Rzt8j+
+        xVIGeUxFjSpAz42p9SwI3KD+cJEJkzdxo7lKZGV4ZS4SWQZN0Av7tPp4BUimOow1GQb2cLXoSG45
+        cDo4vJPclMWeMk4Hu/LwmrksCrkGc38XR4oNtgA6MwsTVfY2GABtIE3OYVps95GMJHDmp1Lt4jag
+        f/BLwmkcm+LpqcBuOZQkF3tsA8VrablNrBMlaiNkdbK6OxBApcpYJR7Ym6CAaLBI0ZMVs4sB4Ss4
+        88kUt7oNbLgmGzKb4gkXK5zH28h7GIDNpqbscj+yIJ2SMDxiaUlJweaKxzNE7ytj50ACSvn28Cez
+        CvmLIkIttwnp2cC2xj0UpAcEEfUF+x+NQwADBqss+cYbk1htgL9dvCVIDCyWiiGJexOyA22D8Vdy
+        KsNZ6U2WhQGaS+nP8hYGqNC64Uf5/vGnapk66IOtasrYZdJjQux4MY6GPTCtRVZx7s3iW2Ab9JdA
+        rFiV5P5E9Lw2cJ+s17DM2xaIBWRcyNgbExd6YIFtoHPmrkYT+dSaJBBvR4Dic69bIN5WgFEe/caq
+        T8AtHre1gQt507/nBW13AgWrsoZl/iRsgXRZoVTJ2MOLFdrxMTsQgafSVIm48ZuYBybtwBVFyD/+
+        jmBADgJs1fV8SfcKI40qOWumshQv1TzH0zvcToh5FkFxsC+Gvr9cur1uG8Rrg+F+cZdZJ8nXaXS3
+        Wa//WF73tvLmWj0vaH+pmckpw0JszRT3tZkOF7QxnrqPFxcXbc6ZfZaUXHnMIo4GLFNJjvLal/5t
+        z0PlWDJjnz9zUj/Fc6iQLPV2Flsg4M4FfO3B0cZ+VKNe96a4hY3ppSjQtZCVvztiII7lVNKIuUiO
+        eSseH+Y70PaTFlXCzxieN4gKIxKBOMGTnTwART73Z0VHw/bQI3LPxIIjZLydkuKO1wauK5DyupAb
+        rxlyhKREojgaVGnEDB6l4TScnk+vz6fh35dXs3A6m179xJymRg/syTnhJc2pG50/OeXylqYg/Xex
+        gk/oSj3fCNp/Y1LHCRCt8wHy24CYHeglPYFICjj9XtSepstq/25/HQbbyWXJa9Rp/eNciwd8nu7U
+        WIlsKpwOBtfM4LGBmmUY6uuyHpAzHblMMpkZ1aDnSCO1kgueGD0eGzLZaOJaLMXOQqoht90C98gf
+        hJdCKdk1G11zocvDaBt2Hc9UaBYXfBiQNa86DcfbEAmv9NYMrgFAWx5N3zGB/ZLyOWsKE7m3ErVT
+        0ZNFgxXuyFUJM1DPi9qtXWfFGYRctd8jZUX3GQ0Xw8s6ct5h5JJTfxYoZBW5jvQ/DYPr2QusX+x+
+        sUPYClVju78oTtfp7poUAY5Wj9M4QnHYEfsG8bgt9N4nbuL3PvF7n/i9T+w67XT9HegTV9ys0TAd
+        ZdPx87bP1o//ATtosOQVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:27 GMT
+      etag:
+      - W/"2ecdd494c4eb6e9e5bfe91da103f9066"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F98C8:C5799E2:5ED6602B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3623'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:20:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C920:204C5:A5F9947:C579AB9:5ED6602B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3622'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_revision_list_one_revision.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_revision_list_one_revision.yaml
@@ -1,0 +1,1359 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:39 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:42445EB:4EBE8FA:5ED65FFB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3736'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:39 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244629:4EBE92D:5ED65FFB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3735'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821240,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjEyNDA=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:19:39Z","updated_at":"2020-06-02T14:19:39Z","pushed_at":"2020-06-02T14:19:40Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:41 GMT
+      etag:
+      - '"07a559935fa1650bb72885e107c84210"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244669:4EBE97F:5ED65FFB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3734'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"c652e99c56e66888d5e46a359c6114f6cd7b8887","node_id":"MDY6Q29tbWl0MjY4ODIxMjQwOmM2NTJlOTljNTZlNjY4ODhkNWU0NmEzNTljNjExNGY2Y2Q3Yjg4ODc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c652e99c56e66888d5e46a359c6114f6cd7b8887","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/c652e99c56e66888d5e46a359c6114f6cd7b8887","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:41Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:41Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:42 GMT
+      etag:
+      - '"5fbe7cfc5d15471fa53a6d077ab6491f"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:424480C:4EBEB50:5ED65FFD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3733'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X227bOBD9lUDPTiTLsnwBiu5Dg0UXiIJg3XbdojAoaiTRpUQtSTlxjPz7ztDK
+        xX5IoyD7lhdDInWGZ85cON55NavAm3sVMxa0N/C4qiphvfnOMyXDDR6PQ5jN+DiGOJ5Op9kYopiN
+        xjMeD4dRHvNskuLyBKG1ymAlMgRdfFrGV+HMpt9kcLFeRpefPt9crK+uL6uLMFn8JS8Xcp0svsvE
+        7ZW/km9fgqQ6v01ofX1+k/y5DJfh1Wi5LnCffzjgxVpbKk0MO+5/l6xk+uR8o1WNX0LFhEQSyB+X
+        z4CW/yho8Qydww8yZsnlMAiD0yA+DcLFMJoPZ/No+N27u1eA1PjfjqjAGFYQic+1sIJJcQsnSIud
+        aGiUEVbpLRK1GvCb+0gM82CW5eFoMpmG0WQYjaeQheGMTdI0mvIJ7kyzyQgCBLaaBCitbczc91kj
+        zgphyzYlAXx3hF+BxZArDadSpKcWjDU+/a5W1ZaYGLA+gnziYPwXn436veHh+2Q0fo8kJAjUdsVV
+        W2MaBwNvA1rkgjMrMD1Qzf07YJ7mTBoYeBqYoS2vrY0oatwZePTAbKtR/7qVcuA1bCsVQxC93r2d
+        m69wsbSVXB2q/CS8Lwns/tBXyGqOzn11avV12+/iajA2jw1AqkJQ4Ezpqhz3qP3E43E8OmxHV/HX
+        fxLJ18thsljeko0N5rg+9sYtmrCrltaA5qq2mE6ucFrfWf64+RChhUJ3NlzH+13RkS3jP/J8PoaP
+        3+VKSnWN2GOqhzV9YN5/ACGr/bOoi/4GELTzlS0BdUL6d+S0wD7Rx5ID7LCTYGcRGZkwKLGGrI+R
+        DoJkrmvksXMtzNlqU8O1aKi0e9E6AKIhpQtWi1vXI3oZQiClpOupfVxyAATCBrOrF3KP2PmNFhvG
+        tySDBg5ig5r2t3YERWN229DF9AUjTgoLCyuWVVRmrl0eX5DvJdhdq+8l2K9y3ktwf2lhMzuo3heV
+        YMM09Q1v/uMnFuRKivoXvuCkCDJ/i8kv1azmJQ5+D/8L6MJ6YrnnwEFT5L0tJNxoZYHbJzNYt9KN
+        aFCzVB5MaP+2gi4NvAlsa1ZIje8dhjpXmoMb+SS2P+Ko8hxFdDf3TafR45l4wvN9+uXj8ZFI2JGd
+        V+TD3X8pNiYaWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:42 GMT
+      etag:
+      - W/"d28bd8a09eca7356cef757bb88f7ced3"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:42448FC:4EBEC97:5ED65FFE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3732'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:42 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:424493E:4EBECE0:5ED65FFE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3731'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c652e99c56e66888d5e46a359c6114f6cd7b8887
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTYvbMBD9K0FnJ7YVW/6AQg8byhbiEJqyeEsJsj225Up2kOTtZkP+e0ebHtrb
+        LrQXYb3nmffmQxdiek5yUrOYQpbVMQPG0jRtYogYX8dZzcIwalndJBXCCfHIODVwFA0Gbe9KtqeZ
+        rR5ksB3KaHd3/7wd9j93akuLw2e5O8ihODzK4pXrfxQPX4NCbV4Khw+b5+JTSUu6X5dDh3z9AZPP
+        WmLi3tqTyX2fn8SqE7afq1U9KV/DaTK+AsuNnTQspaiWFow1vjuPR3VuOHJgfQzyMUIJ5N5RWm+V
+        PP5t4Q/5twjfRN+jyWfbT5rkFzJyBVj8l573XC82T3oasSOguHA9wTkhvAIHf+wc6HqCP2DNLowG
+        NFgGbBnQQxjlYZZH4SO5euTmyMJ/lLAa0MHl9yqFbZA1LV0nSUqjJIziFBpKM55UVZTWCTJpk6wh
+        +LfTdh6M/2ZtbIwCY3jnWnc/Ciu4FC+wcAu0eN0zgSt2Ro8nrmG0huTfvnvkCbRoRc2twNlgxbc7
+        4GNouTTgEQ3cOIrMoxHdiIxH3Ae3s0apcZbSpTzLiWOQu16vvwDZfLPqhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:42 GMT
+      etag:
+      - W/"921f4ae4ec59b9f629e942a26d193e19"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:41 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:42449BE:4EBED7C:5ED65FFE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3730'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["c652e99c56e66888d5e46a359c6114f6cd7b8887"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"523b609d0d50e7d5898b187f14ebcdcd86080842","node_id":"MDY6Q29tbWl0MjY4ODIxMjQwOjUyM2I2MDlkMGQ1MGU3ZDU4OThiMTg3ZjE0ZWJjZGNkODYwODA4NDI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/523b609d0d50e7d5898b187f14ebcdcd86080842","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/523b609d0d50e7d5898b187f14ebcdcd86080842","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:43Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:19:43Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"c652e99c56e66888d5e46a359c6114f6cd7b8887","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/c652e99c56e66888d5e46a359c6114f6cd7b8887","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/c652e99c56e66888d5e46a359c6114f6cd7b8887"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:43 GMT
+      etag:
+      - '"282bd86450d8f3f1be063fab0da8d197"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/523b609d0d50e7d5898b187f14ebcdcd86080842
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:42449FE:4EBEDD5:5ED65FFE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3729'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBCG/4tnWquQuEnmitJKVsVAEF0if1yxoziO4mshVP3vXMTIwsByw733
+        3Ptc2QgnVs0zcQfKJh5UQhjZHeujhcZbSuVGipdQB9m+ZYfN7lO2zx+Hft8de3lR29odn+RFvz5+
+        2W09EXgeO4Ic4pAqztXgl+8e3VkvTQx8hCFSCSDVxBEWndcLhISJz7NpwmQVZYCcILr+7RV1CwZZ
+        dWXJKSoyIr+HsjS5ACGKorA5ZEI95KURq1V2EsauNa3XZIbTADMRQ/D4v6Y/PxP/s83t9g3aJcZc
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:43 GMT
+      etag:
+      - W/"0c6d9c4ddae59651a3d5e7ce4677ee84"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:41 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244A63:4EBEE58:5ED65FFF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3728'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "523b609d0d50e7d5898b187f14ebcdcd86080842"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWrslSd3MFQUkq2IgiC6RHV+xoziO4mshVP3vXMXIwtDlLe++
+        e9+ZjXBg5TUTd6Bt4kEnhJHdsT5aqL2lVm1U8RqqoNr3bLd5+lLty+euf+72vTrpbeX2j+pk3h6+
+        7baaCDyOHUEOcUgl53rw8w+P7mjmTQx8hCHSCCDNxBFmnTczhISJX7Ouw2Q1dYCcILr+6xVNCw2y
+        8syS0zSUL+9NIdZW2FzAyuZyLc1Crg6LDExjGysLIYXMlmSG0wBEkEfweFvT35+J/9vmcvkBML9E
+        yn0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:44 GMT
+      etag:
+      - W/"78f959f8fd5d49724a49e1e4ee88267f"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244AA4:4EBEEA0:5ED65FFF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3727'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:44 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244B92:4EBEF9E:5ED66000
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3726'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHa6SJgcW2QLYLFMgGKHrY3YtASbTEWBJVkrLrCPnvfYeU
+        bNn1Jo7DYy6JTZPPDD9mOHzbkUxHs8nV9fXkcjIdn40qlYqI2kZ3t59X98WfRfLl5pF/+2uZVIv1
+        14dsevfwef319vePI3TmpUBPK4yNonKdcsuNsPhh3hRF1P1aCrRapcV5IeNz6mvY/0fUWi65BW3O
+        CyPORmpVCT2ataNCZbKCkQMYGCJPr67Gv04m15d7zq/vFzfrH5M/Gv6tztMvxTJ++D65u03Wdw/Z
+        vxjKYY/rqNEF6Lm1tZkx5hvNh4tM2ryJGyN0oiorKnuRqJI1rDf2aflxCkimO4xbMjTs4WrZkfxw
+        4Aw7PJPclsWeM94HN/LwmLkqCrUCc38WR5plGwDtmYPJKnsbDICWKZsLLC2m+0SLJLHnp1Ld4JbR
+        P5xLwhlsmxbpqcBuOJykI/bUMi1q5bhNbBItaytVdbK7OxBAlc54JR/5m6CAGLDI0ZMdc4MBEUsc
+        5pMpfnTLXLgma1o2LRIhl9iPt5H3MADbdU3Z5X6wgrRL0oqIpyUlBZcrns4Qva+MnQMJKBWbzR/N
+        KuQvigi92CSkZwPbLe6hID1giKgvrP/ROAQwYFiVhVgHYxKrZfjbxVuCxMBjpTmSeDAjO9CWDb/S
+        obKCl8FsORiguVLhVt7BAJXGNOKos3/8rjqmYX2wVU0Z+0x6TIgdb8bTMAdujMwqIYKt+AbYsv4S
+        iDWvkjyciZ7XMv/JnRqeBZsCsYCMCxUHY+JCZw7YMpNzfzXaKKTXZIF4Owa0mAedAvE2BqwOeG6c
+        +wTc4HFbWxyhYP73PNZ2O1DwKmt4Fs7CBkiXFUqVjD++WKEdH7NbIvBUmmoZN2ET85ZJM/BFEfJP
+        uC3YIrcGXNX1fEn3ikUaVHJumcpSvlTzHE/vcDshFtgExcG+Gfr+cun2umkQr2Xb+8VfZp2lULvR
+        3Wa9/0N73dsq2NHqeaz9peY2pwwLszXXItRkOhxrYzx1ny4uLtpccPcsKYUOmEU8DViukxzldSj/
+        256HyrHk1j1/5uR+iudQoXgabC82QMD9EQg1B08bnqMa9Xowxx1sSC9lAdVCVeHuiC1xaKdSVs5l
+        csxb8fgw34G2n4ysEnHG8bxBVFiZSMQJnux0AlDki3Cr6GmYHjQi/0wsBEIm2C5p4Xkt86pAKupC
+        rYNmyAGSEokWEKjSiFs8Sifjyfh8fHU+nvx9OZ1d3sw+3PxAn6aGBvbTPtMp9akbk7/QBem/ixV8
+        gir1vBC0/8YkxQl2jMm3kN+2iNkBLekniKTAod+L2tN8We7f7a/DYDq5KkWNOq1/nBv5iM9QLAc1
+        VqKaCruDxhW3eGygZtk29XVZD8i5iXwmGc2sbqA5Ukut1YNIrBm2bTPZoONKLuTOQKohN2qBf+Rv
+        jZdSa9WJjV5c6PIwZMNO8Uyl4XEhtg2qFlXn4XAaMhGV2SyDFwBoyoPuO0vgvqRizpvCRv6tRHIq
+        NFkIrDiOQpdYBtK8SG7tlBW/IHRU+zlSVvSfIbhYUdaRPx1WLQTps0Ahq6hVZP5pOI6eu8D6wf4X
+        14SpUDW2+4sWdJ3ujkkR4JB6vMcRisOO2AvEQ1noXSdu4ned+F0nfteJvdJO198BnbgSdgXBdJBN
+        h8/bPls//QcQ9RnaFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:45 GMT
+      etag:
+      - W/"2e5dad7974dc1895b1ca33bd1961afb8"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244BDB:4EBF010:5ED66000
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3725'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits?path=datapackage.json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1WW2/aMBT+K1WeaXM3AanaJjFVnQQIDdZBVSHHOUlMc5Pt0FHEf99xoOvgoWuq
+        7q0vKJz4+879c263hkyp0Td8xw2J1YusyLegG/lBLwjtoBvbHoQsYlFArMAKPMfoGEUZwZJHCBoO
+        5mTi9FR4k1nD1dwbD65/DVeTh/Fqthk6185wkN0Pryb28GrmLgYzbzxN+XCauIvVV2tx8221uBrd
+        jwfzh/HgizcaXF8iOSvznCujvzVordJS6KeC5oDevqc0peLs61qUBZ6EnPIMzRg/mi9Amz8n2niB
+        JHggokrDHMuxzi1ybjlT2+vbvb7nLozdkycF/9FFDlLSRAdxXXDFaXaGMdGKsnu0nh1S7RhKAJ55
+        6kS3CwFxvdhzQ8tlcUx6kdf1fGaF0AWIXScERkPiY4a10AVIlapk3zRpxS8SrtI61AUwBVSlNHNQ
+        VKpSwHnGw3MFUklT/y6X+UYHI0GZCDJ1DNJ8tW+s3zs631dCmi2GUEOgUEtW1gWOi9Ux1iB4zBlV
+        HMcDq7n/DzinMc0kdAwBVOpXRl1InhT4pmPoB6pqgfUv6izrGBXdZCVFkP67e78035BiqvJseVzl
+        v9r7msbunb6hrPLE75tHq23a5qGvEnvzLABZmXDdOJk2W47vtPwQ3yfusRxNyI+fo4yt5vZoOn/U
+        HGuccXGaTWOUzmFbagmClYXCcWoWpzYb5k/rSw8ZEnHgaBTvX0unuaT5HOfLPXw+F5dZVj4g9jTU
+        450+ojf/gDCq/TMvkvYECNqapUoB64Th73TSHHWiDVMD2KKSoLLwSFNILLGAqA3JAYLBPBQYx7aR
+        sIarDiUTvNKr3SqsIyASlSKhBX9sNKIVEQL1SDaa2ialBoBAWON0tULuEVuzEnxN2UaXQQADvsaa
+        tmc7gSKZ2lT6Ypphx3WFuYIljXK9Zo1cnl6QHyt4uFY/VrDd5nys4P7SQjE72t5XrWBFhdYNo3/7
+        9HXIiO9Ar8d8AoQEQRD54BHq+j1GbNuLCYu6IZq7SP9OH2hPV3gLzy/fei2+XF7tc3e3u/sNmeus
+        SswMAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:45 GMT
+      etag:
+      - W/"468ab5e0d1265679b4f8d0bafe282f1f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:43 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244C1E:4EBF05F:5ED66001
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3724'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:45 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244C74:4EBF0BD:5ED66001
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3723'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHa6SJgcW2QLYLFMgGKHrY3YtASbTEWBJVkrLrCPnvfYeU
+        bNn1Jo7DYy6JTZPPDD9mOHzbkUxHs8nV9fXkcjIdn40qlYqI2kZ3t59X98WfRfLl5pF/+2uZVIv1
+        14dsevfwef319vePI3TmpUBPK4yNonKdcsuNsPhh3hRF1P1aCrRapcV5IeNz6mvY/0fUWi65BW3O
+        CyPORmpVCT2ataNCZbKCkQMYGCJPr67Gv04m15d7zq/vFzfrH5M/Gv6tztMvxTJ++D65u03Wdw/Z
+        vxjKYY/rqNEF6Lm1tZkx5hvNh4tM2ryJGyN0oiorKnuRqJI1rDf2aflxCkimO4xbMjTs4WrZkfxw
+        4Aw7PJPclsWeM94HN/LwmLkqCrUCc38WR5plGwDtmYPJKnsbDICWKZsLLC2m+0SLJLHnp1Ld4JbR
+        P5xLwhlsmxbpqcBuOJykI/bUMi1q5bhNbBItaytVdbK7OxBAlc54JR/5m6CAGLDI0ZMdc4MBEUsc
+        5pMpfnTLXLgma1o2LRIhl9iPt5H3MADbdU3Z5X6wgrRL0oqIpyUlBZcrns4Qva+MnQMJKBWbzR/N
+        KuQvigi92CSkZwPbLe6hID1giKgvrP/ROAQwYFiVhVgHYxKrZfjbxVuCxMBjpTmSeDAjO9CWDb/S
+        obKCl8FsORiguVLhVt7BAJXGNOKos3/8rjqmYX2wVU0Z+0x6TIgdb8bTMAdujMwqIYKt+AbYsv4S
+        iDWvkjyciZ7XMv/JnRqeBZsCsYCMCxUHY+JCZw7YMpNzfzXaKKTXZIF4Owa0mAedAvE2BqwOeG6c
+        +wTc4HFbWxyhYP73PNZ2O1DwKmt4Fs7CBkiXFUqVjD++WKEdH7NbIvBUmmoZN2ET85ZJM/BFEfJP
+        uC3YIrcGXNX1fEn3ikUaVHJumcpSvlTzHE/vcDshFtgExcG+Gfr+cun2umkQr2Xb+8VfZp2lULvR
+        3Wa9/0N73dsq2NHqeaz9peY2pwwLszXXItRkOhxrYzx1ny4uLtpccPcsKYUOmEU8DViukxzldSj/
+        256HyrHk1j1/5uR+iudQoXgabC82QMD9EQg1B08bnqMa9Xowxx1sSC9lAdVCVeHuiC1xaKdSVs5l
+        csxb8fgw34G2n4ysEnHG8bxBVFiZSMQJnux0AlDki3Cr6GmYHjQi/0wsBEIm2C5p4Xkt86pAKupC
+        rYNmyAGSEokWEKjSiFs8Sifjyfh8fHU+nvx9OZ1d3sw+3PxAn6aGBvbTPtMp9akbk7/QBem/ixV8
+        gir1vBC0/8YkxQl2jMm3kN+2iNkBLekniKTAod+L2tN8We7f7a/DYDq5KkWNOq1/nBv5iM9QLAc1
+        VqKaCruDxhW3eGygZtk29XVZD8i5iXwmGc2sbqA5Ukut1YNIrBm2bTPZoONKLuTOQKohN2qBf+Rv
+        jZdSa9WJjV5c6PIwZMNO8Uyl4XEhtg2qFlXn4XAaMhGV2SyDFwBoyoPuO0vgvqRizpvCRv6tRHIq
+        NFkIrDiOQpdYBtK8SG7tlBW/IHRU+zlSVvSfIbhYUdaRPx1WLQTps0Ahq6hVZP5pOI6eu8D6wf4X
+        14SpUDW2+4sWdJ3ujkkR4JB6vMcRisOO2AvEQ1noXSdu4ned+F0nfteJvdJO198BnbgSdgXBdJBN
+        h8/bPls//QcQ9RnaFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:19:45 GMT
+      etag:
+      - W/"2e5dad7974dc1895b1ca33bd1961afb8"
+      last-modified:
+      - Tue, 02 Jun 2020 14:19:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244CB4:4EBF111:5ED66001
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3722'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:19:46 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C918:3CF32:4244D0E:4EBF175:5ED66001
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3721'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_create_existing_name.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_create_existing_name.yaml
@@ -1,0 +1,3600 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:24 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAAB7:59CF03A:5ED66064
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3495'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:24 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAB04:59CF074:5ED66064
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3494'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821663,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE2NjM=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:21:25Z","updated_at":"2020-06-02T14:21:25Z","pushed_at":"2020-06-02T14:21:26Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:26 GMT
+      etag:
+      - '"250657a16286052abd46d300c0894ede"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAABA9:59CF0E0:5ED66064
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3493'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"bce41e4d117fa6f74a99cf9344d65913149859eb","node_id":"MDY6Q29tbWl0MjY4ODIxNjYzOmJjZTQxZTRkMTE3ZmE2Zjc0YTk5Y2Y5MzQ0ZDY1OTEzMTQ5ODU5ZWI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/bce41e4d117fa6f74a99cf9344d65913149859eb","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/bce41e4d117fa6f74a99cf9344d65913149859eb","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:26Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:26Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:27 GMT
+      etag:
+      - '"9f8975890be4c0aa9c656794bb1a980e"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAD57:59CF347:5ED66066
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3492'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aMBT+K1WeaXMhAYJUbQ/0oZNoxUbXhWlCTnJCTB07sx1WQP3vOw7pBR46
+        UnVvfUGJne/zd64+bC1OCrCGVkGUBml1rEQUBdXWcGupnOBGnIDvgp+6bj8jvazvkzBMsrDr+2kv
+        CN2u64eDIIQYoVykMKcpgsajqDfxQh3fMme8jPzr0eX91TLaXBdflrPp5H42/Xo3nl50Z8WFN1sm
+        TjS9CyIvCsabiTMbRe719GIznk6C69FNMLu9PN/TRSqdC2kUNtq/5SQn8uRiJQXHL6EglKEI1I/L
+        Z2CWPy/M4hkahx+kRBuTPcdzTp3eqeNNXX/ouUOvN7MeHj1gvPHfjihAKbIwIi451ZQwuoETlEVO
+        JJRCUS3kGoVqCfjNYyTczAnTzOv2+wPP77t+MIDU80LSj2N/kPRxZ5D2u+AgsJLGAbnWpRraNinp
+        2YLqvIqNA+z6CLsAjSEXEk4ZjU81KK1s8zufF2ujRIG2EWQbDco++mz03zsevktGZbdIQgMBrueJ
+        qDimsdOxViBpRhOiKaYHenP3DpinGWEKOpYEosyWVXFFFxx3OpZ5ILqS6H9eMdaxSrJmgiDIvD68
+        n5lvMDHXBZvve/lFeI8J7O7QN7hVHZz75tRqa7bdxFVhbJ4bABMLagKn8rrKcc+0n14Q9Lr77WjS
+        +/7jiiXLyL2aRhvDscIcl4fW1IvKa6qlUiATwTWmU104lV0zf1qd+8iwkA1H3fH+VXSGS9nPOl+P
+        4fN3mWBM/EHsodT9mt6jt59AqGr3TPmiPQGCtrbQOaCfUP6DMZpin2jDVAO22Emws9DUUCh0sYS0
+        DUkDQTF/OOrY1i2s5qpilUhamtJuJWsPiERCLginm7pHtCJCoEnJuqe2MakGIBBWmF2tkDvE1i4l
+        XZFkbdwgIQG6Qp+2ZzuAIplel+ZiusGIGw9TDXOSFqbM6nZ5eEF+lGBzrX6UYLvK+SjB3aWFzWyv
+        eo8qwZJI0zes4c9fWJBzRvkdvuCkCCx7j8kvloQnOQ5+T/8LzIX1grnlwGGmyEcuFFxKoSHRL2aw
+        ZqUZ0YCTmO1NaL8rai4NvAl0peYoLdkZDDwTMoF65GPY/oxGkWXoxPrmvm989HwmnvB6nz5+PD5w
+        Enbk2ipjw8NfcJqMVFkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:27 GMT
+      etag:
+      - W/"d0d04b8cca91ab8774ab35de61ee2784"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAE88:59CF49D:5ED66067
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3491'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAF03:59CF51A:5ED66067
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3490'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/bce41e4d117fa6f74a99cf9344d65913149859eb
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPJIAxn1KlHpJDKtEoLdUKqioyMARnMUS2WW0S5b933PTQ3nal
+        9mLhecy8N2/GN6J7TjJSN8B8YK3vxx2PupjxNG26NGCsjcLUD3yWJmEKNXHIOLVwEC0m5esy2tPU
+        1E+Dl59KtltvXz+fyutOfjpVxf61Kr4858UmqOSGVqfGK4vnsKRlmF/3XrUu/V2xuebFPtytv4XV
+        0/YDFp/VgIV7Y846c11+FqujMP1cr5pJugrOk3YlGK7NpGA5iHppQBvt2vNwkJeWIwbGxSQXM6RA
+        7B2t9UYOh78l/EH/FuIH6Xs4+Wz6SZHsRkYuAZv/2vOeq8XmRU0jOgKSC+sJzgnDK7Dhj0cbtJ7g
+        D9izTaMe9ZZetPRo4bOM+hmNKnJ3yEORgf9IYRSggtvvVfI7L207GsRxQlnsszCBltKUx3XNkiZG
+        JGnjALx/O22rQbtv5kZjJGjNj9a67SiM4IO4wsIu0OLXnglcsQtqPHMFo9Ek+/7DIS+gRCcabgTO
+        Bjt+3AEfQ8cHDQ5RwLWFyDxqcRwRcYj94GZWSDXOw2BLXoaJY5K93u8/ARdm4OSEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      etag:
+      - W/"2d7a7d6c5116de05ba0f23cd4463dcc3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:26 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAFAC:59CF5EB:5ED66068
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3489'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["bce41e4d117fa6f74a99cf9344d65913149859eb"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"b618bcbb4e99e8974709b4121ceb44f97088302c","node_id":"MDY6Q29tbWl0MjY4ODIxNjYzOmI2MThiY2JiNGU5OWU4OTc0NzA5YjQxMjFjZWI0NGY5NzA4ODMwMmM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b618bcbb4e99e8974709b4121ceb44f97088302c","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:28Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:28Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"bce41e4d117fa6f74a99cf9344d65913149859eb","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/bce41e4d117fa6f74a99cf9344d65913149859eb","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/bce41e4d117fa6f74a99cf9344d65913149859eb"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      etag:
+      - '"45c9212a72309f0623d85cb6bf78afbe"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAAFFA:59CF669:5ED66068
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3488'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWiuqm+LMFQUk04mgdons+IIdxXFkXyvSqv+dqxhZGFje8u67
+        911Zgo5V98zcgbaZB50REntgY7TQeEut2qryPdRB9Qex3758vfWHy358HY6jOutd7Y7P6mw+ni52
+        V88EntJAkEOccsW5nvzy06M7mWUbA08wRRoBpJmYYDF4s0DImPk9mybMVlMHyAmi699e0fTQIquu
+        LDtNQ6YFUYCwRbHpdNlthJay7eRKCFuuZbEqhHxcSzBkhvMERJBH8Pi/pj8/M/+zze32DZCFwVh9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:29 GMT
+      etag:
+      - W/"40669a4dc909bd9f91022db600c40818"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:26 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB09D:59CF71C:5ED66068
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3487'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "b618bcbb4e99e8974709b4121ceb44f97088302c"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vnghNqkY8ZlbZSytRUsEQ++6gTxUlkH6gB8d97qGOXDl3e5b3n
+        3ucqAh5Fec8oHWobpdeRMIgHMYwWm9ZyW22q9buvfdXt1W7z8vXW7S+74bU/DNVZb2t3eK7O8PF0
+        sdt6ZvAUeoYc0RRLKfXULj9bcidYmtHLgNPII0g8MwZc9C0sCCNFec+m8bPV3CFJhvj6t9cIHRoS
+        5VVEp3kI1mkOBkBhUWBeZCpLClDpKjUISh2LLMnzx2Rl2IzmCZlgD9/S/5r+/Izyzza32zd6IMQu
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:29 GMT
+      etag:
+      - W/"a005d018f4e6e2b5059504a4abf79295"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB0FB:59CF788:5ED66069
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3486'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:30 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB1E2:59CF8AE:5ED66069
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3485'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SOmnmNgaJ7aFdgQBpg2EPbF4GSaIm2JGokZc8R8t33P1Ky
+        ZM9NHIePeUlsmvzd8Xh3PF47EelkHs7evw+vZ7N3F5NKpjyiscndp8+b++LPIvly+8C+/bVOqtX2
+        6zK7uVt+Dr8u7z5MMJmVHDMN1yaKym3KDNPc4IdFUxRR92vJMWqk4peFiC9prg7+v6JWYs0MaAtW
+        aH4xkZuKq8m8nRQyExWEHMFAEGk6m01/C8P31wfKb+9Xt9sf4R8N+1bn6ZdiHS+/h3efku3dMvsX
+        SxnkMRU1qgA9N6bW8yBwg/rdVSZM3sSN5iqRleGVuUpkGTRBL+zj+sMNIJnqMNZkGDjA1aIjueXA
+        6eD4TnJTFgfKOB3syuNrFrIo5AbMw12cKDbYAejMLExU2etgALSBNDmHabHdRzKSwJmfS7WL24D+
+        wS8Jp3FsiqfnArvlUJJc7LENFK+l5TaxTpSojZDV2eruQQCVKmOVeGCvggKiwSJFz1bMLgaEr+HM
+        Z1Pc6jaw4ZpsyWyKJ1yscR6vIx9gADbbmrLL/ciCdErC8IilJSUFmyseLxC9L4ydIwko5bvDn8wr
+        5C+KCLXaJaQnA9sa91iQHhFE1GfsfzIOAQwYrLLiW29MYrUB/nbxliAxsFgqhiTuTcgetA3GX8mp
+        DGelN1kWBmgupT/LWxigQuuGn+T7p5+qZeqgD7aqKWOXSU8JsdPFOBr2wLQWWcW5N4vvgG3QXwKx
+        YlWS+xPR89rAfbJewzJvWyAWkHEhY29MXOiBBbaBzpm7Gk3kU2uSQLw9AYovvG6BeDsBRnn0G6s+
+        AXd43NYGLuRN/54XtN0JFKzKGpb5k7AD0mWFUiVjD89WaKfH7EAEnkpTJeLGb2IemLQDVxQh//g7
+        ggE5CLBV19Ml3QuMNKrkrJnKUjxX85xO73B7IeZZBMXBoRj6/nzp9rJtEK8NhvvFXWadJF+n0d1m
+        vf5jed3byptr9byg/aVmJqcMC7E1U9zXZjpc0MZ46j5eXV21OWf2WVJy5TGLOBqwTCU5ymtf+rc9
+        D5VjyYx9/ixI/RTPoUKy1NtZ7ICAOxfwtQdHG/tRjXrdm+IWNqaXokDXQlb+7oiBOJZTSSMWIjnl
+        rXh6mO9B249aVAm/YHjeICqMSATiBE928gAU+dyfFR0N20OPyD0TC46Q8XZKijteG7iuQMrrQm69
+        ZsgRkhKJ4mhQpREzeJSG03B6OZ1dTsO/r2/m4fU8/PUH5jQ1emA/n3NLc+pG589MQfrvYgWf0JV6
+        uhF0+MakjhPkaJ0PkN8HxPxIL+kniKSA0x9E7Xm6rA/v9pdhsJ1clrxGndY/zrV4wOfpXo2VyKbC
+        6WBwwwweG6hZhqG+LusBOdORyySTuVENeo40Uiu55InR47Ehk40mbsRK7C2kGnLXLXCP/EF4KZSS
+        XbPRNRe6PIy2YdfxTIVmccGHAVnzqtNwvA2R8ErvzOAaALTl0fQ9E9gvKV+wpjCReytROxU9WTRY
+        4Y5clTAD9byo3dp1VpxByFX7PVJWdJ/RcDG8rCPnHUauOPVngUJWkZtI/9MwuJ69wPrF7hc7hK1Q
+        Nbb/i+J0ne6vSRHgaPU4jSMUhx2xbxCP20JvfeImfusTv/WJ3/rErtNO19+RPnHFzQYN01E2HT9v
+        +2z9+B/h/mL/FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:30 GMT
+      etag:
+      - W/"66ddf7bcdb91ca5dadf71d4b9a947359"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:29 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB23A:59CF90B:5ED6606A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3484'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:30 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB286:59CF969:5ED6606A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3483'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SOmnmNgaJ7aFdgQBpg2EPbF4GSaIm2JGokZc8R8t33P1Ky
+        ZM9NHIePeUlsmvzd8Xh3PF47EelkHs7evw+vZ7N3F5NKpjyiscndp8+b++LPIvly+8C+/bVOqtX2
+        6zK7uVt+Dr8u7z5MMJmVHDMN1yaKym3KDNPc4IdFUxRR92vJMWqk4peFiC9prg7+v6JWYs0MaAtW
+        aH4xkZuKq8m8nRQyExWEHMFAEGk6m01/C8P31wfKb+9Xt9sf4R8N+1bn6ZdiHS+/h3efku3dMvsX
+        SxnkMRU1qgA9N6bW8yBwg/rdVSZM3sSN5iqRleGVuUpkGTRBL+zj+sMNIJnqMNZkGDjA1aIjueXA
+        6eD4TnJTFgfKOB3syuNrFrIo5AbMw12cKDbYAejMLExU2etgALSBNDmHabHdRzKSwJmfS7WL24D+
+        wS8Jp3FsiqfnArvlUJJc7LENFK+l5TaxTpSojZDV2eruQQCVKmOVeGCvggKiwSJFz1bMLgaEr+HM
+        Z1Pc6jaw4ZpsyWyKJ1yscR6vIx9gADbbmrLL/ciCdErC8IilJSUFmyseLxC9L4ydIwko5bvDn8wr
+        5C+KCLXaJaQnA9sa91iQHhFE1GfsfzIOAQwYrLLiW29MYrUB/nbxliAxsFgqhiTuTcgetA3GX8mp
+        DGelN1kWBmgupT/LWxigQuuGn+T7p5+qZeqgD7aqKWOXSU8JsdPFOBr2wLQWWcW5N4vvgG3QXwKx
+        YlWS+xPR89rAfbJewzJvWyAWkHEhY29MXOiBBbaBzpm7Gk3kU2uSQLw9AYovvG6BeDsBRnn0G6s+
+        AXd43NYGLuRN/54XtN0JFKzKGpb5k7AD0mWFUiVjD89WaKfH7EAEnkpTJeLGb2IemLQDVxQh//g7
+        ggE5CLBV19Ml3QuMNKrkrJnKUjxX85xO73B7IeZZBMXBoRj6/nzp9rJtEK8NhvvFXWadJF+n0d1m
+        vf5jed3byptr9byg/aVmJqcMC7E1U9zXZjpc0MZ46j5eXV21OWf2WVJy5TGLOBqwTCU5ymtf+rc9
+        D5VjyYx9/ixI/RTPoUKy1NtZ7ICAOxfwtQdHG/tRjXrdm+IWNqaXokDXQlb+7oiBOJZTSSMWIjnl
+        rXh6mO9B249aVAm/YHjeICqMSATiBE928gAU+dyfFR0N20OPyD0TC46Q8XZKijteG7iuQMrrQm69
+        ZsgRkhKJ4mhQpREzeJSG03B6OZ1dTsO/r2/m4fU8/PUH5jQ1emA/n3NLc+pG589MQfrvYgWf0JV6
+        uhF0+MakjhPkaJ0PkN8HxPxIL+kniKSA0x9E7Xm6rA/v9pdhsJ1clrxGndY/zrV4wOfpXo2VyKbC
+        6WBwwwweG6hZhqG+LusBOdORyySTuVENeo40Uiu55InR47Ehk40mbsRK7C2kGnLXLXCP/EF4KZSS
+        XbPRNRe6PIy2YdfxTIVmccGHAVnzqtNwvA2R8ErvzOAaALTl0fQ9E9gvKV+wpjCReytROxU9WTRY
+        4Y5clTAD9byo3dp1VpxByFX7PVJWdJ/RcDG8rCPnHUauOPVngUJWkZtI/9MwuJ69wPrF7hc7hK1Q
+        Nbb/i+J0ne6vSRHgaPU4jSMUhx2xbxCP20JvfeImfusTv/WJ3/rErtNO19+RPnHFzQYN01E2HT9v
+        +2z9+B/h/mL/FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:31 GMT
+      etag:
+      - W/"66ddf7bcdb91ca5dadf71d4b9a947359"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:29 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB2CC:59CF9B2:5ED6606A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3482'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXWvbMBT9K0HPSSzb8ocMgw26lQycUJYS3FGCJF/HyvwRLLlrG/Lfd0W2sb2l
+        kL4Y61wfnXvPPfhITC1IRmTsp1JJyYBzSHnCEsol8wNfgWSs4glN05AGikxJ15ew1SWS8psivgu4
+        lZuG5vuCrW4Wz8t98bpqF0G+rnURfNXL2/totblnq7Wiy9dPUbG/e873X/YPmwVd3hYRYsjLf+Zt
+        /gEvH4cGL66tPZjM88RBz3fa1qOcq771Bjj0xmvBCmP7AWaNljMLxhrPPbfb9qUUWAPrIclDRqux
+        9obRats22/9b+Ef+EuGz6Fs0xWjrfiDZkXSiBRz+Wy1qMUw+Pw19h45AK7TzBPeE8Bwc/HHnQOcJ
+        foAzO1pAAzqj8YwGa59lgZ8F6QM5Tcm5IwvvKGEHwA6Ov6OUJJDGIatYKGmoqirmJUtYpKiEBKAK
+        AwlKyDi67rZdD8a7WBuNacEYsXPWLTpttWgmLj0HoX4gOjnbhj0exACdNST7/mdAqYD5wErfTyoR
+        VwkTnKuKh4yVccT90Gc8jTjI6w74N86Xq18vzpdqnh6n5AkGXWklrMb8YirOZ8AfRiUaA1MygDCu
+        RMbO6F2HlSlxL8KOA66jG5vG2f7S9AJJ7ng6/QKHWNh6qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:31 GMT
+      etag:
+      - W/"45c9212a72309f0623d85cb6bf78afbe"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB323:59CFA22:5ED6606B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3481'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b618bcbb4e99e8974709b4121ceb44f97088302c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28hO/KXAKI3ZigPrWHcxJxSCPk5spbJkLKUhK/3vO24D69Je
+        ZGWMXUgcdKTzPrzn6CEwrIVgGkjmWcfEHathtHHWBGdBx3zzdsY1DBM5ZLmQlMmMAh2PJzzM0yTK
+        0kRKSCFLQhrSnKchlnLqB4rQ9CzY9hqfNt53bkoI69SoVr7Z8pGwLemhs4604Jnztodzrfi5B+cd
+        GfbVqt0PmA48EdZ4MJg45r7oYf2Bp1HOBecxUAo5zeIspDyOxpEAHsdrmoV5PgnHAska3+rV71Av
+        gE5B4dpycqriK15EQL0jgnfbgqXIwOPIHzRH2p3RlskjiJ7tDr3ZOugPhj+16SRXTmzBW4b4fTeM
+        5FppQHsOyngAO1uXxXy7+B7pcoNxGyXLq0/horrWsihdefmU3y+r63tZzTfL6rP6oma8UJf1rSmL
+        WTZEZTGs+W5R3djnKjeNvPp4zyv96+W3ZCMmC/V8f0ZvzRBVXzuMEAmMsFKZGpk4jmMa49lKK3Pn
+        gulD4ECv/6sZx6n4GzzvGq7hf70Q/7d/6/HxJ+VOwRDgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:31 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB375:59CFA8A:5ED6606B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3480'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "b618bcbb4e99e8974709b4121ceb44f97088302c"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxNjYzOjBlOTMxYjFiMmMzY2FjM2FkMTcwMGNkMmM4NWZkMGM5ZTg1NTBhNTk=","sha":"0e931b1b2c3cac3ad1700cd2c85fd0c9e8550a59","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/0e931b1b2c3cac3ad1700cd2c85fd0c9e8550a59","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:32Z"},"object":{"sha":"b618bcbb4e99e8974709b4121ceb44f97088302c","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      etag:
+      - '"b6d21a7c3b06ead293d0cd01a897b156"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/0e931b1b2c3cac3ad1700cd2c85fd0c9e8550a59
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB3BC:59CFAE1:5ED6606B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3479'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "0e931b1b2c3cac3ad1700cd2c85fd0c9e8550a59", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxNjYzOnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"0e931b1b2c3cac3ad1700cd2c85fd0c9e8550a59","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/0e931b1b2c3cac3ad1700cd2c85fd0c9e8550a59"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:33 GMT
+      etag:
+      - '"7d246aaf45fa674a8b2ab5598e409a81"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB49D:59CFBF1:5ED6606C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3478'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:33 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB592:59CFD1C:5ED6606D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3477'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJmGipG7WwGJ72O0CBbIBih529yJQEi3RlkSVpOw6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFkxvb4Or6fT6bFKqRIQ0Nrn7/GV9n/+Zx18/PPDvf63icrn5
+        tkhv7hZfgm+Lu48TTOaFwEwrjA3DYpNwy42w+GFe53nY/VoIjFqlxXkuo3Oaa9j/V1RarrgFbc5z
+        I84mal0KPZk1k1ylsoSQAxgIIk2n08vfguD2ak/5zf3yw+Zn8EfNv1dZ8jVfRYsfwd3neHO3SP/F
+        Ug55XIe1zkHPrK3MjDE3aK4vUmmzOqqN0LEqrSjtRawKVrNe2KfVxxtAUt1hWpNhYA9XyY7klgNn
+        2OGdZLbI95RxOrQrD6+ZqzxXazD3d3GkWLYF0Jm1MFmmb4MB0DBlMwHTYruPZCSJMz+V2i5uGP2D
+        XxLO4Ni0SE4FdsuhJLnYY8O0qFTLrSMTa1lZqcqT1d2BAKp0ykv5wN8EBcSARYqerFi7GBCxgjOf
+        THGrG9aGa7whs2kRC7nCebyNvIcB2G4qyi73IwvSKUkrQp4UlBTaXPF4huh9ZewcSECJ2B7+ZFYi
+        f1FE6OU2IT0b2K1xDwXpAUFEfcH+R+MQwIDBKkux8cYkVsPwt4u3GImBR0pzJHFvQnagDRt/Jaey
+        ghfeZLUwQDOl/Fm+hQEqjanFUb5//Km2TMP6YCvrInKZ9JgQO16Mo2EP3BiZlkJ4s/gW2LD+Eog0
+        L+PMn4ie1zD3qfUannrbArGAjHIVeWPiQmctsGEm4+5qtKFPrUkC8XYEaDH3ugXibQVY7dFvWvUJ
+        uMXjtrZwIW/69zzWdCeQ8zKteepPwhZIlxVKlZQ/vFihHR+zAxF4Kk21jGq/iXlg0g5cUYT84+8I
+        BuQgoK26ni/pXmGkUSXXmqko5Es1z/H0DrcTYp5FUBzsi6HvL5dur9sG8Ro23C/uMusk+TqN7jbr
+        9R/L695W3lyr57Hml4rbjDIsxFZcC1+b6XCsifDUfby4uGgywdtnSSG0xyziaMByHWcor33p3/Q8
+        VI4Ft+3zZ07qJ3gO5Yon3s5iCwTcuYCvPTja2I8q1OveFG9hY3ohc3QtVOnvjhiIYzmlsnIu42Pe
+        iseH+Q60+WRkGYszjucNosLKWCJO8GQnD0CRL/xZ0dGwPfSI3DMxFwgZb6ekheM1zHUFElHlauM1
+        Q46QlEi0QIMqCbnFozS4DC7PL6fnl8HfVzez4GoW/PoTc+oKPbAn51wHNKeqTfb0lGuagvTfxQo+
+        oSv1fCNo/41JHSdAjMkGyO8DYnagl/QEIs7h9HtRe5ouq/27/XUYbCdThahQp/WPcyMf8Plyp8aK
+        VV3idDC45haPDdQsw1Bfl/WAjJvQZZLJzOoaPUcaqbRaiNia8diQyUYT13IpdxZSDbntFrhH/iC8
+        kFqrrtnomgtdHkbbsOt4JtLwKBfDgKpE2Wk43oaMRWm2ZnANANryaPqOCdoviZjzOreheytROxU9
+        WTRY4Y5CFzAD9byo3dp1VpxByFX7PVJWdJ/RcLGiqELnHVYtBfVngUJWUevQ/FNzuF57gfWL3S/t
+        ELZC1djuL1rQdbq7JkGAo9XjNA5RHHbEvkE8bgu994nr6L1P/N4nfu8Tu047XX8H+sSlsGs0TEfZ
+        dPy87bP143+7ERYCFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:33 GMT
+      etag:
+      - W/"e89dfe29c917cdaa2e20cc3edb6888d4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB5DA:59CFD80:5ED6606D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3476'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vnghNqkY8ZlbZSytRUsEQ++6gTxUlkH6gB8d97qGOXDl3e5b3n
+        3ucqAh5Fec8oHWobpdeRMIgHMYwWm9ZyW22q9buvfdXt1W7z8vXW7S+74bU/DNVZb2t3eK7O8PF0
+        sdt6ZvAUeoYc0RRLKfXULj9bcidYmtHLgNPII0g8MwZc9C0sCCNFec+m8bPV3CFJhvj6t9cIHRoS
+        5VVEp3kI1mkOBkBhUWBeZCpLClDpKjUISh2LLMnzx2Rl2IzmCZlgD9/S/5r+/Izyzza32zd6IMQu
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:33 GMT
+      etag:
+      - W/"a005d018f4e6e2b5059504a4abf79295"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB634:59CFDDE:5ED6606D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3475'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXWvbMBT9K0HPSSzb8ocMgw26lQycUJYS3FGCJF/HyvwRLLlrG/Lfd0W2sb2l
+        kL4Y61wfnXvPPfhITC1IRmTsp1JJyYBzSHnCEsol8wNfgWSs4glN05AGikxJ15ew1SWS8psivgu4
+        lZuG5vuCrW4Wz8t98bpqF0G+rnURfNXL2/totblnq7Wiy9dPUbG/e873X/YPmwVd3hYRYsjLf+Zt
+        /gEvH4cGL66tPZjM88RBz3fa1qOcq771Bjj0xmvBCmP7AWaNljMLxhrPPbfb9qUUWAPrIclDRqux
+        9obRats22/9b+Ef+EuGz6Fs0xWjrfiDZkXSiBRz+Wy1qMUw+Pw19h45AK7TzBPeE8Bwc/HHnQOcJ
+        foAzO1pAAzqj8YwGa59lgZ8F6QM5Tcm5IwvvKGEHwA6Ov6OUJJDGIatYKGmoqirmJUtYpKiEBKAK
+        AwlKyDi67rZdD8a7WBuNacEYsXPWLTpttWgmLj0HoX4gOjnbhj0exACdNST7/mdAqYD5wErfTyoR
+        VwkTnKuKh4yVccT90Gc8jTjI6w74N86Xq18vzpdqnh6n5AkGXWklrMb8YirOZ8AfRiUaA1MygDCu
+        RMbO6F2HlSlxL8KOA66jG5vG2f7S9AJJ7ng6/QKHWNh6qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:34 GMT
+      etag:
+      - W/"45c9212a72309f0623d85cb6bf78afbe"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB68B:59CFE57:5ED6606D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3474'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b618bcbb4e99e8974709b4121ceb44f97088302c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28hO/KXAKI3ZigPrWHcxJxSCPk5spbJkLKUhK/3vO24D69Je
+        ZGWMXUgcdKTzPrzn6CEwrIVgGkjmWcfEHathtHHWBGdBx3zzdsY1DBM5ZLmQlMmMAh2PJzzM0yTK
+        0kRKSCFLQhrSnKchlnLqB4rQ9CzY9hqfNt53bkoI69SoVr7Z8pGwLemhs4604Jnztodzrfi5B+cd
+        GfbVqt0PmA48EdZ4MJg45r7oYf2Bp1HOBecxUAo5zeIspDyOxpEAHsdrmoV5PgnHAska3+rV71Av
+        gE5B4dpycqriK15EQL0jgnfbgqXIwOPIHzRH2p3RlskjiJ7tDr3ZOugPhj+16SRXTmzBW4b4fTeM
+        5FppQHsOyngAO1uXxXy7+B7pcoNxGyXLq0/horrWsihdefmU3y+r63tZzTfL6rP6oma8UJf1rSmL
+        WTZEZTGs+W5R3djnKjeNvPp4zyv96+W3ZCMmC/V8f0ZvzRBVXzuMEAmMsFKZGpk4jmMa49lKK3Pn
+        gulD4ECv/6sZx6n4GzzvGq7hf70Q/7d/6/HxJ+VOwRDgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:34 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB6D1:59CFEA7:5ED6606E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3473'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:34 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB725:59CFEFE:5ED6606E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3472'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJmGipG7WwGJ72O0CBbIBih529yJQEi3RlkSVpOw6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFkxvb4Or6fT6bFKqRIQ0Nrn7/GV9n/+Zx18/PPDvf63icrn5
+        tkhv7hZfgm+Lu48TTOaFwEwrjA3DYpNwy42w+GFe53nY/VoIjFqlxXkuo3Oaa9j/V1RarrgFbc5z
+        I84mal0KPZk1k1ylsoSQAxgIIk2n08vfguD2ak/5zf3yw+Zn8EfNv1dZ8jVfRYsfwd3neHO3SP/F
+        Ug55XIe1zkHPrK3MjDE3aK4vUmmzOqqN0LEqrSjtRawKVrNe2KfVxxtAUt1hWpNhYA9XyY7klgNn
+        2OGdZLbI95RxOrQrD6+ZqzxXazD3d3GkWLYF0Jm1MFmmb4MB0DBlMwHTYruPZCSJMz+V2i5uGP2D
+        XxLO4Ni0SE4FdsuhJLnYY8O0qFTLrSMTa1lZqcqT1d2BAKp0ykv5wN8EBcSARYqerFi7GBCxgjOf
+        THGrG9aGa7whs2kRC7nCebyNvIcB2G4qyi73IwvSKUkrQp4UlBTaXPF4huh9ZewcSECJ2B7+ZFYi
+        f1FE6OU2IT0b2K1xDwXpAUFEfcH+R+MQwIDBKkux8cYkVsPwt4u3GImBR0pzJHFvQnagDRt/Jaey
+        ghfeZLUwQDOl/Fm+hQEqjanFUb5//Km2TMP6YCvrInKZ9JgQO16Mo2EP3BiZlkJ4s/gW2LD+Eog0
+        L+PMn4ie1zD3qfUannrbArGAjHIVeWPiQmctsGEm4+5qtKFPrUkC8XYEaDH3ugXibQVY7dFvWvUJ
+        uMXjtrZwIW/69zzWdCeQ8zKteepPwhZIlxVKlZQ/vFihHR+zAxF4Kk21jGq/iXlg0g5cUYT84+8I
+        BuQgoK26ni/pXmGkUSXXmqko5Es1z/H0DrcTYp5FUBzsi6HvL5dur9sG8Ro23C/uMusk+TqN7jbr
+        9R/L695W3lyr57Hml4rbjDIsxFZcC1+b6XCsifDUfby4uGgywdtnSSG0xyziaMByHWcor33p3/Q8
+        VI4Ft+3zZ07qJ3gO5Yon3s5iCwTcuYCvPTja2I8q1OveFG9hY3ohc3QtVOnvjhiIYzmlsnIu42Pe
+        iseH+Q60+WRkGYszjucNosLKWCJO8GQnD0CRL/xZ0dGwPfSI3DMxFwgZb6ekheM1zHUFElHlauM1
+        Q46QlEi0QIMqCbnFozS4DC7PL6fnl8HfVzez4GoW/PoTc+oKPbAn51wHNKeqTfb0lGuagvTfxQo+
+        oSv1fCNo/41JHSdAjMkGyO8DYnagl/QEIs7h9HtRe5ouq/27/XUYbCdThahQp/WPcyMf8Plyp8aK
+        VV3idDC45haPDdQsw1Bfl/WAjJvQZZLJzOoaPUcaqbRaiNia8diQyUYT13IpdxZSDbntFrhH/iC8
+        kFqrrtnomgtdHkbbsOt4JtLwKBfDgKpE2Wk43oaMRWm2ZnANANryaPqOCdoviZjzOreheytROxU9
+        WTRY4Y5CFzAD9byo3dp1VpxByFX7PVJWdJ/RcLGiqELnHVYtBfVngUJWUevQ/FNzuF57gfWL3S/t
+        ELZC1djuL1rQdbq7JkGAo9XjNA5RHHbEvkE8bgu994nr6L1P/N4nfu8Tu047XX8H+sSlsGs0TEfZ
+        dPy87bP143+7ERYCFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:34 GMT
+      etag:
+      - W/"e89dfe29c917cdaa2e20cc3edb6888d4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB76D:59CFF66:5ED6606E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3471'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/iOBT+K1WeaXPBSQjSaGal7o66ElTVttNhRhWynRNixrms7dAL4r/vcUgv
+        8NAhVfetLwicfMff+c6VtVPSApyxU1BtQDkDh1dFIYwzXjs6p/iARf6IccYIJAmMkpjEXsKIH/gc
+        GCFZEnuj0dALOELLKoW5SBE0OZ1FF0Fi2LX0JssZOT89u5suZw/nxVkwuczFLPhbTL9ehefXV+T8
+        knvThz/C2fLibrL8a/nj+sybfp2FeIa4ye2kmHza4UUbk1fKMuy4/5PTnKqjP1eqKvFNKKiQSAL5
+        4/EJ2OMvC3t4gs7hCyk11uXAC7xjLzr2gkufjAN/HIx+OJtHBawa/9sVBWhNF5bEWSmMoPIIOdGa
+        8l94etSFYOAYBfjOYyTiGEbRkGRkyLwhz7IoSUlMQu4xiAGyYcCAUxaF6GGjrAC5MbUeuy6txclC
+        mLxhVgBXQV1ptwCDIa8UHEvBjg1oo137OZ8X95aMBuMiyLUctHvw3ajfO16+VUK7PZLQQqA0c141
+        JaaxN3BWoEQmODUC0wPV3P4GzNOMSg0DRwHV9pHTlFosSnwycOwXahqF+peNlAOnpveyogiyPzfv
+        5+YbXMxNIee7Kr8I7yGB3V76Bln13r1vTq2+brtdXDXG5rkByGohbOB03lY5PrPtJwrDaLjbji6i
+        b9+nki9n/vRy9mBtrDDH1b437aEOumppNChelQbTqS2cxm0tf159ImhhoTobbcf7XdFZW9p95vl6
+        DJ/fyyopq1vE7lPdrekd8+4TCFltv4ty0d8AgtZuZXJAnZD+xjotsE/0sdQC1thJsLOI1JrQKLGC
+        tI+RDoJkbkvksW5bWGurYZorUdvS7kVrB4iGKrWgpXhoe0QvQwi0Kdn21D4utQAEwgqzqxdyi1i7
+        tRIryu+tDAo4iBVq2t/aHhSNmfvaDqYrjLhVWBiY07SwZda2y/0B+VGC3Vj9KMF+lfNRgtuhhc1s
+        p3oPKsGaKts3nPHPpz2dA/GBpL4fZzTKYkKThGfJkJA0ChN/6JNkFCbA0Pw7LWhPI/zwm1+fen02
+        l0Pv3Nxgw5pLUf5CsVArkNl7bMZM0ZLnuBg//W+yrr2w3HMhs1v2oy0kXKvKADcvdtTupFthoaRM
+        7myw/zbCDlWclKbRc6TGtw5DmVWKQ7sSSxwPlmOVZZgF7WZz1+bQjd1nn294fY4d/vdhTyScWK1X
+        1ofNf7iWbl55DgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:35 GMT
+      etag:
+      - W/"674f9550fa5f148667f3c5430ee0da15"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB7CA:59CFFCD:5ED6606E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3470'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:35 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB81E:59D0032:5ED6606F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3469'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXWvbMBT9K0HPSSzb8ocMgw26lQycUJYS3FGCJF/HyvwRLLlrG/Lfd0W2sb2l
+        kL4Y61wfnXvPPfhITC1IRmTsp1JJyYBzSHnCEsol8wNfgWSs4glN05AGikxJ15ew1SWS8psivgu4
+        lZuG5vuCrW4Wz8t98bpqF0G+rnURfNXL2/totblnq7Wiy9dPUbG/e873X/YPmwVd3hYRYsjLf+Zt
+        /gEvH4cGL66tPZjM88RBz3fa1qOcq771Bjj0xmvBCmP7AWaNljMLxhrPPbfb9qUUWAPrIclDRqux
+        9obRats22/9b+Ef+EuGz6Fs0xWjrfiDZkXSiBRz+Wy1qMUw+Pw19h45AK7TzBPeE8Bwc/HHnQOcJ
+        foAzO1pAAzqj8YwGa59lgZ8F6QM5Tcm5IwvvKGEHwA6Ov6OUJJDGIatYKGmoqirmJUtYpKiEBKAK
+        AwlKyDi67rZdD8a7WBuNacEYsXPWLTpttWgmLj0HoX4gOjnbhj0exACdNST7/mdAqYD5wErfTyoR
+        VwkTnKuKh4yVccT90Gc8jTjI6w74N86Xq18vzpdqnh6n5AkGXWklrMb8YirOZ8AfRiUaA1MygDCu
+        RMbO6F2HlSlxL8KOA66jG5vG2f7S9AJJ7ng6/QKHWNh6qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:35 GMT
+      etag:
+      - W/"45c9212a72309f0623d85cb6bf78afbe"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB8AC:59D00E7:5ED6606F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3468'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["b618bcbb4e99e8974709b4121ceb44f97088302c"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"f90ccb880a2e626516e2b48af130de4e606ef647","node_id":"MDY6Q29tbWl0MjY4ODIxNjYzOmY5MGNjYjg4MGEyZTYyNjUxNmUyYjQ4YWYxMzBkZTRlNjA2ZWY2NDc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/f90ccb880a2e626516e2b48af130de4e606ef647","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/f90ccb880a2e626516e2b48af130de4e606ef647","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:35Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:35Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"b618bcbb4e99e8974709b4121ceb44f97088302c","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b618bcbb4e99e8974709b4121ceb44f97088302c","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b618bcbb4e99e8974709b4121ceb44f97088302c"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:36 GMT
+      etag:
+      - '"bf45540bd03963bce5d2677943c7ed6e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/f90ccb880a2e626516e2b48af130de4e606ef647
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB902:59D013E:5ED6606F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3467'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vnghNqkY8ZlbZSytRUsEQ++6gTxUlkH6gB8d97qGOXDl3e5b3n
+        3ucqAh5Fec8oHWobpdeRMIgHMYwWm9ZyW22q9buvfdXt1W7z8vXW7S+74bU/DNVZb2t3eK7O8PF0
+        sdt6ZvAUeoYc0RRLKfXULj9bcidYmtHLgNPII0g8MwZc9C0sCCNFec+m8bPV3CFJhvj6t9cIHRoS
+        5VVEp3kI1mkOBkBhUWBeZCpLClDpKjUISh2LLMnzx2Rl2IzmCZlgD9/S/5r+/Izyzza32zd6IMQu
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:36 GMT
+      etag:
+      - W/"a005d018f4e6e2b5059504a4abf79295"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB988:59D01EF:5ED66070
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3466'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "f90ccb880a2e626516e2b48af130de4e606ef647"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWqchmJC5agHJdCKoXSI7vmBHcRzZ14q06n/nKkYWBpa3vPvu
+        fRcWoWPVLRO3oEziXiWEyO7YGAw0zlAr11K8+9rLfl/s1i9fb/3+vBtfh8MoT2pb28OzPOmPzdls
+        65nAYxwIsohTqjhXk1t+OrRHvWyD5xGmQCOANBMiLAanFwgJE79l0/jZKOoAOUF0/dsr6B5aZNWF
+        JatoqHvK2laXZaZyELl4WAnIdVGqbnWfGShAZAI6UTySGc4TEEEe3uH/mv78TPzPNtfrN77qW919
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:37 GMT
+      etag:
+      - W/"e1556ea2758f9d9dc12abb59e39199cb"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BAB9C7:59D0240:5ED66070
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3465'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:37 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABAE2:59D0388:5ED66071
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3464'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJlGipN6sgcX2sNsFCmQDFD1s9yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFk5vb8Or6fT6bFLJlEc0Nrn78nV9X/xRJN8+PrAff66Sarn5
+        vshu7hZfw++Lu08TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpOp5cfwvD2ak/5zf3y4+Zn+HvDftR5+q1YxYu/w7svyeZukf2L
+        pQzymIoaVYCeG1PrWRC4QX19kQmTN3GjuUpkZXhlLhJZBk3QC/u8+nQDSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9jYYAG0gTc5hWmz3kYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2wDxWtpuU2sEyVqI2R1sro7EEClylglHtiboIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMfbyHsYgM2mpuxyP7IgnZIwPGJpSUnB5orHM0TvK2PnQAJK+fbwJ7MK
+        +YsiQi23CenZwLbGPRSkBwQR9QX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnYw4sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XxJ9wojjSo5a6ayFC/VPMfTO9xOiHkWQXGwL4a+v1y6vW4bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6mZySnDQmzNFPe1mQ4XtDGeuo8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9rMWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhZXh5fjk9vwz/urqZhVez8NefmNPU6IE9Oec6pDl1o/Onp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECROt8gPw2IGYHeklPIJICTr8Xtafpstq/21+HwXZyWfIadVr/ONfiAZ8vd2qs
+        RDYVTgeDa2bw2EDNMgz1dVkPyJmOXCaZzIxq0HOkkVrJBU+MHo8NmWw0cS2WYmch1ZDbboF75A/C
+        S6GU7JqNrrnQ5WG0DbuOZyo0iws+DMiaV52G422IhFd6awbXAKAtj6bvmMB+SfmcNYWJ3FuJ2qno
+        yaLBCnfkqoQZqOdF7daus+IMQq7a75GyovuMhovhZR057zByyak/CxSyilxH+p+GwfXsBdYvdr/Y
+        IWyFqrHdXxSn63R3TYoAR6vHaRyhOOyIfYN43BZ67xM38Xuf+L1P/N4ndp12uv4O9IkrbtZomI6y
+        6fh522frx/8A7885YBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:38 GMT
+      etag:
+      - W/"d36699bdd00da574823c0f965a7d19a6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABB27:59D03F3:5ED66071
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3463'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:38 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABB70:59D044A:5ED66072
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3462'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJlGipN6sgcX2sNsFCmQDFD1s9yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFk5vb8Or6fT6bFLJlEc0Nrn78nV9X/xRJN8+PrAff66Sarn5
+        vshu7hZfw++Lu08TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpOp5cfwvD2ak/5zf3y4+Zn+HvDftR5+q1YxYu/w7svyeZukf2L
+        pQzymIoaVYCeG1PrWRC4QX19kQmTN3GjuUpkZXhlLhJZBk3QC/u8+nQDSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9jYYAG0gTc5hWmz3kYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2wDxWtpuU2sEyVqI2R1sro7EEClylglHtiboIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMfbyHsYgM2mpuxyP7IgnZIwPGJpSUnB5orHM0TvK2PnQAJK+fbwJ7MK
+        +YsiQi23CenZwLbGPRSkBwQR9QX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnYw4sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XxJ9wojjSo5a6ayFC/VPMfTO9xOiHkWQXGwL4a+v1y6vW4bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6mZySnDQmzNFPe1mQ4XtDGeuo8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9rMWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhZXh5fjk9vwz/urqZhVez8NefmNPU6IE9Oec6pDl1o/Onp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECROt8gPw2IGYHeklPIJICTr8Xtafpstq/21+HwXZyWfIadVr/ONfiAZ8vd2qs
+        RDYVTgeDa2bw2EDNMgz1dVkPyJmOXCaZzIxq0HOkkVrJBU+MHo8NmWw0cS2WYmch1ZDbboF75A/C
+        S6GU7JqNrrnQ5WG0DbuOZyo0iws+DMiaV52G422IhFd6awbXAKAtj6bvmMB+SfmcNYWJ3FuJ2qno
+        yaLBCnfkqoQZqOdF7daus+IMQq7a75GyovuMhovhZR057zByyak/CxSyilxH+p+GwfXsBdYvdr/Y
+        IWyFqrHdXxSn63R3TYoAR6vHaRyhOOyIfYN43BZ67xM38Xuf+L1P/N4ndp12uv4O9IkrbtZomI6y
+        6fh522frx/8A7885YBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:38 GMT
+      etag:
+      - W/"d36699bdd00da574823c0f965a7d19a6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:32 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABBC5:59D04A0:5ED66072
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3461'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/f90ccb880a2e626516e2b48af130de4e606ef647
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VS24rbMBD9lUXPSSzL8hUKbcmy9CFZts0SnFKCJI9je33DkpdkQ/59R00X2rcE
+        0hehmdHozDlzjkQXgiQkj6lSMoqoYBCwwHcDYJJHInc9mgGHgAaQBzwkE9J2GWzLDJsW8zR4YrGR
+        65ouqpQ/zr/tl1X69tik/uIBb9WOLx7uD5tVelhWz/tl83xIqyeertP94u3ry2b1vV5WX9hmnbLl
+        XH3Cz8ehxo8LY3qdOI7oy9muNMUoZ6prnAH6TjsNGKFNN8C0LuXUgDbased22xwygTUwDjY52NGU
+        WLuCWmGaevvvCH/BXwJ8Br0GU4ym6AaSHEkrGkDyPwpRiOHu/nXoWlQEGlFaTXBPmJ6BTX/e2aTV
+        BB8gZ9vGKKNTGkwpW7k8YW7i+RtympDzRAb+I4QZACc4/rGSK1wlVCZVnIW+H4Shm3mM+uADxH7k
+        h8wLJPVcdttt2xm0czE2CtOA1mJnpZuja3qhXjC6G3urZ4bD9WKA1miS/PxgJgM3kkpKDnEMURzy
+        kMaSu8xVIDnP45BGkUeZui2zDx9fgX4zH1+Mefo1Ia8wlHmphCnRuGiHc4xaJrmoNUzIAELbEhlb
+        Xe7a3yrbizDjgHtox7q2sh/qTmCTDU+ndwIwg6WhBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:38 GMT
+      etag:
+      - W/"bf45540bd03963bce5d2677943c7ed6e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:35 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABC27:59D050D:5ED66072
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3460'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=f90ccb880a2e626516e2b48af130de4e606ef647
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T32vbMBDH/xc/t5H8S3YCYzRhKwksY93DnBAIknWOlcqSsZSGtPR/r9SY0aZ7
+        yLox9iKJO93dh7vvPQSKNhCMAk4tbWl5Szcw2Bqtgougpbb+tcfU1DkYI7jiOM+jFEd4GNMsxXFG
+        eEYIzwmNeZZnUVlhl8qIe1ckDJOLYNdJF1tb25oRQrQVg42w9Y4NSt2gDlptUAOWGqs7uJSCXVow
+        1iB/rtfNwXMasKjUyoJyjlPwjx1UH6ohLkuW55hGQCKShgQiluS0CmPMIQGCCVQkyRxabRu5fg31
+        AugcFCY1Q+dWfMPrEFy9E4J3t8WlQp7HoN+YDtd7JTXlJxAd3fez2Rno+oY/j+mcrvxJQ+yh9Zqs
+        hATXnr6yM8Beb6aTGYZiLKdb927m91xMzfTq2b5b/Ah7e5gurz/jRTGXfHL0r5T7cVgW8ztezLbL
+        4ov4KsZsIq5c5Dg73v492y+KG33MflPz6093rJCHlfoZ+T3dlvFC9JFDfxff2uHKrwyoUnOhNn47
+        nExJ4mxrKdStCUYPgQFZ/Vfad2r5GzzvEp3fuxfF/+3OPT4+AfHfrNb5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:39 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:35 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABC84:59D0586:5ED66072
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3459'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "Next Tag with Same Name", "tag": "version-1.0",
+      "type": "commit", "object": "f90ccb880a2e626516e2b48af130de4e606ef647"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxNjYzOjdhNDA2ZTg2ZDY3YzdmZjQwNjc0MTIzODI3ODU5ODgxMTIxMTY5MzA=","sha":"7a406e86d67c7ff4067412382785988112116930","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/7a406e86d67c7ff4067412382785988112116930","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:39Z"},"object":{"sha":"f90ccb880a2e626516e2b48af130de4e606ef647","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/f90ccb880a2e626516e2b48af130de4e606ef647"},"tag":"version-1.0","message":"Next
+        Tag with Same Name","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '702'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:40 GMT
+      etag:
+      - '"1e81020361fad486536192b5e123b16e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/7a406e86d67c7ff4067412382785988112116930
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABD0E:59D0636:5ED66073
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3458'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "7a406e86d67c7ff4067412382785988112116930", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"message":"Reference already exists","documentation_url":"https://developer.github.com/v3/git/refs/#create-a-reference"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '121'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:40 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABDE2:59D0729:5ED66074
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3457'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:40 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABE9E:59D0809:5ED66074
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3456'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJlGipN6NgcX2sNsFCmQDFD1s9yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFk4/fgyvptPrs0klUx7R2OTuy9f1ffFHkXy7fWA//lwl1XLz
+        fZHd3C2+ht8Xd58mmMxKjpmGaxNF5SZlhmlu8MO8KYqo+7XkGDVS8fNCxOc0Vwf/X1ErsWIGtDkr
+        ND+byHXF1WTWTgqZiQpCDmAgiDSdTi8/hOHHqz3lN/fL283P8PeG/ajz9Fuxihd/h3dfks3dIvsX
+        SxnkMRU1qgA9N6bWsyBwg/r6IhMmb+JGc5XIyvDKXCSyDJqgF/Z59ekGkEx1GGsyDOzhatGR3HLg
+        dHB4J7kpiz1lnA525eE1c1kUcg3m/i6OFBtsAXRmFiaq7G0wANpAmpzDtNjuIxlJ4MxPpdrFbUD/
+        4JeE0zg2xdNTgd1yKEku9tgGitfScptYJ0rURsjqZHV3IIBKlbFKPLA3QQHRYJGiJytmFwPCV3Dm
+        kyludRvYcE02ZDbFEy5WOI+3kfcwAJtNTdnlfmRBOiVheMTSkpKCzRWPZ4jeV8bOgQSU8u3hT2YV
+        8hdFhFpuE9KzgW2NeyhIDwgi6gv2PxqHAAYMVlnyjTcmsdoAf7t4S5AYWCwVQxL3JmQH2gbjr+RU
+        hrPSmywLAzSX0p/lLQxQoXXDj/L940/VMnXQB1vVlLHLpMeE2PFiHA17YFqLrOLcm8W3wDboL4FY
+        sSrJ/YnoeW3gPlmvYZm3LRALyLiQsTcmLvTAAttA58xdjSbyqTVJIN6OAMXnXrdAvK0Aozz6jVWf
+        gFs8bmsDF/Kmf88L2u4EClZlDcv8SdgC6bJCqZKxhxcrtONjdiACT6WpEnHjNzEPTNqBK4qQf/wd
+        wYAcBNiq6/mS7hVGGlVy1kxlKV6qeY6nd7idEPMsguJgXwx9f7l0e902iNcGw/3iLrNOkq/T6G6z
+        Xv+xvO5t5c21el7Q/lIzk1OGhdiaKe5rMx0uaGM8dR8vLi7anDP7LCm58phFHA1YppIc5bUv/due
+        h8qxZMY+f+akfornUCFZ6u0stkDAnQv42oOjjf2oRr3uTXELG9NLUaBrISt/d8RAHMuppBFzkRzz
+        Vjw+zHeg7WctqoSfMTxvEBVGJAJxgic7eQCKfO7Pio6G7aFH5J6JBUfIeDslxR2vDVxXIOV1ITde
+        M+QISYlEcTSo0ogZPErDy/Dy/HJ6fhn+dXUzC69m4a8/Maep0QN7cs71Lc2pG50/PeUDTUH672IF
+        n9CVer4RtP/GpI4TIFrnA+S3ATE70Et6ApEUcPq9qD1Nl9X+3f46DLaTy5LXqNP6x7kWD/h8uVNj
+        JbKpcDoYXDODxwZqlmGor8t6QM505DLJZGZUg54jjdRKLnhi9HhsyGSjiWuxFDsLqYbcdgvcI38Q
+        XgqlZNdsdM2FLg+jbdh1PFOhWVzwYUDWvOo0HG9DJLzSWzO4BgBteTR9xwT2S8rnrClM5N5K1E5F
+        TxYNVrgjVyXMQD0vard2nRVnEHLVfo+UFd1nNFwML+vIeYeRS079WaCQVeQ60v80DK5nL7B+sfvF
+        DmErVI3t/qI4Xae7a1IEOFo9TuMIxWFH7BvE47bQe5+4id/7xO994vc+seu00/V3oE9ccbNGw3SU
+        TcfP2z5bP/4HuNFCNxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:41 GMT
+      etag:
+      - W/"577dc51981c96ff570ad53391a23f91f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:39 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABEEA:59D086B:5ED66074
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3455'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:21:41 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C931:204C8:4BABF40:59D08DB:5ED66075
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3454'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_create_fetch.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_create_fetch.yaml
@@ -1,0 +1,2488 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:52 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883D8C4:A1F6B24:5ED66044
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3569'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:52 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883D92D:A1F6B74:5ED66044
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3568'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821530,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE1MzA=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:20:52Z","updated_at":"2020-06-02T14:20:52Z","pushed_at":"2020-06-02T14:20:54Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:54 GMT
+      etag:
+      - '"edf70eb1b3e6e9839d7937cd3989ed02"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883D99F:A1F6C0C:5ED66044
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3567'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"60c26a0466eddf710e4b59cf97fc43a3d8da902a","node_id":"MDY6Q29tbWl0MjY4ODIxNTMwOjYwYzI2YTA0NjZlZGRmNzEwZTRiNTljZjk3ZmM0M2EzZDhkYTkwMmE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/60c26a0466eddf710e4b59cf97fc43a3d8da902a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/60c26a0466eddf710e4b59cf97fc43a3d8da902a","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:54Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:54Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:55 GMT
+      etag:
+      - '"6a499af072d371f88d9dfa3ccc0e7994"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883DC2C:A1F6EF7:5ED66046
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3566'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aMBT+K1WeaRNCCBep2ia1mvoA0zZ2gWlCTnJCTB07sx0oIP77zgnpWnjY
+        mqp76wtK7Hyfv3P1YedIloMzdHJmLGin5cQqz7l1hjvHZAw3Qi/2Q+YFYQhJkvbaHgRRdxCng14a
+        Bx3WSfoJG3g+Q6hUCcx5gqDR1TT86A9s9E14o+U0+HB1czeejNYfltP1dHvjTyfvvPFyJmbvP+Xj
+        7fV6NvnExxOxnC1vO7N85I386+3sKrudTm7Xo/z68kgXK22mNCmstX/OWMb02fVKK4lfQs64QBGo
+        H5cvgJbfLmjxAo3DDxJmyWTf871zLzz3/Ek7GPresBvMnP29B8gb/+2IHIxhCxJxI7nlTPAtnKEs
+        dqahUIZbpTco1GrAb+4j0U69QZL6nV6v7we9dtDtQ+L7A9aLoqAf93Cnn/Q64CGw1OSAzNrCDF2X
+        FfxiwW1WRuQAtzrCzcFiyJWGc8GjcwvGGpd+5/N8Q0oMWBdBLmkw7pPPRv+94OGHZDRugyQkCEg7
+        j1UpMY29lrMCzVMeM8sxPdCbh3fAPE2ZMNByNDBDW04pDV9I3Gk59MBsqdH/shSi5RRsIxRDEL3u
+        X87MZ5iY2VzMj738KLxPCezh0Ge41Zyc++zUamq2W8fVYGweGoBQC06BM1lV5bhH7SfsdsPOcTv6
+        GH79PhbxctoeT6Zb4lhhjutTa6pF49fVUhrQsZIW06kqnNKtmN+sLgNkWOiao+p4/yo64jLug86/
+        x/Dhu1QJodaIPZV6XNNH9O4fEKo6PHO5aE6AoJ2rbAboJ5S/J6M59okmTBVgh50EOwtPiMKgizUk
+        TUhqCIpZS9Sxq1pYxVVGJta8oNJuJOsIiERKL5jk26pHNCJCIKVk1VObmFQBEAgrzK5GyANi5xaa
+        r1i8ITdoiIGv0KfN2U6gSGY3BV1MXzDi5GFuYc6SnMqsapenF+RrCdbX6msJNquc1xI8XFrYzI6q
+        90klWDBNfcMZ/viJBTkXXN7iC06KINKXmPwizWSc4eD3538BXViPmBsOHDRF3nOh4EIrC7F9NIPV
+        K/WIBpJF4mhC+1VyujTwJrClmaO0+GAwyFTpGKqRT2D7I40qTdGJ1c19V/vo4Uw84e99+unj8YmT
+        sCNXVpEN+9+nPexNWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:55 GMT
+      etag:
+      - W/"253def7b34cce4f4ec9560bf31ca9eab"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883DDFE:A1F7139:5ED66047
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3565'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:56 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883DE5E:A1F71D2:5ED66047
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3564'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/60c26a0466eddf710e4b59cf97fc43a3d8da902a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY7aMBD9FeQzEGNCQiJVaiVQxSGsuo1UJVWFJsmEGOIE2c5SQPz7jksP7W1X
+        ai9WPC8z782b8Y2ZBljMAl6KALgfBFhVdTjj6BeLqKyjsC79OcyrZQURF8DGrOsr3MmKkpJVFnwR
+        kS2+tTw5ZP7TavNzmybnp0N2zq4bkaWf+PaQt/nnZ7W9rs95+iy3aXvID8d5rhKeiPU1XzXHLD2e
+        E7X+QMUH3VLhxtqTiT0PTnK6l7YZimnZK0/jqTeeQgvG9honrSwmFo01njt3O3WpgDC0HiV5lKEk
+        Ye9orbGq3f0t4Q/6txA/SN/DCYNtes3iG+tAITX/tYEG9Gj9ovuOHEEF0nlCc6LwFF34494FnSf0
+        A/Xs0gQXfMKDCRfpzI8Fjxd+zu5j9lBk8T9SWI2k4PZ7lWY1j6pazMNwKfxw5i+WWAkRQVgU/rIM
+        CVlW4Rz5v52202C8N3OTMQqNgb2zbtNJK6GVVxy5BRr92jNJK3YhjSfQ2FnD4u8/xuwFtaxlCVbS
+        bKjjxx3pMdTQGhwzjWAcxIbOyH1HyJi5D7CDJqpuaFtX8tL2QEnuer+/AjRWUFCEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:56 GMT
+      etag:
+      - W/"4631ac273f5cd75409cd64af5a0f0c2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:54 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883DF02:A1F727F:5ED66048
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3563'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["60c26a0466eddf710e4b59cf97fc43a3d8da902a"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"692c213d03a98406987aa2f10b8cf9fdcd966062","node_id":"MDY6Q29tbWl0MjY4ODIxNTMwOjY5MmMyMTNkMDNhOTg0MDY5ODdhYTJmMTBiOGNmOWZkY2Q5NjYwNjI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/692c213d03a98406987aa2f10b8cf9fdcd966062","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/692c213d03a98406987aa2f10b8cf9fdcd966062","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:56Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:20:56Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"60c26a0466eddf710e4b59cf97fc43a3d8da902a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/60c26a0466eddf710e4b59cf97fc43a3d8da902a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/60c26a0466eddf710e4b59cf97fc43a3d8da902a"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:57 GMT
+      etag:
+      - '"06d2212c6d72fdcf65d7cd6db001aa02"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/692c213d03a98406987aa2f10b8cf9fdcd966062
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883DF5B:A1F72FE:5ED66048
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3562'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBRF/4tnWoc2uCRzRQHJdIEgukT+eMGu4jiyXwuh6n/nVYwsDCx3ue+8
+        e04sQcfqS2buQNnMg8oIiV2xIVpovaVWrqV4CU2Q+7dyu374fHqWH9vhsd8N8qg2jdvdy6N+vfuy
+        m2Yi8JB6ghzimGvO1ejn7x7dQc9NDDzBGGkEkGZiglnv9QwhY+aXbNswWUUdICeIrn97Rb0Hg6w+
+        sewUDYnCLIQqSiHA2m51XUCpbyrTVavOlEu1tLdWVcVCkRlOIxBBHsHj/5r+/Mz8zzbn8zeOjYz8
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:57 GMT
+      etag:
+      - W/"9ca4e34e6c17812b4f2d8e1e999cdb6b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:54 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E006:A1F73D9:5ED66049
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3561'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "692c213d03a98406987aa2f10b8cf9fdcd966062"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWqdpZeLMFaWVTBcIoktkxxfiKo4j+1oIVf87VzGyMLC85d13
+        77uwCC0rb5l4B9om7nVCiOyODcFC7Sy1aq3Ei6+8Or6t9uvt59Oz+tgPu/4wqLPeVN3hUZ3N68OX
+        3VQTgafYE9QhjqnkXI9u/u6wO5l5EzyPMAYaAaSZEGHWOzNDSJj4LevaT1ZTB8gJouvfXsEcoUFW
+        XljqNA0JmTf5YmmzpZbFKhOyuNc6bxeZKZpWtraxUohM5GSG0whEkId3+L+mPz8T/7PN9foNtrlC
+        y30BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:58 GMT
+      etag:
+      - W/"417d9ae9f3a413be8191a33250d9d6e4"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E0D8:A1F74B9:5ED66049
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3560'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E2A8:A1F7709:5ED6604A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3559'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHm02zBhbbArtdoEAaoOhhuxeBkmiJsSSqJGXXEfLf+w4p
+        WbLrTRyHx1wSmyafGX7McPi2E5lO5rPrm5vZ5ft307NJpVIRUdvk9vOX9V3xe5F8/fDAv/25Sqrl
+        5o/77Or2/svl7cOvHyfozEuBnlYYG0XlJuWWG2Hxw6Ipiqj7tRRotUqL80LG59TXsP+PqLVccQva
+        ghdGnE3UuhJ6Mm8nhcpkBSMHMDBEnl5fT3+ezW4u95zf3C0/bL7Pfmv4tzpPvxar+P7v2e3nZHN7
+        n/2LoRz2uI4aXYCeW1ubOWO+0by7yKTNm7gxQieqsqKyF4kqWcN6Y59WH68AyXSHcUuGhj1cLTuS
+        Hw6cYYdnktuy2HPG++BGHh6zUEWh1mDuz+JIs2wLoD1zMFllr4MB0DJlc4GlxXQfaZEk9vxUqhvc
+        MvqHc0k4g23TIj0V2A2Hk3TEHlumRa0ct4lNomVtpapOdncHAqjSGa/kA38VFBADFjl6smNuMCBi
+        hcN8MsWPbpkL12RDy6ZFIuQK+/E68h4GYLupKbvcjVaQdklaEfG0pKTgcsXjGaL3hbFzIAGlYrv5
+        k3mF/EURoZfbhPRkYLvFPRSkBwwR9Zn1PxqHAAYMq7IUm2BMYrUMf7t4S5AYeKw0RxIPZmQH2rLx
+        VzpUVvAymC0HAzRXKtzKOxig0phGHHX2j99VxzSsD7aqKWOfSY8JsePNeBrmwI2RWSVEsBXfAlvW
+        XwKx5lWShzPR81rmP7lTw7NgUyAWkHGh4mBMXOjMAVtmcu6vRhuF9JosEG/HgBaLoFMg3taA1QHP
+        jXOfgFs8bmuLIxTM/57H2m4HCl5lDc/CWdgC6bJCqZLxh2crtONjdiACT6WplnETNjEPTJqBL4qQ
+        f8JtwYAcDLiq6+mS7gWLNKrk3DKVpXyu5jme3uF2QiywCYqDfTP0/fnS7WXTIF7LhvvFX2adpVC7
+        0d1mvf9je93bKtjR6nms/anmNqcMC7M11yLUZDoca2M8dR8vLi7aXHD3LCmFDphFPA1YrpMc5XUo
+        /9ueh8qx5NY9fxbkfornUKF4GmwvtkDA/REINQdPG5+jGvV6MMcdbEwvZQHVQlXh7oiBOLZTKSsX
+        MjnmrXh8mO9A209GVok443jeICqsTCTiBE92OgEo8kW4VfQ0TA8akX8mFgIhE2yXtPC8lnlVIBV1
+        oTZBM+QISYlECwhUacQtHqWz6Wx6Pr0+n87+uryaz6bz97Pv6NPU0MB+3OeG+tSNyZ/pgvTfxQo+
+        QZV6Wgjaf2OS4gQ7xuQD5JcBMT+gJf0AkRQ49HtRe5ovq/27/WUYTCdXpahRp/WPcyMf8BmK5ajG
+        SlRTYXfQuOYWjw3ULENTX5f1gJybyGeSydzqBpojtdRa3YvEmnHbkMlGHddyKXcGUg25VQv8I38w
+        XkqtVSc2enGhy8OQDTvFM5WGx4UYGlQtqs7D8TRkIiqzXQYvANCUR913lsB9ScWCN4WN/FuJ5FRo
+        shBYcRyFLrEMpHmR3NopK35B6Kj2c6Ss6D9DcLGirCN/OqxaCtJngUJWUevI/NNwHD13gfWD/S+u
+        CVOhamz3Fy3oOt0dkyLAIfV4jyMUhx2xF4jHstCbTtzEbzrxm078phN7pZ2uvwM6cSXsGoLpKJuO
+        n7d9tn78DxP5r1EVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:59 GMT
+      etag:
+      - W/"a9328e54e3cde250cc069327f0219fb3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E30A:A1F7792:5ED6604B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3558'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E370:A1F780A:5ED6604B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3557'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHm02zBhbbArtdoEAaoOhhuxeBkmiJsSSqJGXXEfLf+w4p
+        WbLrTRyHx1wSmyafGX7McPi2E5lO5rPrm5vZ5ft307NJpVIRUdvk9vOX9V3xe5F8/fDAv/25Sqrl
+        5o/77Or2/svl7cOvHyfozEuBnlYYG0XlJuWWG2Hxw6Ipiqj7tRRotUqL80LG59TXsP+PqLVccQva
+        ghdGnE3UuhJ6Mm8nhcpkBSMHMDBEnl5fT3+ezW4u95zf3C0/bL7Pfmv4tzpPvxar+P7v2e3nZHN7
+        n/2LoRz2uI4aXYCeW1ubOWO+0by7yKTNm7gxQieqsqKyF4kqWcN6Y59WH68AyXSHcUuGhj1cLTuS
+        Hw6cYYdnktuy2HPG++BGHh6zUEWh1mDuz+JIs2wLoD1zMFllr4MB0DJlc4GlxXQfaZEk9vxUqhvc
+        MvqHc0k4g23TIj0V2A2Hk3TEHlumRa0ct4lNomVtpapOdncHAqjSGa/kA38VFBADFjl6smNuMCBi
+        hcN8MsWPbpkL12RDy6ZFIuQK+/E68h4GYLupKbvcjVaQdklaEfG0pKTgcsXjGaL3hbFzIAGlYrv5
+        k3mF/EURoZfbhPRkYLvFPRSkBwwR9Zn1PxqHAAYMq7IUm2BMYrUMf7t4S5AYeKw0RxIPZmQH2rLx
+        VzpUVvAymC0HAzRXKtzKOxig0phGHHX2j99VxzSsD7aqKWOfSY8JsePNeBrmwI2RWSVEsBXfAlvW
+        XwKx5lWShzPR81rmP7lTw7NgUyAWkHGh4mBMXOjMAVtmcu6vRhuF9JosEG/HgBaLoFMg3taA1QHP
+        jXOfgFs8bmuLIxTM/57H2m4HCl5lDc/CWdgC6bJCqZLxh2crtONjdiACT6WplnETNjEPTJqBL4qQ
+        f8JtwYAcDLiq6+mS7gWLNKrk3DKVpXyu5jme3uF2QiywCYqDfTP0/fnS7WXTIF7LhvvFX2adpVC7
+        0d1mvf9je93bKtjR6nms/anmNqcMC7M11yLUZDoca2M8dR8vLi7aXHD3LCmFDphFPA1YrpMc5XUo
+        /9ueh8qx5NY9fxbkfornUKF4GmwvtkDA/REINQdPG5+jGvV6MMcdbEwvZQHVQlXh7oiBOLZTKSsX
+        MjnmrXh8mO9A209GVok443jeICqsTCTiBE92OgEo8kW4VfQ0TA8akX8mFgIhE2yXtPC8lnlVIBV1
+        oTZBM+QISYlECwhUacQtHqWz6Wx6Pr0+n87+uryaz6bz97Pv6NPU0MB+3OeG+tSNyZ/pgvTfxQo+
+        QZV6Wgjaf2OS4gQ7xuQD5JcBMT+gJf0AkRQ49HtRe5ovq/27/WUYTCdXpahRp/WPcyMf8BmK5ajG
+        SlRTYXfQuOYWjw3ULENTX5f1gJybyGeSydzqBpojtdRa3YvEmnHbkMlGHddyKXcGUg25VQv8I38w
+        XkqtVSc2enGhy8OQDTvFM5WGx4UYGlQtqs7D8TRkIiqzXQYvANCUR913lsB9ScWCN4WN/FuJ5FRo
+        shBYcRyFLrEMpHmR3NopK35B6Kj2c6Ss6D9DcLGirCN/OqxaCtJngUJWUevI/NNwHD13gfWD/S+u
+        CVOhamz3Fy3oOt0dkyLAIfV4jyMUhx2xF4jHstCbTtzEbzrxm078phN7pZ2uvwM6cSXsGoLpKJuO
+        n7d9tn78DxP5r1EVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:20:59 GMT
+      etag:
+      - W/"a9328e54e3cde250cc069327f0219fb3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E3CB:A1F7880:5ED6604B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3556'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/692c213d03a98406987aa2f10b8cf9fdcd966062
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIthwbCqWklBRsc9Rw+EoJa3sdK/FHsOS7hiP//VakLe1b
+        DtIXYe1qNLuzI78y3QCLmAxFKVZuxV0I1x6X4ToAEPWKF+uyDuuqrEIpuRRszvqhwp2qCBRvcvkg
+        QlM8tjw+5F662f5MsvglPeR+3MXnOEuO8SZp0mzP6ayfbqomz752cfZJpV+SLn18OubiwU8O+Uty
+        2H6gy6expYsbY046chw4qeVemWYqluXQOSOeBu10aECbYcRFq4qFQW20Y9fdrjtXQDk0DoEcQnSK
+        cu9orTFdu/u3hL/obyG+kr6HEybTDCOLXlkPHVLz3xpoYJx9fh6HnhTBDpTVhOZE4SXa8Me9DVpN
+        6AD1bGGCC77gcsFFtvIiwSNfPrHLnF0rMvgfKcyIVMHrLysFAa6l69WeW3C3rGsZVl7g+SUvMECs
+        XVFgCYX07zttW4N2buYmYTrUGvZWum2vjIJ2Zt1zgvJI0dlVNqrxBCP2RrPo++8GJS+FBO5JiVVV
+        ByuOXuGH9EyCuvRccKt1BSEXcN8G/9j5dvb72flWzsuPOXvGUdWqBKPIv+SK6x7ph1FDq3HORgRt
+        U2zqtdr3lJkz+wFmGmkc/dS2VvZzOwCB7PZyeQPw1useqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      etag:
+      - W/"06d2212c6d72fdcf65d7cd6db001aa02"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E445:A1F7905:5ED6604B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3555'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=692c213d03a98406987aa2f10b8cf9fdcd966062
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28h2atkKjNGYrTiwjnUPc0IhSNbZVipLxlIastLvvnMbWJft
+        IevG2IPEoZPu/+N/p4fA8A6CWSC55z2v7ngDk42zJjgLeu7bX2dcyzGRQZpVknGZMmBxPBVhRpMo
+        pYmUQCFNQhayTNAQSzn1FUUYPQu2g8anrfe9mxHCezVplG+3YlLZjgzQW0c68Nx5O8C5VuLcg/OO
+        jPt63e1HTAeeVNZ4MJg45n47QP2GsriKo6kMp5xlFyFlWcp5XEehyKqa1RKpKQ1pjGSt7/T6R6gX
+        QKegCG0FOVXxJ15EQL0jglfbgqXIyOPIbzRH2p3RlssjiIHvDr3ZOhgOhj+16RRX/sQQv+/HkayV
+        BrTnoIwHsLNNkS+2yy+RLjYYd1GyunofLstrLfPCFZdP+f2qvL6X5WKzKj+oj2oucnXZ3Join6dj
+        VOTjWuyW5Y19rnLTyqt396LU319+TjbVdKme78/ZrRmj8lOPESKBqaxUpkEmgeNIL/BsrZW5c8Hs
+        IXCg6/9qxnEq/gbPq4Zr/F8vxP/t33p8/AYryZnM4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E4AF:A1F7991:5ED6604C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3554'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "692c213d03a98406987aa2f10b8cf9fdcd966062"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxNTMwOjhlYjk2ZWFhZDU2YjZhYmFmYmFmNDJkYjMyN2UwMDIwZGY0OThiMjQ=","sha":"8eb96eaad56b6abafbaf42db327e0020df498b24","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8eb96eaad56b6abafbaf42db327e0020df498b24","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:00Z"},"object":{"sha":"692c213d03a98406987aa2f10b8cf9fdcd966062","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/692c213d03a98406987aa2f10b8cf9fdcd966062"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      etag:
+      - '"fb9a41379e4f86810fca767a66664136"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8eb96eaad56b6abafbaf42db327e0020df498b24
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E513:A1F7A16:5ED6604C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3553'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "8eb96eaad56b6abafbaf42db327e0020df498b24", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxNTMwOnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"8eb96eaad56b6abafbaf42db327e0020df498b24","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8eb96eaad56b6abafbaf42db327e0020df498b24"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:01 GMT
+      etag:
+      - '"bb79c9b237d732651f077d12b2241d79"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E5F9:A1F7B2A:5ED6604C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3552'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:02 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E7E1:A1F7D3F:5ED6604D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3551'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULbm013DSy2BXa7QIE0QNHDdi8CJdESY0lUScquI+S/9x1S
+        smTXSZyEx1wSmyafGX7McPi2E5lOFvOrDx/ms/fvpmeTSqUiorbJ9Zevm5vi9yL59vGOf/9znVSr
+        7R+32eX17dfZ9d2vnybozEuBnlYYG0XlNuWWG2Hxw7Ipiqj7tRRotUqL80LG59TXsP+PqLVccwva
+        khdGnE3UphJ6smgnhcpkBSNHMDBEnl5dTX+ezz/MDpzf3qw+bn/Mf2v49zpPvxXr+Pbv+fWXZHt9
+        m/2LoRz2uI4aXYCeW1ubBWO+0by7yKTNm7gxQieqsqKyF4kqWcN6Y5/Xny4ByXSHcUuGhgNcLTuS
+        Hw6cYcdnktuyOHDG++BGHh+zVEWhNmAezuJEs2wHoD1zMFllr4MB0DJlc4GlxXTvaZEk9vylVDe4
+        ZfQP55JwBtumRfpSYDccTtIRu2+ZFrVy3CY2iZa1lap6sbt7EECVzngl7/iroIAYsMjRFzvmBgMi
+        1jjML6b40S1z4Zpsadm0SIRcYz9eRz7AAGy3NWWXm9EK0i5JKyKelpQUXK64P0P0PjN2jiSgVOw2
+        f7KokL8oIvRql5AeDWy3uMeC9Ighoj6x/ifjEMCAYVVWYhuMSayW4W8XbwkSA4+V5kjiwYzsQVs2
+        /kqHygpeBrPlYIDmSoVbeQcDVBrTiJPO/um76piG9cFWNWXsM+kpIXa6GU/DHLgxMquECLbiO2DL
+        +ksg1rxK8nAmel7L/Cd3angWbArEAjIuVByMiQudOWDLTM791WijkF6TBeLtGdBiGXQKxNsZsDrg
+        uXHuE3CHx21tcYSC+d/zWNvtQMGrrOFZOAs7IF1WKFUyfvdkhXZ6zA5E4Kk01TJuwibmgUkz8EUR
+        8k+4LRiQgwFXdT1e0j1jkUaVnFumspRP1Tyn0zvcXogFNkFxcGiGvj9duj1vGsRr2XC/+MussxRq
+        N7rbrPd/bK97WwU7Wj2PtT/V3OaUYWG25lqEmkyHY22Mp+79xcVFmwvuniWl0AGziKcBy3WSo7wO
+        5X/b81A5lty658+S3E/xHCoUT4PtxQ4IuD8CoebgaeNzVKNeD+a4g43ppSygWqgq3B0xEMd2KmXl
+        UianvBVPD/M9aPvZyCoRZxzPG0SFlYlEnODJTicARb4It4qehulBI/LPxEIgZILtkhae1zKvCqSi
+        LtQ2aIYcISmRaAGBKo24xaN0Pp1Pz6dX59P5X7PLxXy6eD//gT5NDQ3sgT6zxXRKferG5A93mVEX
+        pP8uVvAJqtTjQtDhG5MUJ0CMyQfILwNicURLegCRFDj0B1H7Ml/Wh3f78zCYTq5KUaNO6x/nRt7h
+        MxTLUY2VqKbC7qBxwy0eG6hZhqa+LusBOTeRzySThdUNNEdqqbW6FYk147Yhk406buRK7g2kGnKn
+        FvhH/mC8lFqrTmz04kKXhyEbdopnKg2PCzE0qFpUnYfjachEVGa3DF4AoCmPuu8tgfuSiiVvChv5
+        txLJqdBkIbDiOApdYhlI8yK5tVNW/ILQUe3nSFnRf4bgYkVZR/50WLUSpM8ChayiNpH5p+E4eu4C
+        6wf7X1wTpkLV2P4vWtB1uj8mRYBD6vEeRygOO2IvEI9loTeduInfdOI3nfhNJ/ZKO11/R3TiStgN
+        BNNRNh0/b/tsff8feAoISBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:02 GMT
+      etag:
+      - W/"da52bc0b092bba59efd8550b23b30d2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E885:A1F7E25:5ED6604E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3550'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT0/DMAzFv0vOtClZKWulHSYNEBNhl/Fvlypp3DVT01SNOyjTvjuGMwcOSNa7
+        +D37Z5/YADUrvjVwVPvAjzAE67voMk7YBeu8gdIacsiVzJ7cs5OHt3Szuv943Mr3Tbdud508mrvb
+        rppysXtdf6qXfHzY3oxyuVjQgHFoKdwg9qHgXPU23ltsRh1X3vEBeh+4A1QB/QBRa3WEEJBQSMvS
+        TUZRD5BTiNy/M3p9gApZcWKhUbRsDjrPQClzlelMaVVTpcLombiGJBGJqdN8rkVKdDj1QAk6/H9R
+        fz75Z47z+QsOGxGAhwEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:03 GMT
+      etag:
+      - W/"bb79c9b237d732651f077d12b2241d79"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883E94A:A1F7F02:5ED6604E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3549'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8eb96eaad56b6abafbaf42db327e0020df498b24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S246bMBD9lcjPEIxDvYBUqQ80q61EoqrZVvASDTCAWW7CZlO0yr93rPxAK1Wy
+        Lc/lnDkzmg82ThVeVcViliap/Pl8HNMuC87Jy+/TJb2du7bPujeR/zq2efIqsi5vs+E42HtKvr1l
+        XbqdxOstTV5u+XPGz5dWpd33z8xhugUiDbGIJAJUn2QhoYCaTiCq4iCekHPBqzqIwkIEBFiXngCt
+        MbOOPQ9mtW+UaddiX06Dt+A8aW9AA9pMC7q9KlyD2mjPvtfrsFVAMTQegTwDjfb+oTTlN7iw+ION
+        MCCp+NFCC8vu6/syjSQNB1BWHPVE7j1a95fGOq04SqDiFiaoI5dLl4uLH8TCjznP2d1hU9FhaSz/
+        YyoyEqXwDxU/QBQGXEbhE4CofV6EZR3VVVlFUnIpiNlss2WmMoMy/3dKD07t/bUa6oQmRWrecdFq
+        Gl1/z0nSgFpDY1Wm225UJe56ZUyPO5vs2GRVqxIMIewIHjbSytXQa3TYgqBtiK2jVs1IEdoe+oBZ
+        F2Id17532AxbPwGBrHm//wEOLkRluQIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:03 GMT
+      etag:
+      - W/"fb9a41379e4f86810fca767a66664136"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883EB44:A1F814A:5ED6604F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3548'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:03 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883EBB9:A1F81F6:5ED6604F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3547'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULbm013DSy2BXa7QIE0QNHDdi8CJdESY0lUScquI+S/9x1S
+        smTXSZyEx1wSmyafGX7McPi2E5lOFvOrDx/ms/fvpmeTSqUiorbJ9Zevm5vi9yL59vGOf/9znVSr
+        7R+32eX17dfZ9d2vnybozEuBnlYYG0XlNuWWG2Hxw7Ipiqj7tRRotUqL80LG59TXsP+PqLVccwva
+        khdGnE3UphJ6smgnhcpkBSNHMDBEnl5dTX+ezz/MDpzf3qw+bn/Mf2v49zpPvxXr+Pbv+fWXZHt9
+        m/2LoRz2uI4aXYCeW1ubBWO+0by7yKTNm7gxQieqsqKyF4kqWcN6Y5/Xny4ByXSHcUuGhgNcLTuS
+        Hw6cYcdnktuyOHDG++BGHh+zVEWhNmAezuJEs2wHoD1zMFllr4MB0DJlc4GlxXTvaZEk9vylVDe4
+        ZfQP55JwBtumRfpSYDccTtIRu2+ZFrVy3CY2iZa1lap6sbt7EECVzngl7/iroIAYsMjRFzvmBgMi
+        1jjML6b40S1z4Zpsadm0SIRcYz9eRz7AAGy3NWWXm9EK0i5JKyKelpQUXK64P0P0PjN2jiSgVOw2
+        f7KokL8oIvRql5AeDWy3uMeC9Ighoj6x/ifjEMCAYVVWYhuMSayW4W8XbwkSA4+V5kjiwYzsQVs2
+        /kqHygpeBrPlYIDmSoVbeQcDVBrTiJPO/um76piG9cFWNWXsM+kpIXa6GU/DHLgxMquECLbiO2DL
+        +ksg1rxK8nAmel7L/Cd3angWbArEAjIuVByMiQudOWDLTM791WijkF6TBeLtGdBiGXQKxNsZsDrg
+        uXHuE3CHx21tcYSC+d/zWNvtQMGrrOFZOAs7IF1WKFUyfvdkhXZ6zA5E4Kk01TJuwibmgUkz8EUR
+        8k+4LRiQgwFXdT1e0j1jkUaVnFumspRP1Tyn0zvcXogFNkFxcGiGvj9duj1vGsRr2XC/+MussxRq
+        N7rbrPd/bK97WwU7Wj2PtT/V3OaUYWG25lqEmkyHY22Mp+79xcVFmwvuniWl0AGziKcBy3WSo7wO
+        5X/b81A5lty658+S3E/xHCoUT4PtxQ4IuD8CoebgaeNzVKNeD+a4g43ppSygWqgq3B0xEMd2KmXl
+        UianvBVPD/M9aPvZyCoRZxzPG0SFlYlEnODJTicARb4It4qehulBI/LPxEIgZILtkhae1zKvCqSi
+        LtQ2aIYcISmRaAGBKo24xaN0Pp1Pz6dX59P5X7PLxXy6eD//gT5NDQ3sgT6zxXRKferG5A93mVEX
+        pP8uVvAJqtTjQtDhG5MUJ0CMyQfILwNicURLegCRFDj0B1H7Ml/Wh3f78zCYTq5KUaNO6x/nRt7h
+        MxTLUY2VqKbC7qBxwy0eG6hZhqa+LusBOTeRzySThdUNNEdqqbW6FYk147Yhk406buRK7g2kGnKn
+        FvhH/mC8lFqrTmz04kKXhyEbdopnKg2PCzE0qFpUnYfjachEVGa3DF4AoCmPuu8tgfuSiiVvChv5
+        txLJqdBkIbDiOApdYhlI8yK5tVNW/ILQUe3nSFnRf4bgYkVZR/50WLUSpM8ChayiNpH5p+E4eu4C
+        6wf7X1wTpkLV2P4vWtB1uj8mRYBD6vEeRygOO2IvEI9loTeduInfdOI3nfhNJ/ZKO11/R3TiStgN
+        BNNRNh0/b/tsff8feAoISBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:04 GMT
+      etag:
+      - W/"da52bc0b092bba59efd8550b23b30d2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883EC43:A1F828A:5ED6604F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3546'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/692c213d03a98406987aa2f10b8cf9fdcd966062
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIthwbCqWklBRsc9Rw+EoJa3sdK/FHsOS7hiP//VakLe1b
+        DtIXYe1qNLuzI78y3QCLmAxFKVZuxV0I1x6X4ToAEPWKF+uyDuuqrEIpuRRszvqhwp2qCBRvcvkg
+        QlM8tjw+5F662f5MsvglPeR+3MXnOEuO8SZp0mzP6ayfbqomz752cfZJpV+SLn18OubiwU8O+Uty
+        2H6gy6expYsbY046chw4qeVemWYqluXQOSOeBu10aECbYcRFq4qFQW20Y9fdrjtXQDk0DoEcQnSK
+        cu9orTFdu/u3hL/obyG+kr6HEybTDCOLXlkPHVLz3xpoYJx9fh6HnhTBDpTVhOZE4SXa8Me9DVpN
+        6AD1bGGCC77gcsFFtvIiwSNfPrHLnF0rMvgfKcyIVMHrLysFAa6l69WeW3C3rGsZVl7g+SUvMECs
+        XVFgCYX07zttW4N2buYmYTrUGvZWum2vjIJ2Zt1zgvJI0dlVNqrxBCP2RrPo++8GJS+FBO5JiVVV
+        ByuOXuGH9EyCuvRccKt1BSEXcN8G/9j5dvb72flWzsuPOXvGUdWqBKPIv+SK6x7ph1FDq3HORgRt
+        U2zqtdr3lJkz+wFmGmkc/dS2VvZzOwCB7PZyeQPw1useqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:04 GMT
+      etag:
+      - W/"06d2212c6d72fdcf65d7cd6db001aa02"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883ECCB:A1F833B:5ED66050
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3545'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=692c213d03a98406987aa2f10b8cf9fdcd966062
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28h2atkKjNGYrTiwjnUPc0IhSNbZVipLxlIastLvvnMbWJft
+        IevG2IPEoZPu/+N/p4fA8A6CWSC55z2v7ngDk42zJjgLeu7bX2dcyzGRQZpVknGZMmBxPBVhRpMo
+        pYmUQCFNQhayTNAQSzn1FUUYPQu2g8anrfe9mxHCezVplG+3YlLZjgzQW0c68Nx5O8C5VuLcg/OO
+        jPt63e1HTAeeVNZ4MJg45n47QP2GsriKo6kMp5xlFyFlWcp5XEehyKqa1RKpKQ1pjGSt7/T6R6gX
+        QKegCG0FOVXxJ15EQL0jglfbgqXIyOPIbzRH2p3RlssjiIHvDr3ZOhgOhj+16RRX/sQQv+/HkayV
+        BrTnoIwHsLNNkS+2yy+RLjYYd1GyunofLstrLfPCFZdP+f2qvL6X5WKzKj+oj2oucnXZ3Join6dj
+        VOTjWuyW5Y19rnLTyqt396LU319+TjbVdKme78/ZrRmj8lOPESKBqaxUpkEmgeNIL/BsrZW5c8Hs
+        IXCg6/9qxnEq/gbPq4Zr/F8vxP/t33p8/AYryZnM4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:04 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:20:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883ED48:A1F83C3:5ED66050
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3544'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:04 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883EDC8:A1F8456:5ED66050
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3543'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULbm013DSy2BXa7QIE0QNHDdi8CJdESY0lUScquI+S/9x1S
+        smTXSZyEx1wSmyafGX7McPi2E5lOFvOrDx/ms/fvpmeTSqUiorbJ9Zevm5vi9yL59vGOf/9znVSr
+        7R+32eX17dfZ9d2vnybozEuBnlYYG0XlNuWWG2Hxw7Ipiqj7tRRotUqL80LG59TXsP+PqLVccwva
+        khdGnE3UphJ6smgnhcpkBSNHMDBEnl5dTX+ezz/MDpzf3qw+bn/Mf2v49zpPvxXr+Pbv+fWXZHt9
+        m/2LoRz2uI4aXYCeW1ubBWO+0by7yKTNm7gxQieqsqKyF4kqWcN6Y5/Xny4ByXSHcUuGhgNcLTuS
+        Hw6cYcdnktuyOHDG++BGHh+zVEWhNmAezuJEs2wHoD1zMFllr4MB0DJlc4GlxXTvaZEk9vylVDe4
+        ZfQP55JwBtumRfpSYDccTtIRu2+ZFrVy3CY2iZa1lap6sbt7EECVzngl7/iroIAYsMjRFzvmBgMi
+        1jjML6b40S1z4Zpsadm0SIRcYz9eRz7AAGy3NWWXm9EK0i5JKyKelpQUXK64P0P0PjN2jiSgVOw2
+        f7KokL8oIvRql5AeDWy3uMeC9Ighoj6x/ifjEMCAYVVWYhuMSayW4W8XbwkSA4+V5kjiwYzsQVs2
+        /kqHygpeBrPlYIDmSoVbeQcDVBrTiJPO/um76piG9cFWNWXsM+kpIXa6GU/DHLgxMquECLbiO2DL
+        +ksg1rxK8nAmel7L/Cd3angWbArEAjIuVByMiQudOWDLTM791WijkF6TBeLtGdBiGXQKxNsZsDrg
+        uXHuE3CHx21tcYSC+d/zWNvtQMGrrOFZOAs7IF1WKFUyfvdkhXZ6zA5E4Kk01TJuwibmgUkz8EUR
+        8k+4LRiQgwFXdT1e0j1jkUaVnFumspRP1Tyn0zvcXogFNkFxcGiGvj9duj1vGsRr2XC/+MussxRq
+        N7rbrPd/bK97WwU7Wj2PtT/V3OaUYWG25lqEmkyHY22Mp+79xcVFmwvuniWl0AGziKcBy3WSo7wO
+        5X/b81A5lty658+S3E/xHCoUT4PtxQ4IuD8CoebgaeNzVKNeD+a4g43ppSygWqgq3B0xEMd2KmXl
+        UianvBVPD/M9aPvZyCoRZxzPG0SFlYlEnODJTicARb4It4qehulBI/LPxEIgZILtkhae1zKvCqSi
+        LtQ2aIYcISmRaAGBKo24xaN0Pp1Pz6dX59P5X7PLxXy6eD//gT5NDQ3sgT6zxXRKferG5A93mVEX
+        pP8uVvAJqtTjQtDhG5MUJ0CMyQfILwNicURLegCRFDj0B1H7Ml/Wh3f78zCYTq5KUaNO6x/nRt7h
+        MxTLUY2VqKbC7qBxwy0eG6hZhqa+LusBOTeRzySThdUNNEdqqbW6FYk147Yhk406buRK7g2kGnKn
+        FvhH/mC8lFqrTmz04kKXhyEbdopnKg2PCzE0qFpUnYfjachEVGa3DF4AoCmPuu8tgfuSiiVvChv5
+        txLJqdBkIbDiOApdYhlI8yK5tVNW/ILQUe3nSFnRf4bgYkVZR/50WLUSpM8ChayiNpH5p+E4eu4C
+        6wf7X1wTpkLV2P4vWtB1uj8mRYBD6vEeRygOO2IvEI9loTeduInfdOI3nfhNJ/ZKO11/R3TiStgN
+        BNNRNh0/b/tsff8feAoISBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:05 GMT
+      etag:
+      - W/"da52bc0b092bba59efd8550b23b30d2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883EE50:A1F84FF:5ED66050
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3542'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:21:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92D:33B7A:883EEEC:A1F85B8:5ED66051
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3541'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_create_fetch_substring_names.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_create_fetch_substring_names.yaml
@@ -1,0 +1,3893 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:06 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112D89E:142F992:5ED66051
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3540'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:06 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112D8BD:142F9AA:5ED66052
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3539'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821585,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE1ODU=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:21:06Z","updated_at":"2020-06-02T14:21:06Z","pushed_at":"2020-06-02T14:21:07Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:07 GMT
+      etag:
+      - '"5116ee9aa80376bedd55fa3e345e50da"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112D8D8:142F9CF:5ED66052
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3538'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"2f0e992d03aa8103555f16e22328075266a24be4","node_id":"MDY6Q29tbWl0MjY4ODIxNTg1OjJmMGU5OTJkMDNhYTgxMDM1NTVmMTZlMjIzMjgwNzUyNjZhMjRiZTQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2f0e992d03aa8103555f16e22328075266a24be4","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/2f0e992d03aa8103555f16e22328075266a24be4","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:08Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:08Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:08 GMT
+      etag:
+      - '"9ecc46c45780ce2ba4b35f424476ebc9"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112D984:142FA99:5ED66053
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3537'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1Xy27bOhD9lUBrJ5Lpt4Gid5GiSAE5SOu017koDEoaSXQpUiUpJ7aRf++MrDSx
+        F71RkO6yMSRSZ3jmdTjeeYoX4E29glsHxut4sS4K4bzpzrM5xw2WBjCZsCTocT7uBr3BYJB2h8BY
+        j42D0YANh5z1I+gjVOkEliJBUHi+GF6xiYu+ySBcLfqX5xd3s3nWvVx9KsKP14PL+acf4fksX8yz
+        u/A87M7mX4twfiPD1cU2XGW3s+31Zra6ycPVZ3Ezv3p3wItXLteGGDbcv+Q85+bkw9pohV9CwYVE
+        Esgfl8+Alv/JaPEMncMPEu7IZRaw4DQYngZs3u1PWXcajG+8+4cIUDT+2hEFWMszInGhhBNcii2c
+        IC1+YqDUVjhtNkjUGcBvHjLRTYNJkrLeaDRm/VG3PxhDwtiEj6KoP45HuDNORj0IEFgZCkDuXGmn
+        vs9LcZYJl1cRBcCvj/ALcJhybeBUiujUgXXWp9/lstgQEwvOR5BPHKz/7LMxfq94+L4Yrd+iCAkC
+        yi1jXSks46DjrcGIVMTcCSwPjOb+HbBOUy4tdDwD3NKWVykrMoU7HY8euKsMxl9VUna8km+k5gii
+        1/vXc/MFLuaukMvDKD9J73MSuz/0BWG1R+e+uLTauu03ebWYm0cBkDoTlDib112OeyQ/w8Fg2DuU
+        o6vh139nMl4tUGoWW7Kxxho3x97Ui5Y13VJZMLFWDsupbpzKry2/X78jtctMY6NWvP9rOrJl/Uee
+        f87h43epllLfIvaY6mFPH5j3f4OQ1f5ZqKy9AQTtfO1ywDgh/XtyWqBOtLFUA3aoJKgsIiETFkNs
+        IGljpIEgmVuFPHa1hNW2qsjGRpTU2q1oHQDRkDYZV2Jba0QrQwikkqw1tY1LNQCBsMbqaoXcI3Z+
+        acSaxxsKg4EYxBpj2t7aERSNuU1JF9M1ZpwiLBwseVJQm9VyeXxBvrVgc62+tWC7znlrwf2lhWJ2
+        0L3PasGSG9INb/rfd2zIpRTqB77gpAgyfY3JLzJcxTkOfr//F9CF9cRyy4GDpsgHW0i4NNpB7J7M
+        YM1KM6KB4pE8mNB+VoIuDbwJXGWXSC3eOwwq1SaGeuSTKH/EUacpBrG+ue+aGD2eiSf8WaefPx4f
+        BQkVufaKfLj/BV3UCHZZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:09 GMT
+      etag:
+      - W/"3905c3889fc459d46b0571df1fb7c296"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DA1A:142FB38:5ED66054
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3536'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:09 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DA43:142FB7B:5ED66055
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3535'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2f0e992d03aa8103555f16e22328075266a24be4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPSTAGAkGq1EOqKitBtC3bKqmqaAgDmPIR2Wa7SZT/vuOmh93b
+        rtReLDyPmffmzfjCdA0sZqLkuFyKgnsAkcu9IAhKd4FCeCLiYSAWCxB+jj6bsn4ocC8LSkpW28W9
+        WJr8e8uTZutvVuunNKvcTXPXJZ8fgk129ytZpfU2q56SVeKm2bcuyXZt0qzPSVP9Ts8Pp7TZ1Unz
+        Re6y+w9UfFQtFa6NOerYceAo55U09ZjPD0PnKDwO2unQgDaDwlkr85lBbbRjz/2+OxVAGBqHkhzK
+        6CRh72itNl27fy3hBf1biG+k7+GE0dSDYvGF9dAhNf+1hhrU5NOjGnpyBDuQ1hOaE4XnaMMfKxu0
+        ntAP1LNNE1zwGV/MuMhcPxZuzKMdu07ZTZHB/0hhFJKCy99Vcku+LErhhWEk/ND1gwgLIZYQ5rkf
+        HUJCoiL0kP/baVsN2nkzNxnTodZQWevWvTQSWnnGiV2gyZ89k7RiJ9J4BIW90Sz+8XPKHlHJUh7A
+        SJoNdXy7Iz2GElqNU6YQtIXY2GtZ9YRMmf0AMyqi6se2tSVP7QCUZK/X6zO7VMkChAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:09 GMT
+      etag:
+      - W/"da216a1704ddeccfd093d7e901b5f625"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DA7B:142FBC0:5ED66055
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3534'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["2f0e992d03aa8103555f16e22328075266a24be4"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"326037e3d9c930db99719e92c146d2acab0a4e96","node_id":"MDY6Q29tbWl0MjY4ODIxNTg1OjMyNjAzN2UzZDljOTMwZGI5OTcxOWU5MmMxNDZkMmFjYWIwYTRlOTY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/326037e3d9c930db99719e92c146d2acab0a4e96","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:10Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:10Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"2f0e992d03aa8103555f16e22328075266a24be4","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/2f0e992d03aa8103555f16e22328075266a24be4","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/2f0e992d03aa8103555f16e22328075266a24be4"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      etag:
+      - '"a1aea1139ec1d77a835a52013813fa0e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DA92:142FBD7:5ED66055
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3533'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghPno5AZFajksrSpyhLZ+AUbxXEUP1BTxH/vQx27dOhyl/vO
+        u+fKRmhZdc/ILSgTuVcRYWQPrA8GGmeolStZvvnay9NHvlttP19ej+muf+72vbyodW33G3nR709f
+        Zl1PBJ7HjiCLOMSKczW4+dGhPev5IXg+whBoBJBmwgizzukZQsTI79k0fjKKOkBOEF3/9gr6BAdk
+        1ZVFq2hItAksl8IkmVKLNMmKomjTEoTIxCJ5LERZKpFryMkMpwGIIA/v8H9Nf35G/meb2+0bMJzr
+        F30BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      etag:
+      - W/"1570b68f489f7c1d0307727470b12ee6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DABF:142FC0C:5ED66056
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3532'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "326037e3d9c930db99719e92c146d2acab0a4e96"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy07DMBBF/8VrWuelVM66olDJ7QaC6CbyY6hdxUlkTytC1X9nKpZsWLC5mztn
+        7rmyCB+suWfiDpRNPKiEENkDG0YLnbfUyrWsX0Mb5Om92q+fP3cvx3w/bPvDIC9q07rDk7zot8cv
+        u2lnAs+xJ8ghTqnhXE1+efToznppxsAjTCONANLMGGHRe71ASJj4PbsuzFZRB8gJouvfXqM+gUHW
+        XFlyiobKos7KFZRWGFFmVguxygWIwuRVbQtllM5UBaImM5wnIII8gsf/Nf35mfifbW63b4oZei19
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:11 GMT
+      etag:
+      - W/"5390dd1f8c2492de0de8e556a9abe291"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DADA:142FC29:5ED66056
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3531'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:11 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DB66:142FCCA:5ED66057
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3530'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S212apgaJ7SFdgQBZg2ICuLwIl0RJjSdRIyp4j5Lv3f6Rk
+        yZ6bOAkf85LYNPm74/HueLx2ItPJYn55dTWfvb96fzapVCoiGpvcXH/e3Ba/F8mXD/f865/rpFpt
+        /7jL3t3cfZ7dXv/9cYLJvBSYaYWxUVRuU265ERY/LJuiiLpfS4FRq7Q4L2R8TnMN+/+KWss1t6At
+        eWHE2URtKqEni3ZSqExWEHIEA0Gk6eXl9Jf5/Gp2oPz2dvVh+23+W8O/1nn6pVjHd//Mb66T7c1d
+        9h+WcsjjOmp0AXpubW0WjPlB8/NFJm3exI0ROlGVFZW9SFTJGtYL+7T++A6QTHcYZzIMHOBq2ZH8
+        cuAMO76T3JbFgTJeB7fy+JqlKgq1AfNwFyeKZTsAnZmDySp7HQyAlimbC5gW230gI0mc+UupbnHL
+        6B/8knAGx6ZF+lJgtxxKkos9tEyLWjluE5tEy9pKVb1Y3T0IoEpnvJL3/FVQQAxYpOiLFXOLARFr
+        OPOLKX51y1y4JlsymxaJkGucx+vIBxiA7bam7HI7siCdkrQi4mlJScHlioczRO8zY+dIAkrF7vAn
+        iwr5iyJCr3YJ6dHAdsY9FqRHBBH1CfufjEMAAwarrMQ2GJNYLcPfLt4SJAYeK82RxIMJ2YO2bPyV
+        nMoKXgaT5WCA5kqFs7yDASqNacRJvn/6qTqmYX2wVU0Z+0x6SoidLsbTsAdujMwqIYJZfAdsWX8J
+        xJpXSR5ORM9rmf/kvIZnwbZALCDjQsXBmLjQmQO2zOTcX402Cqk1SSDengAtlkG3QLydAKsD+o1T
+        n4A7PG5rCxcKpn/PY213AgWvsoZn4STsgHRZoVTJ+P2TFdrpMTsQgafSVMu4CZuYBybtwBdFyD/h
+        jmBADgJc1fV4SfcMI40qOWemspRP1Tyn0zvcXogFFkFxcCiGvj9duj1vG8Rr2XC/+MuskxTqNLrb
+        rNd/LK97WwVzrZ7H2p9qbnPKsBBbcy1CbabDsTbGU/fh4uKizQV3z5JS6IBZxNOA5TrJUV6H0r/t
+        eagcS27d82dJ6qd4DhWKp8HOYgcE3LtAqD142tiPatTrwRR3sDG9lAW6FqoKd0cMxLGcSlm5lMkp
+        b8XTw3wP2n4yskrEGcfzBlFhZSIRJ3iykwegyBfhrOhp2B56RP6ZWAiETLBT0sLzWua7AqmoC7UN
+        miFHSEokWqBBlUbc4lE6n86n59PL8+n8r9m7xXy2mF5+w5ymRg/sh3NmM5pTNyZ/YgrSfxcr+ISu
+        1OONoMM3JnWcIMeYfID8OiAWR3pJP0AkBZz+IGpfpsv68G5/HgbbyVUpatRp/ePcyHt8nu7VWIlq
+        KpwOBjfc4rGBmmUY6uuyHpBzE/lMMllY3aDnSCO1VncisWY8NmSy0cSNXMm9hVRD7roF/pE/CC+l
+        1qprNvrmQpeH0TbsOp6pNDwuxDCgalF1Go63IRNRmZ0ZfAOAtjyavmcC9yUVS94UNvJvJWqnoieL
+        BivcUegSZqCeF7Vbu86KNwi5ar9Hyor+MxouVpR15L3DqpWg/ixQyCpqE5l/Gw7XcxdYv9j/4oaw
+        FarG9n/Rgq7T/TUpAhytHq9xhOKwI/YN4nFb6K1P3MRvfeK3PvFbn9h32un6O9InroTdoGE6yqbj
+        522frR++Awt3nzsVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:12 GMT
+      etag:
+      - W/"4da00857903caa023a0ea1383346a5ec"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DB94:142FD0A:5ED66057
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3529'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:12 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DBBE:142FD39:5ED66058
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3528'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S212apgaJ7SFdgQBZg2ICuLwIl0RJjSdRIyp4j5Lv3f6Rk
+        yZ6bOAkf85LYNPm74/HueLx2ItPJYn55dTWfvb96fzapVCoiGpvcXH/e3Ba/F8mXD/f865/rpFpt
+        /7jL3t3cfZ7dXv/9cYLJvBSYaYWxUVRuU265ERY/LJuiiLpfS4FRq7Q4L2R8TnMN+/+KWss1t6At
+        eWHE2URtKqEni3ZSqExWEHIEA0Gk6eXl9Jf5/Gp2oPz2dvVh+23+W8O/1nn6pVjHd//Mb66T7c1d
+        9h+WcsjjOmp0AXpubW0WjPlB8/NFJm3exI0ROlGVFZW9SFTJGtYL+7T++A6QTHcYZzIMHOBq2ZH8
+        cuAMO76T3JbFgTJeB7fy+JqlKgq1AfNwFyeKZTsAnZmDySp7HQyAlimbC5gW230gI0mc+UupbnHL
+        6B/8knAGx6ZF+lJgtxxKkos9tEyLWjluE5tEy9pKVb1Y3T0IoEpnvJL3/FVQQAxYpOiLFXOLARFr
+        OPOLKX51y1y4JlsymxaJkGucx+vIBxiA7bam7HI7siCdkrQi4mlJScHlioczRO8zY+dIAkrF7vAn
+        iwr5iyJCr3YJ6dHAdsY9FqRHBBH1CfufjEMAAwarrMQ2GJNYLcPfLt4SJAYeK82RxIMJ2YO2bPyV
+        nMoKXgaT5WCA5kqFs7yDASqNacRJvn/6qTqmYX2wVU0Z+0x6SoidLsbTsAdujMwqIYJZfAdsWX8J
+        xJpXSR5ORM9rmf/kvIZnwbZALCDjQsXBmLjQmQO2zOTcX402Cqk1SSDengAtlkG3QLydAKsD+o1T
+        n4A7PG5rCxcKpn/PY213AgWvsoZn4STsgHRZoVTJ+P2TFdrpMTsQgafSVMu4CZuYBybtwBdFyD/h
+        jmBADgJc1fV4SfcMI40qOWemspRP1Tyn0zvcXogFFkFxcCiGvj9duj1vG8Rr2XC/+MuskxTqNLrb
+        rNd/LK97WwVzrZ7H2p9qbnPKsBBbcy1CbabDsTbGU/fh4uKizQV3z5JS6IBZxNOA5TrJUV6H0r/t
+        eagcS27d82dJ6qd4DhWKp8HOYgcE3LtAqD142tiPatTrwRR3sDG9lAW6FqoKd0cMxLGcSlm5lMkp
+        b8XTw3wP2n4yskrEGcfzBlFhZSIRJ3iykwegyBfhrOhp2B56RP6ZWAiETLBT0sLzWua7AqmoC7UN
+        miFHSEokWqBBlUbc4lE6n86n59PL8+n8r9m7xXy2mF5+w5ymRg/sh3NmM5pTNyZ/YgrSfxcr+ISu
+        1OONoMM3JnWcIMeYfID8OiAWR3pJP0AkBZz+IGpfpsv68G5/HgbbyVUpatRp/ePcyHt8nu7VWIlq
+        KpwOBjfc4rGBmmUY6uuyHpBzE/lMMllY3aDnSCO1VncisWY8NmSy0cSNXMm9hVRD7roF/pE/CC+l
+        1qprNvrmQpeH0TbsOp6pNDwuxDCgalF1Go63IRNRmZ0ZfAOAtjyavmcC9yUVS94UNvJvJWqnoieL
+        BivcUegSZqCeF7Vbu86KNwi5ar9Hyor+MxouVpR15L3DqpWg/ixQyCpqE5l/Gw7XcxdYv9j/4oaw
+        FarG9n/Rgq7T/TUpAhytHq9xhOKwI/YN4nFb6K1P3MRvfeK3PvFbn9h32un6O9InroTdoGE6yqbj
+        522frR++Awt3nzsVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:12 GMT
+      etag:
+      - W/"4da00857903caa023a0ea1383346a5ec"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DBE3:142FD62:5ED66058
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3527'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW6vaQBD+K7LPajabmwkUWrAtPsTQNgfRUmSSTMx6cpHs5hw94n/vLPZA+6Zg
+        X0J2JrPfZT5yZqoCFjFH+NwJ0CnCPHR4kYVhYIcYitx2/UJADhkHF0OfjVnbFbiVBQ3F87X/TYQ6
+        W9U83q/dZL44LtOdnezj03L/6W0pnt4283qfpPHr5uvCS9L8mKyevLiJj8v55jluvuzXq8XrOv1e
+        J+n6A10+9DVdXGl9UJFlwUFOd1JXQzbNu8bq8dApq0ENSnc9TmqZTTQqrSzz3G6bUwHUQ23RkEUT
+        jaTeHdIq3dTbfyn8BX8L8BX0HkwYdNX1LDqzFhok8T8qqKAffX7pu5YcwQak8YT2ROUpmvLHnSka
+        T+gD0mzGBBd8wv0JF6ntRsKObL5hlzG7MtL4HyF0j8Tg/CdKQYAz33FL18m4k5elHxZu4Ho5zzBA
+        LB2RIcXJ9x67bcNBWTdjkzENKgU7Y92ilVpCPTLpOUD+TNXR1TbieIAeW61Y9PNdoCg5hqEouAMw
+        s7njeV5p+yiEI2Y88ITvg3AzdB8r8D3Od6A/LM43Y15+jdkL9rKUOWhJ+aVUXM9IP4wSaoVj1iMo
+        02JDq+Supc6YmRfQQ0/raIe6Nraf6g5oyBwvl9+CEfCRqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      etag:
+      - W/"a1aea1139ec1d77a835a52013813fa0e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DC12:142FD8C:5ED66058
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3526'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28iOYzkKjNKYrTjQlnUXdUIh6OPEVipLxlIastL/PqkNtEt3
+        kXVj7ELioCOd9+E9R4+Rpi1Ek0hQRzvK72kNg7U1OjqJOuqaX2dsQ31iDPmYC0JFToAMhymLxzhL
+        cpwJARjyLCYxGTMc+1JWfvciBJ9Em175p41znZ0gRDs5qKVrNmzATYt66IxFLThqnenhVEl26sA6
+        i8K+XLa7gGnBIW60A+0Th9xnPaw+pUMcpzmkgnCSxoIRkieBkScjLIaUUxbTERDsyRrXquXPUG+A
+        jkFhyjB0rOI7Xo/g9Q4IPmyLL4UCj0W/0RxhtloZKg4gerrd92Zjod8b/tymY1z5E0PcrgsjuZIK
+        vD17ZX8AW1OXxWwzv01UufZxm2SLiy/xvLpSoihtef6c3y2qqwdRzdaL6lJeyykr5Hl9p8timoeo
+        LMKabefVjXmpctOIi88PrFKvL79la57O5cv9KbnTIaq+dj7ySKC5EVLXnon5ccQjf7ZUUt/baPIY
+        WVCr/2rG/VT8DZ4PDVf4X2/E/+3fenr6ATSXMr3gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DC2E:142FDBA:5ED66059
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3525'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "326037e3d9c930db99719e92c146d2acab0a4e96"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxNTg1Ojg1MzRiZDA0NmEwMzEzODQ0MzkwMjBmNWIzOWE2YzlkODgyNzA1N2I=","sha":"8534bd046a031384439020f5b39a6c9d8827057b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8534bd046a031384439020f5b39a6c9d8827057b","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:13Z"},"object":{"sha":"326037e3d9c930db99719e92c146d2acab0a4e96","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      etag:
+      - '"747de1673dd33a248e853af68ac23796"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8534bd046a031384439020f5b39a6c9d8827057b
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DC53:142FDE5:5ED66059
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3524'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "8534bd046a031384439020f5b39a6c9d8827057b", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxNTg1OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"8534bd046a031384439020f5b39a6c9d8827057b","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8534bd046a031384439020f5b39a6c9d8827057b"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:14 GMT
+      etag:
+      - '"bb1f24a7578bbc24b11074e058afe798"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DC96:142FE28:5ED66059
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3523'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:15 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DCEE:142FE9B:5ED6605A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3522'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHtzaZZA4vtIdsFCqQBihbY7kWgJNpiLIkqSdl1hLx7/yEl
+        S3adxHF4zCWxafKb4XBmOJxmJNPRbHp1fT2dfLz+eDYqVSoiGhvd3nxd3+W/5cm3Tw/8+x+rpFxu
+        fr9fXN7ef53c3fz1eYTJvBCYaYWxUVRsUm65ERY/zOs8j9pfC4FRq7Q4z2V8TnMN+/+KSssVt6DN
+        eW7E2UitS6FHs2aUq4UsIeQABoJI06ur8c/T6fVkT/nN3fLT5sf015p/r7L0W76K7/+e3t4km9v7
+        xb9YyiGP66jWOeiZtZWZMeYHzYeLhbRZHddG6ESVVpT2IlEFq1kn7Mvq8yUgC91inMkwsIerZEvy
+        y4Ez7PBOMlvke8p4HdzKw2vmKs/VGsz9XRwplm0BdGYOJsvF22AANEzZTMC02O4jGUnizE+lusUN
+        o3/wS8IZHJsW6anAdjmUJBd7bJgWlXLcOjaJlpWVqjxZ3R0IoEoveCkf+JuggBiwSNGTFXOLAREr
+        OPPJFL+6YS5ckw2ZTYtEyBXO423kPQzAdlNRdrkbWJBOSVoR8bSgpOByxeMZoveVsXMgAaVie/ij
+        WYn8RRGhl9uE9GxgO+MeCtIDgoj6gv2PxiGAAYNVlmITjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Ri5KIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIYvgm2BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazINugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJeLmq+CCdhC6TLCqXKgj+8WKEdH7M9EXgqTbWM67CJuWfSDnxRhPwT
+        7gh6ZC/AVV3Pl3SvMNKgknNmKgr5Us1zPL3F7YRYYBEUB/ti6PvLpdvrtkG8hvX3i7/MWkmhTqO9
+        zTr9h/Lat1Uw1+p4rPmp4jajDAuxFdci1GZaHGtiPHUfLy4umkxw9ywphA6YRTwNWK6TDOV1KP2b
+        jofKseDWPX/mpH6K51CueBrsLLZAwL0LhNqDpw39qEK9HkxxBxvSC5mja6HKcHdETxzKKZWVc5kc
+        81Y8Psx3oM0XI8tEnHE8bxAVViYScYInO3kAinwRzoqehu2hR+SfiblAyAQ7JS08r2G+K5CKKleb
+        oBlygKREogUaVGnELR6l0/F0fD6+Oh9P/5xczqaT2fjqB+bUFXpgT86ZfKA5VW2yp6dc0hSk/zZW
+        8AldqecbQftvTOo4AWJM1kN+6RGzA72kJxBJDqffi9rTdFnt3+2vw2A7mSpEhTqte5wb+YDP450a
+        K1F1idPB4JpbPDZQs/RDXV3WATJuIp9JRjOra/QcaaTS6l4k1gzH+kw2mLiWS7mzkGrIbbfAP/J7
+        4YXUWrXNRt9caPMw2oZtxzOVhse56AdUJcpWw+E2ZCJKszWDbwDQlgfTd0zgvqRizuvcRv6tRO1U
+        9GTRYIU7Cl3ADNTzonZr21nxBiFX7fZIWdF/RsPFiqKKvHdYtRTUnwUKWUWtI/NPzeF67gLrFvtf
+        3BC2QtXY7i9a0HW6uyZFgKPV4zWOUBy2xK5BPGwLvfeJ6/i9T/zeJ37vE/tOO11/B/rEpbBrNEwH
+        2XT4vO2y9eN/kr959BUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:15 GMT
+      etag:
+      - W/"753b8ab16bf8a9b00301b2bbc106268c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DD0F:142FEC6:5ED6605B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3521'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:15 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DD2D:142FEF1:5ED6605B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3520'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHtzaZZA4vtIdsFCqQBihbY7kWgJNpiLIkqSdl1hLx7/yEl
+        S3adxHF4zCWxafKb4XBmOJxmJNPRbHp1fT2dfLz+eDYqVSoiGhvd3nxd3+W/5cm3Tw/8+x+rpFxu
+        fr9fXN7ef53c3fz1eYTJvBCYaYWxUVRsUm65ERY/zOs8j9pfC4FRq7Q4z2V8TnMN+/+KSssVt6DN
+        eW7E2UitS6FHs2aUq4UsIeQABoJI06ur8c/T6fVkT/nN3fLT5sf015p/r7L0W76K7/+e3t4km9v7
+        xb9YyiGP66jWOeiZtZWZMeYHzYeLhbRZHddG6ESVVpT2IlEFq1kn7Mvq8yUgC91inMkwsIerZEvy
+        y4Ez7PBOMlvke8p4HdzKw2vmKs/VGsz9XRwplm0BdGYOJsvF22AANEzZTMC02O4jGUnizE+lusUN
+        o3/wS8IZHJsW6anAdjmUJBd7bJgWlXLcOjaJlpWVqjxZ3R0IoEoveCkf+JuggBiwSNGTFXOLAREr
+        OPPJFL+6YS5ckw2ZTYtEyBXO423kPQzAdlNRdrkbWJBOSVoR8bSgpOByxeMZoveVsXMgAaVie/ij
+        WYn8RRGhl9uE9GxgO+MeCtIDgoj6gv2PxiGAAYNVlmITjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Ri5KIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIYvgm2BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazINugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJeLmq+CCdhC6TLCqXKgj+8WKEdH7M9EXgqTbWM67CJuWfSDnxRhPwT
+        7gh6ZC/AVV3Pl3SvMNKgknNmKgr5Us1zPL3F7YRYYBEUB/ti6PvLpdvrtkG8hvX3i7/MWkmhTqO9
+        zTr9h/Lat1Uw1+p4rPmp4jajDAuxFdci1GZaHGtiPHUfLy4umkxw9ywphA6YRTwNWK6TDOV1KP2b
+        jofKseDWPX/mpH6K51CueBrsLLZAwL0LhNqDpw39qEK9HkxxBxvSC5mja6HKcHdETxzKKZWVc5kc
+        81Y8Psx3oM0XI8tEnHE8bxAVViYScYInO3kAinwRzoqehu2hR+SfiblAyAQ7JS08r2G+K5CKKleb
+        oBlygKREogUaVGnELR6l0/F0fD6+Oh9P/5xczqaT2fjqB+bUFXpgT86ZfKA5VW2yp6dc0hSk/zZW
+        8AldqecbQftvTOo4AWJM1kN+6RGzA72kJxBJDqffi9rTdFnt3+2vw2A7mSpEhTqte5wb+YDP450a
+        K1F1idPB4JpbPDZQs/RDXV3WATJuIp9JRjOra/QcaaTS6l4k1gzH+kw2mLiWS7mzkGrIbbfAP/J7
+        4YXUWrXNRt9caPMw2oZtxzOVhse56AdUJcpWw+E2ZCJKszWDbwDQlgfTd0zgvqRizuvcRv6tRO1U
+        9GTRYIU7Cl3ADNTzonZr21nxBiFX7fZIWdF/RsPFiqKKvHdYtRTUnwUKWUWtI/NPzeF67gLrFvtf
+        3BC2QtXY7i9a0HW6uyZFgKPV4zWOUBy2xK5BPGwLvfeJ6/i9T/zeJ37vE/tOO11/B/rEpbBrNEwH
+        2XT4vO2y9eN/kr959BUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:15 GMT
+      etag:
+      - W/"753b8ab16bf8a9b00301b2bbc106268c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DD45:142FF09:5ED6605B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3519'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW6vaQBD+K7LPajabmwkUWrAtPsTQNgfRUmSSTMx6cpHs5hw94n/vLPZA+6Zg
+        X0J2JrPfZT5yZqoCFjFH+NwJ0CnCPHR4kYVhYIcYitx2/UJADhkHF0OfjVnbFbiVBQ3F87X/TYQ6
+        W9U83q/dZL44LtOdnezj03L/6W0pnt4283qfpPHr5uvCS9L8mKyevLiJj8v55jluvuzXq8XrOv1e
+        J+n6A10+9DVdXGl9UJFlwUFOd1JXQzbNu8bq8dApq0ENSnc9TmqZTTQqrSzz3G6bUwHUQ23RkEUT
+        jaTeHdIq3dTbfyn8BX8L8BX0HkwYdNX1LDqzFhok8T8qqKAffX7pu5YcwQak8YT2ROUpmvLHnSka
+        T+gD0mzGBBd8wv0JF6ntRsKObL5hlzG7MtL4HyF0j8Tg/CdKQYAz33FL18m4k5elHxZu4Ho5zzBA
+        LB2RIcXJ9x67bcNBWTdjkzENKgU7Y92ilVpCPTLpOUD+TNXR1TbieIAeW61Y9PNdoCg5hqEouAMw
+        s7njeV5p+yiEI2Y88ITvg3AzdB8r8D3Od6A/LM43Y15+jdkL9rKUOWhJ+aVUXM9IP4wSaoVj1iMo
+        02JDq+Supc6YmRfQQ0/raIe6Nraf6g5oyBwvl9+CEfCRqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:16 GMT
+      etag:
+      - W/"a1aea1139ec1d77a835a52013813fa0e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DD6E:142FF2F:5ED6605B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3518'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28iOYzkKjNKYrTjQlnUXdUIh6OPEVipLxlIastL/PqkNtEt3
+        kXVj7ELioCOd9+E9R4+Rpi1Ek0hQRzvK72kNg7U1OjqJOuqaX2dsQ31iDPmYC0JFToAMhymLxzhL
+        cpwJARjyLCYxGTMc+1JWfvciBJ9Em175p41znZ0gRDs5qKVrNmzATYt66IxFLThqnenhVEl26sA6
+        i8K+XLa7gGnBIW60A+0Th9xnPaw+pUMcpzmkgnCSxoIRkieBkScjLIaUUxbTERDsyRrXquXPUG+A
+        jkFhyjB0rOI7Xo/g9Q4IPmyLL4UCj0W/0RxhtloZKg4gerrd92Zjod8b/tymY1z5E0PcrgsjuZIK
+        vD17ZX8AW1OXxWwzv01UufZxm2SLiy/xvLpSoihtef6c3y2qqwdRzdaL6lJeyykr5Hl9p8timoeo
+        LMKabefVjXmpctOIi88PrFKvL79la57O5cv9KbnTIaq+dj7ySKC5EVLXnon5ccQjf7ZUUt/baPIY
+        WVCr/2rG/VT8DZ4PDVf4X2/E/+3fenr6ATSXMr3gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:16 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DD8D:142FF56:5ED6605C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3517'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "This is a different tag", "tag": "version-1.0.0",
+      "type": "commit", "object": "326037e3d9c930db99719e92c146d2acab0a4e96"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxNTg1OmJhMmZjZjcxZDQ2M2FkOWE2ZjA4NDFlNjIwYWU5YTA1MWI0MWQ5YWY=","sha":"ba2fcf71d463ad9a6f0841e620ae9a051b41d9af","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/ba2fcf71d463ad9a6f0841e620ae9a051b41d9af","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:16Z"},"object":{"sha":"326037e3d9c930db99719e92c146d2acab0a4e96","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96"},"tag":"version-1.0.0","message":"This
+        is a different tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '704'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:16 GMT
+      etag:
+      - '"fdcecdf46ba4486234c9f273b06211b9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/ba2fcf71d463ad9a6f0841e620ae9a051b41d9af
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DDA8:142FF77:5ED6605C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3516'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "ba2fcf71d463ad9a6f0841e620ae9a051b41d9af", "ref":
+      "refs/tags/version-1.0.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0.0","node_id":"MDM6UmVmMjY4ODIxNTg1OnJlZnMvdGFncy92ZXJzaW9uLTEuMC4w","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0.0","object":{"sha":"ba2fcf71d463ad9a6f0841e620ae9a051b41d9af","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/ba2fcf71d463ad9a6f0841e620ae9a051b41d9af"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '395'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:17 GMT
+      etag:
+      - '"cac289e862946a78ae0e59ab64d54bf4"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DDE8:142FFBE:5ED6605C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3515'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:18 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DE6F:143004E:5ED6605D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3514'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S226apgaJ7SFdgQBZg2ICuLwIl0RZjSdRIyp4j5Lv3f6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJNPRbHp5dTWdfLj6cDYqVSoiGhvdXH9d3+a/58m3T/f8+5+rpFxu
+        /rhbvL+5+zq5vf778wiTeSEw0wpjo6jYpNxyIyx+mNd5HrW/FgKjVmlxnsv4nOYa9v8VlZYrbkGb
+        89yIs5Fal0KPZs0oVwtZQsgBDASRppeX44/T6dVkT/nN7fLT5sf0t5p/r7L0W76K7/6Z3lwnm5u7
+        xX9YyiGP66jWOeiZtZWZMeYHzbuLhbRZHddG6ESVVpT2IlEFq1kn7Mvq83tAFrrFOJNhYA9XyZbk
+        lwNn2OGdZLbI95TxOriVh9fMVZ6rNZj7uzhSLNsC6MwcTJaL18EAaJiymYBpsd0HMpLEmZ9KdYsb
+        Rv/gl4QzODYt0lOB7XIoSS720DAtKuW4dWwSLSsrVXmyujsQQJVe8FLe81dBATFgkaInK+YWAyJW
+        cOaTKX51w1y4JhsymxaJkCucx+vIexiA7aai7HI7sCCdkrQi4mlBScHlioczRO8LY+dAAkrF9vBH
+        sxL5iyJCL7cJ6cnAdsY9FKQHBBH1GfsfjUMAAwarLMUmGJNYDcPfNt4SJAYeK82RxIMJ2YE2bPiV
+        nMoKXgST5WCAZkqFs7yDASqNqcVRvn/8qTqmYV2wlXUR+0x6TIgdL8bTsAdujFyUQgSz+BbYsO4S
+        iDUvkyyciI7XMP/JeQ1fBNsCsYCMcxUHY+JCZw7YMJNxfzXaKKTWJIF4OwK0mAfdAvG2AqwO6DdO
+        fQJu8bitLVwomP4djzXtCeS8XNR8EU7CFkiXFUqVBb9/tkI7PmZ7IvBUmmoZ12ETc8+kHfiiCPkn
+        3BH0yF6Aq7qeLuleYKRBJefMVBTyuZrneHqL2wmxwCIoDvbF0PfnS7eXbYN4DevvF3+ZtZJCnUZ7
+        m3X6D+W1b6tgrtXxWPNLxW1GGRZiK65FqM20ONbEeOo+XFxcNJng7llSCB0wi3gasFwnGcrrUPo3
+        HQ+VY8Gte/7MSf0Uz6Fc8TTYWWyBgHsXCLUHTxv6UYV6PZjiDjakFzJH10KV4e6InjiUUyor5zI5
+        5q14fJjvQJsvRpaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/E3OBkAl2Slp4XsN8VyAVVa42
+        QTPkAEmJRAs0qNKIWzxKp+Pp+Hx8eT6e/jV5P5tOZuPLH5hTV+iBPTpn8o7mVLXJHp/ykaYg/bex
+        gk/oSj3dCNp/Y1LHCRBjsh7ya4+YHeglPYJIcjj9XtSepstq/25/GQbbyVQhKtRp3ePcyHt8Hu/U
+        WImqS5wOBtfc4rGBmqUf6uqyDpBxE/lMMppZXaPnSCOVVncisWY41meywcS1XMqdhVRDbrsF/pHf
+        Cy+k1qptNvrmQpuH0TZsO56pNDzORT+gKlG2Gg63IRNRmq0ZfAOAtjyYvmMC9yUVc17nNvJvJWqn
+        oieLBivcUegCZqCeF7Vb286KNwi5ardHyor+MxouVhRV5L3DqqWg/ixQyCpqHZl/aw7XcxdYt9j/
+        4oawFarGdn/Rgq7T3TUpAhytHq9xhOKwJXYN4mFb6K1PXMdvfeK3PvFbn9h32un6O9AnLoVdo2E6
+        yKbD522XrR9+Ai2n5d0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:18 GMT
+      etag:
+      - W/"62739e2c64a99576160fbe78c03fc95b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DE92:1430078:5ED6605E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3513'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QMW+DMBCF/4vngg0GAkgZIiWtGpVmSZs2C7KxA0RgI3xEpVH+e6+dO3To8pZ7
+        7+57dyWjPpH8Wx0FUTt60aNrrfECn5E7YqzSZavQUayL5KV/7Yvze7RbP3487+tgZ7bd0RQX9XBv
+        qjkLj2/bT3HIpqf9ZipWyyUumMYOww3A4HJKxdD6dQvNJP3K9nTUg3W01yAc2FF7XSs90A4QBbUs
+        +1kJnGmgGEL374xWnnUFJL8S1wg8lsY8kopFiWA84GkU8YyF7BRLnomkylSahgsWLyTSwTxoTGDx
+        /0X9+eSfOW63L2gxVciHAQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:18 GMT
+      etag:
+      - W/"bb1f24a7578bbc24b11074e058afe798"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DEB7:14300A6:5ED6605E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3512'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/8534bd046a031384439020f5b39a6c9d8827057b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S246bMBD9lcjPEAwmJEaq1K1IqzwAarvqavclGmACznITNruFVf69Y+UHWqkv
+        lmfmnDNnRvPB+qHCs6pYzNIkjX59+9qn1+cwT06/s8faz6+1n64/1EvywLPu+J6uxzVPvvN0fX1P
+        r1+67Om05k/H4HltX/OkXrL1wc+C0yfmMN0AiR52IiwqHkbAhS8OYSgkD/hlVwgJUSmrwyHY892+
+        IMI8tURojBl17Hkwqm2tTDMX23LovAnHQXsdGtBmmNBtVeEa1EZ79j2fu6UCqqHxiOQZqLX3D60J
+        X+PE4g/WQ4fk4mcDDUyb49s09GQNO1DWHM1E6S3a9OfaJq05AlBzSwtoNpdHLg8e/TAO/NgXL+zm
+        sKG4Ymms/n0rIoi42KOoZCkFrwop975EGZR+GFUBlFBwCFFGpGyW0SpTm06Z/7ulu6b2/toNTUKb
+        IjdvOGk19K6/5WSpQ62hti7TZdOrEjetMqbFjQU7FqwuqgRDDLuCe4x0chdoNTpsQtC2xOZeq7qn
+        Cl0PfcDME6n2c9s6bISlHYBINrzd/gBXRdk6uQIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:18 GMT
+      etag:
+      - W/"747de1673dd33a248e853af68ac23796"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DEDD:14300CE:5ED6605E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3511'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:19 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DEF3:14300E7:5ED6605E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3510'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S226apgaJ7SFdgQBZg2ICuLwIl0RZjSdRIyp4j5Lv3f6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJNPRbHp5dTWdfLj6cDYqVSoiGhvdXH9d3+a/58m3T/f8+5+rpFxu
+        /rhbvL+5+zq5vf778wiTeSEw0wpjo6jYpNxyIyx+mNd5HrW/FgKjVmlxnsv4nOYa9v8VlZYrbkGb
+        89yIs5Fal0KPZs0oVwtZQsgBDASRppeX44/T6dVkT/nN7fLT5sf0t5p/r7L0W76K7/6Z3lwnm5u7
+        xX9YyiGP66jWOeiZtZWZMeYHzbuLhbRZHddG6ESVVpT2IlEFq1kn7Mvq83tAFrrFOJNhYA9XyZbk
+        lwNn2OGdZLbI95TxOriVh9fMVZ6rNZj7uzhSLNsC6MwcTJaL18EAaJiymYBpsd0HMpLEmZ9KdYsb
+        Rv/gl4QzODYt0lOB7XIoSS720DAtKuW4dWwSLSsrVXmyujsQQJVe8FLe81dBATFgkaInK+YWAyJW
+        cOaTKX51w1y4JhsymxaJkCucx+vIexiA7aai7HI7sCCdkrQi4mlBScHlioczRO8LY+dAAkrF9vBH
+        sxL5iyJCL7cJ6cnAdsY9FKQHBBH1GfsfjUMAAwarLMUmGJNYDcPfNt4SJAYeK82RxIMJ2YE2bPiV
+        nMoKXgST5WCAZkqFs7yDASqNqcVRvn/8qTqmYV2wlXUR+0x6TIgdL8bTsAdujFyUQgSz+BbYsO4S
+        iDUvkyyciI7XMP/JeQ1fBNsCsYCMcxUHY+JCZw7YMJNxfzXaKKTWJIF4OwK0mAfdAvG2AqwO6DdO
+        fQJu8bitLVwomP4djzXtCeS8XNR8EU7CFkiXFUqVBb9/tkI7PmZ7IvBUmmoZ12ETc8+kHfiiCPkn
+        3BH0yF6Aq7qeLuleYKRBJefMVBTyuZrneHqL2wmxwCIoDvbF0PfnS7eXbYN4DevvF3+ZtZJCnUZ7
+        m3X6D+W1b6tgrtXxWPNLxW1GGRZiK65FqM20ONbEeOo+XFxcNJng7llSCB0wi3gasFwnGcrrUPo3
+        HQ+VY8Gte/7MSf0Uz6Fc8TTYWWyBgHsXCLUHTxv6UYV6PZjiDjakFzJH10KV4e6InjiUUyor5zI5
+        5q14fJjvQJsvRpaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/E3OBkAl2Slp4XsN8VyAVVa42
+        QTPkAEmJRAs0qNKIWzxKp+Pp+Hx8eT6e/jV5P5tOZuPLH5hTV+iBPTpn8o7mVLXJHp/ykaYg/bex
+        gk/oSj3dCNp/Y1LHCRBjsh7ya4+YHeglPYJIcjj9XtSepstq/25/GQbbyVQhKtRp3ePcyHt8Hu/U
+        WImqS5wOBtfc4rGBmqUf6uqyDpBxE/lMMppZXaPnSCOVVncisWY41meywcS1XMqdhVRDbrsF/pHf
+        Cy+k1qptNvrmQpuH0TZsO56pNDzORT+gKlG2Gg63IRNRmq0ZfAOAtjyYvmMC9yUVc17nNvJvJWqn
+        oieLBivcUegCZqCeF7Vb286KNwi5ardHyor+MxouVhRV5L3DqqWg/ixQyCpqHZl/aw7XcxdYt9j/
+        4oawFarGdn/Rgq7T3TUpAhytHq9xhOKwJXYN4mFb6K1PXMdvfeK3PvFbn9h32un6O9AnLoVdo2E6
+        yKbD522XrR9+Ai2n5d0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:19 GMT
+      etag:
+      - W/"62739e2c64a99576160fbe78c03fc95b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DF0C:1430106:5ED6605F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3509'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW6vaQBD+K7LPajabmwkUWrAtPsTQNgfRUmSSTMx6cpHs5hw94n/vLPZA+6Zg
+        X0J2JrPfZT5yZqoCFjFH+NwJ0CnCPHR4kYVhYIcYitx2/UJADhkHF0OfjVnbFbiVBQ3F87X/TYQ6
+        W9U83q/dZL44LtOdnezj03L/6W0pnt4283qfpPHr5uvCS9L8mKyevLiJj8v55jluvuzXq8XrOv1e
+        J+n6A10+9DVdXGl9UJFlwUFOd1JXQzbNu8bq8dApq0ENSnc9TmqZTTQqrSzz3G6bUwHUQ23RkEUT
+        jaTeHdIq3dTbfyn8BX8L8BX0HkwYdNX1LDqzFhok8T8qqKAffX7pu5YcwQak8YT2ROUpmvLHnSka
+        T+gD0mzGBBd8wv0JF6ntRsKObL5hlzG7MtL4HyF0j8Tg/CdKQYAz33FL18m4k5elHxZu4Ho5zzBA
+        LB2RIcXJ9x67bcNBWTdjkzENKgU7Y92ilVpCPTLpOUD+TNXR1TbieIAeW61Y9PNdoCg5hqEouAMw
+        s7njeV5p+yiEI2Y88ITvg3AzdB8r8D3Od6A/LM43Y15+jdkL9rKUOWhJ+aVUXM9IP4wSaoVj1iMo
+        02JDq+Supc6YmRfQQ0/raIe6Nraf6g5oyBwvl9+CEfCRqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:19 GMT
+      etag:
+      - W/"a1aea1139ec1d77a835a52013813fa0e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DF35:143012D:5ED6605F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3508'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28iOYzkKjNKYrTjQlnUXdUIh6OPEVipLxlIastL/PqkNtEt3
+        kXVj7ELioCOd9+E9R4+Rpi1Ek0hQRzvK72kNg7U1OjqJOuqaX2dsQ31iDPmYC0JFToAMhymLxzhL
+        cpwJARjyLCYxGTMc+1JWfvciBJ9Em175p41znZ0gRDs5qKVrNmzATYt66IxFLThqnenhVEl26sA6
+        i8K+XLa7gGnBIW60A+0Th9xnPaw+pUMcpzmkgnCSxoIRkieBkScjLIaUUxbTERDsyRrXquXPUG+A
+        jkFhyjB0rOI7Xo/g9Q4IPmyLL4UCj0W/0RxhtloZKg4gerrd92Zjod8b/tymY1z5E0PcrgsjuZIK
+        vD17ZX8AW1OXxWwzv01UufZxm2SLiy/xvLpSoihtef6c3y2qqwdRzdaL6lJeyykr5Hl9p8timoeo
+        LMKabefVjXmpctOIi88PrFKvL79la57O5cv9KbnTIaq+dj7ySKC5EVLXnon5ccQjf7ZUUt/baPIY
+        WVCr/2rG/VT8DZ4PDVf4X2/E/+3fenr6ATSXMr3gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:19 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DF52:1430154:5ED6605F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3507'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:20 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DF76:143017A:5ED6605F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3506'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S226apgaJ7SFdgQBZg2ICuLwIl0RZjSdRIyp4j5Lv3f6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJNPRbHp5dTWdfLj6cDYqVSoiGhvdXH9d3+a/58m3T/f8+5+rpFxu
+        /rhbvL+5+zq5vf778wiTeSEw0wpjo6jYpNxyIyx+mNd5HrW/FgKjVmlxnsv4nOYa9v8VlZYrbkGb
+        89yIs5Fal0KPZs0oVwtZQsgBDASRppeX44/T6dVkT/nN7fLT5sf0t5p/r7L0W76K7/6Z3lwnm5u7
+        xX9YyiGP66jWOeiZtZWZMeYHzbuLhbRZHddG6ESVVpT2IlEFq1kn7Mvq83tAFrrFOJNhYA9XyZbk
+        lwNn2OGdZLbI95TxOriVh9fMVZ6rNZj7uzhSLNsC6MwcTJaL18EAaJiymYBpsd0HMpLEmZ9KdYsb
+        Rv/gl4QzODYt0lOB7XIoSS720DAtKuW4dWwSLSsrVXmyujsQQJVe8FLe81dBATFgkaInK+YWAyJW
+        cOaTKX51w1y4JhsymxaJkCucx+vIexiA7aai7HI7sCCdkrQi4mlBScHlioczRO8LY+dAAkrF9vBH
+        sxL5iyJCL7cJ6cnAdsY9FKQHBBH1GfsfjUMAAwarLMUmGJNYDcPfNt4SJAYeK82RxIMJ2YE2bPiV
+        nMoKXgST5WCAZkqFs7yDASqNqcVRvn/8qTqmYV2wlXUR+0x6TIgdL8bTsAdujFyUQgSz+BbYsO4S
+        iDUvkyyciI7XMP/JeQ1fBNsCsYCMcxUHY+JCZw7YMJNxfzXaKKTWJIF4OwK0mAfdAvG2AqwO6DdO
+        fQJu8bitLVwomP4djzXtCeS8XNR8EU7CFkiXFUqVBb9/tkI7PmZ7IvBUmmoZ12ETc8+kHfiiCPkn
+        3BH0yF6Aq7qeLuleYKRBJefMVBTyuZrneHqL2wmxwCIoDvbF0PfnS7eXbYN4DevvF3+ZtZJCnUZ7
+        m3X6D+W1b6tgrtXxWPNLxW1GGRZiK65FqM20ONbEeOo+XFxcNJng7llSCB0wi3gasFwnGcrrUPo3
+        HQ+VY8Gte/7MSf0Uz6Fc8TTYWWyBgHsXCLUHTxv6UYV6PZjiDjakFzJH10KV4e6InjiUUyor5zI5
+        5q14fJjvQJsvRpaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/E3OBkAl2Slp4XsN8VyAVVa42
+        QTPkAEmJRAs0qNKIWzxKp+Pp+Hx8eT6e/jV5P5tOZuPLH5hTV+iBPTpn8o7mVLXJHp/ykaYg/bex
+        gk/oSj3dCNp/Y1LHCRBjsh7ya4+YHeglPYJIcjj9XtSepstq/25/GQbbyVQhKtRp3ePcyHt8Hu/U
+        WImqS5wOBtfc4rGBmqUf6uqyDpBxE/lMMppZXaPnSCOVVncisWY41meywcS1XMqdhVRDbrsF/pHf
+        Cy+k1qptNvrmQpuH0TZsO56pNDzORT+gKlG2Gg63IRNRmq0ZfAOAtjyYvmMC9yUVc17nNvJvJWqn
+        oieLBivcUegCZqCeF7Vb286KNwi5ardHyor+MxouVhRV5L3DqqWg/ixQyCpqHZl/aw7XcxdYt9j/
+        4oawFarGdn/Rgq7T3TUpAhytHq9xhOKwJXYN4mFb6K1PXMdvfeK3PvFbn9h32un6O9AnLoVdo2E6
+        yKbD522XrR9+Ai2n5d0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:20 GMT
+      etag:
+      - W/"62739e2c64a99576160fbe78c03fc95b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DF9A:14301A9:5ED66060
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3505'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT1ODQAzFv8uehWVxReFq1bEj9lL/9cIENgt0gGXYUMVOv7vRuzMevLxD8l7y
+        S45iQiuyb/WSoPbygJNv3RCoMAojcSYGZ7BoDXvyVZ489c99vn/Tm9X9x+O2Vpth3e2G/GDubodq
+        SePd6/oTXtL5YXsz59f6nQfMU8fhhmj0mZQwtmHdUjOXYeV6OeHovOyRwJObMOjaMiD0xDCsRdEv
+        BriHJDnE7t8oXbnHikR2FL4BXldCbCt7qYxOzsGkkNjoSitM4ggwhehClVpx2TIfLSNygo//X9if
+        b/6Z43T6AneZ2PuLAQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:20 GMT
+      etag:
+      - W/"cac289e862946a78ae0e59ab64d54bf4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DFBE:14301D6:5ED66060
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3504'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/ba2fcf71d463ad9a6f0841e620ae9a051b41d9af
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9laBnXyTZcWrDQheyKSk4YWnaEL+EsT225fqGJW83LPn3jsgPtLAg
+        hObMnDNnBn2wYSzxqkqWsHSbRr++7Ya0vYTH7f79cKrFsf/epH3WZm3xnm1fZSp3v4/nF5m1z+Fh
+        u+sO7f7P5fxzfTk9i/S85+n5dX05X56Yw3QDJJqDrIpqI8owCqCMIar4l1BgJDlgDHwt8lAQXBFh
+        mTsiNMZMOvF9mJRXK9MsuVeMvT/jNGq/RwPajDO6ncpdg9po397Xa38rgXJofCL5Bmrt/0drqq9x
+        ZskHG6BHcvGjgQbm1cvbPA5kDXtQ1hzNRLCHFv5aW9CaowJqbmmSS+7yyOXyJMJEikREGbs7bMxb
+        LIzVf2wlkBEPNhiUcREHvMzjeCNijGUhwqiUUEDOIcQ4ImVzm6wytemV+dwtPTS1/89uaBLaFLl5
+        w1mrcXCFxz1OpnrUGmrr89QovaIDq1JVFc44mJXlOJajKlWAIaLdxCNG+nkVdBodNiNom2LLoFU9
+        UIY+ET3ALDNJD0vXOWyCWzcCkWx4v/8FWYT1nMACAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:20 GMT
+      etag:
+      - W/"fdcecdf46ba4486234c9f273b06211b9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112DFED:14301FC:5ED66060
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3503'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:21 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E015:143022C:5ED66060
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3502'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S226apgaJ7SFdgQBZg2ICuLwIl0RZjSdRIyp4j5Lv3f6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJNPRbHp5dTWdfLj6cDYqVSoiGhvdXH9d3+a/58m3T/f8+5+rpFxu
+        /rhbvL+5+zq5vf778wiTeSEw0wpjo6jYpNxyIyx+mNd5HrW/FgKjVmlxnsv4nOYa9v8VlZYrbkGb
+        89yIs5Fal0KPZs0oVwtZQsgBDASRppeX44/T6dVkT/nN7fLT5sf0t5p/r7L0W76K7/6Z3lwnm5u7
+        xX9YyiGP66jWOeiZtZWZMeYHzbuLhbRZHddG6ESVVpT2IlEFq1kn7Mvq83tAFrrFOJNhYA9XyZbk
+        lwNn2OGdZLbI95TxOriVh9fMVZ6rNZj7uzhSLNsC6MwcTJaL18EAaJiymYBpsd0HMpLEmZ9KdYsb
+        Rv/gl4QzODYt0lOB7XIoSS720DAtKuW4dWwSLSsrVXmyujsQQJVe8FLe81dBATFgkaInK+YWAyJW
+        cOaTKX51w1y4JhsymxaJkCucx+vIexiA7aai7HI7sCCdkrQi4mlBScHlioczRO8LY+dAAkrF9vBH
+        sxL5iyJCL7cJ6cnAdsY9FKQHBBH1GfsfjUMAAwarLMUmGJNYDcPfNt4SJAYeK82RxIMJ2YE2bPiV
+        nMoKXgST5WCAZkqFs7yDASqNqcVRvn/8qTqmYV2wlXUR+0x6TIgdL8bTsAdujFyUQgSz+BbYsO4S
+        iDUvkyyciI7XMP/JeQ1fBNsCsYCMcxUHY+JCZw7YMJNxfzXaKKTWJIF4OwK0mAfdAvG2AqwO6DdO
+        fQJu8bitLVwomP4djzXtCeS8XNR8EU7CFkiXFUqVBb9/tkI7PmZ7IvBUmmoZ12ETc8+kHfiiCPkn
+        3BH0yF6Aq7qeLuleYKRBJefMVBTyuZrneHqL2wmxwCIoDvbF0PfnS7eXbYN4DevvF3+ZtZJCnUZ7
+        m3X6D+W1b6tgrtXxWPNLxW1GGRZiK65FqM20ONbEeOo+XFxcNJng7llSCB0wi3gasFwnGcrrUPo3
+        HQ+VY8Gte/7MSf0Uz6Fc8TTYWWyBgHsXCLUHTxv6UYV6PZjiDjakFzJH10KV4e6InjiUUyor5zI5
+        5q14fJjvQJsvRpaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/E3OBkAl2Slp4XsN8VyAVVa42
+        QTPkAEmJRAs0qNKIWzxKp+Pp+Hx8eT6e/jV5P5tOZuPLH5hTV+iBPTpn8o7mVLXJHp/ykaYg/bex
+        gk/oSj3dCNp/Y1LHCRBjsh7ya4+YHeglPYJIcjj9XtSepstq/25/GQbbyVQhKtRp3ePcyHt8Hu/U
+        WImqS5wOBtfc4rGBmqUf6uqyDpBxE/lMMppZXaPnSCOVVncisWY41meywcS1XMqdhVRDbrsF/pHf
+        Cy+k1qptNvrmQpuH0TZsO56pNDzORT+gKlG2Gg63IRNRmq0ZfAOAtjyYvmMC9yUVc17nNvJvJWqn
+        oieLBivcUegCZqCeF7Vb286KNwi5ardHyor+MxouVhRV5L3DqqWg/ixQyCpqHZl/aw7XcxdYt9j/
+        4oawFarGdn/Rgq7T3TUpAhytHq9xhOKwJXYN4mFb6K1PXMdvfeK3PvFbn9h32un6O9AnLoVdo2E6
+        yKbD522XrR9+Ai2n5d0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:21 GMT
+      etag:
+      - W/"62739e2c64a99576160fbe78c03fc95b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E06B:1430299:5ED66061
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3501'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUW6vaQBD+K7LPajabmwkUWrAtPsTQNgfRUmSSTMx6cpHs5hw94n/vLPZA+6Zg
+        X0J2JrPfZT5yZqoCFjFH+NwJ0CnCPHR4kYVhYIcYitx2/UJADhkHF0OfjVnbFbiVBQ3F87X/TYQ6
+        W9U83q/dZL44LtOdnezj03L/6W0pnt4283qfpPHr5uvCS9L8mKyevLiJj8v55jluvuzXq8XrOv1e
+        J+n6A10+9DVdXGl9UJFlwUFOd1JXQzbNu8bq8dApq0ENSnc9TmqZTTQqrSzz3G6bUwHUQ23RkEUT
+        jaTeHdIq3dTbfyn8BX8L8BX0HkwYdNX1LDqzFhok8T8qqKAffX7pu5YcwQak8YT2ROUpmvLHnSka
+        T+gD0mzGBBd8wv0JF6ntRsKObL5hlzG7MtL4HyF0j8Tg/CdKQYAz33FL18m4k5elHxZu4Ho5zzBA
+        LB2RIcXJ9x67bcNBWTdjkzENKgU7Y92ilVpCPTLpOUD+TNXR1TbieIAeW61Y9PNdoCg5hqEouAMw
+        s7njeV5p+yiEI2Y88ITvg3AzdB8r8D3Od6A/LM43Y15+jdkL9rKUOWhJ+aVUXM9IP4wSaoVj1iMo
+        02JDq+Supc6YmRfQQ0/raIe6Nraf6g5oyBwvl9+CEfCRqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:22 GMT
+      etag:
+      - W/"a1aea1139ec1d77a835a52013813fa0e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E096:14302CC:5ED66061
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3500'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=326037e3d9c930db99719e92c146d2acab0a4e96
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv28iOYzkKjNKYrTjQlnUXdUIh6OPEVipLxlIastL/PqkNtEt3
+        kXVj7ELioCOd9+E9R4+Rpi1Ek0hQRzvK72kNg7U1OjqJOuqaX2dsQ31iDPmYC0JFToAMhymLxzhL
+        cpwJARjyLCYxGTMc+1JWfvciBJ9Em175p41znZ0gRDs5qKVrNmzATYt66IxFLThqnenhVEl26sA6
+        i8K+XLa7gGnBIW60A+0Th9xnPaw+pUMcpzmkgnCSxoIRkieBkScjLIaUUxbTERDsyRrXquXPUG+A
+        jkFhyjB0rOI7Xo/g9Q4IPmyLL4UCj0W/0RxhtloZKg4gerrd92Zjod8b/tymY1z5E0PcrgsjuZIK
+        vD17ZX8AW1OXxWwzv01UufZxm2SLiy/xvLpSoihtef6c3y2qqwdRzdaL6lJeyykr5Hl9p8timoeo
+        LMKabefVjXmpctOIi88PrFKvL79la57O5cv9KbnTIaq+dj7ySKC5EVLXnon5ccQjf7ZUUt/baPIY
+        WVCr/2rG/VT8DZ4PDVf4X2/E/+3fenr6ATSXMr3gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:22 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E0B3:14302F3:5ED66062
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3499'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:22 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E0D0:143030F:5ED66062
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3498'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4S226apgaJ7SFdgQBZg2ICuLwIl0RZjSdRIyp4j5Lv3f6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJNPRbHp5dTWdfLj6cDYqVSoiGhvdXH9d3+a/58m3T/f8+5+rpFxu
+        /rhbvL+5+zq5vf778wiTeSEw0wpjo6jYpNxyIyx+mNd5HrW/FgKjVmlxnsv4nOYa9v8VlZYrbkGb
+        89yIs5Fal0KPZs0oVwtZQsgBDASRppeX44/T6dVkT/nN7fLT5sf0t5p/r7L0W76K7/6Z3lwnm5u7
+        xX9YyiGP66jWOeiZtZWZMeYHzbuLhbRZHddG6ESVVpT2IlEFq1kn7Mvq83tAFrrFOJNhYA9XyZbk
+        lwNn2OGdZLbI95TxOriVh9fMVZ6rNZj7uzhSLNsC6MwcTJaL18EAaJiymYBpsd0HMpLEmZ9KdYsb
+        Rv/gl4QzODYt0lOB7XIoSS720DAtKuW4dWwSLSsrVXmyujsQQJVe8FLe81dBATFgkaInK+YWAyJW
+        cOaTKX51w1y4JhsymxaJkCucx+vIexiA7aai7HI7sCCdkrQi4mlBScHlioczRO8LY+dAAkrF9vBH
+        sxL5iyJCL7cJ6cnAdsY9FKQHBBH1GfsfjUMAAwarLMUmGJNYDcPfNt4SJAYeK82RxIMJ2YE2bPiV
+        nMoKXgST5WCAZkqFs7yDASqNqcVRvn/8qTqmYV2wlXUR+0x6TIgdL8bTsAdujFyUQgSz+BbYsO4S
+        iDUvkyyciI7XMP/JeQ1fBNsCsYCMcxUHY+JCZw7YMJNxfzXaKKTWJIF4OwK0mAfdAvG2AqwO6DdO
+        fQJu8bitLVwomP4djzXtCeS8XNR8EU7CFkiXFUqVBb9/tkI7PmZ7IvBUmmoZ12ETc8+kHfiiCPkn
+        3BH0yF6Aq7qeLuleYKRBJefMVBTyuZrneHqL2wmxwCIoDvbF0PfnS7eXbYN4DevvF3+ZtZJCnUZ7
+        m3X6D+W1b6tgrtXxWPNLxW1GGRZiK65FqM20ONbEeOo+XFxcNJng7llSCB0wi3gasFwnGcrrUPo3
+        HQ+VY8Gte/7MSf0Uz6Fc8TTYWWyBgHsXCLUHTxv6UYV6PZjiDjakFzJH10KV4e6InjiUUyor5zI5
+        5q14fJjvQJsvRpaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/E3OBkAl2Slp4XsN8VyAVVa42
+        QTPkAEmJRAs0qNKIWzxKp+Pp+Hx8eT6e/jV5P5tOZuPLH5hTV+iBPTpn8o7mVLXJHp/ykaYg/bex
+        gk/oSj3dCNp/Y1LHCRBjsh7ya4+YHeglPYJIcjj9XtSepstq/25/GQbbyVQhKtRp3ePcyHt8Hu/U
+        WImqS5wOBtfc4rGBmqUf6uqyDpBxE/lMMppZXaPnSCOVVncisWY41meywcS1XMqdhVRDbrsF/pHf
+        Cy+k1qptNvrmQpuH0TZsO56pNDzORT+gKlG2Gg63IRNRmq0ZfAOAtjyYvmMC9yUVc17nNvJvJWqn
+        oieLBivcUegCZqCeF7Vb286KNwi5ardHyor+MxouVhRV5L3DqqWg/ixQyCpqHZl/aw7XcxdYt9j/
+        4oawFarGdn/Rgq7T3TUpAhytHq9xhOKwJXYN4mFb6K1PXMdvfeK3PvFbn9h32un6O9AnLoVdo2E6
+        yKbD522XrR9+Ai2n5d0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:23 GMT
+      etag:
+      - W/"62739e2c64a99576160fbe78c03fc95b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E0F1:143033A:5ED66062
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3497'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:21:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C92F:26688:112E14D:1430392:5ED66063
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3496'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_create_invalid_names[].yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_create_invalid_names[].yaml
@@ -1,0 +1,1693 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:15 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80F39A:C7FC151:5ED66187
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2830'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:16 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80F42F:C7FC1CA:5ED66187
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2829'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822820,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI4MjA=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:26:16Z","updated_at":"2020-06-02T14:26:16Z","pushed_at":"2020-06-02T14:26:17Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:17 GMT
+      etag:
+      - '"304d18cdbc65239a9e8af868afa6c71b"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80F4C2:C7FC285:5ED66188
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2828'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d","node_id":"MDY6Q29tbWl0MjY4ODIyODIwOmZlM2Y5MDcwZWJmNjBhMzk1MzhlYmU4NmQ5ZThiNzk5MjZjYjdlNWQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:17Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:17Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:18 GMT
+      etag:
+      - '"c430aa0d01550fe75ee78ae8972ed865"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80F781:C7FC5DB:5ED66189
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2827'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTW/aQBD9K5HPEBsDNiBFrar0kEpQRU2aQlWhtT3GS9a77u6aFBD/vTPG+YBD
+        GkfpLQcQ3vWbffPmY4etI1kOzsjJmbGgnZYTqzzn1hltHZMx3Eihmw690IMoDTzWHfa7A4hgECRD
+        GEThcOgHcRRCP0GoVAnMeYKg8fk0uPSHNroR3ng57X09v1jj5+5rPhNjf9ofn8d3s5sv+WT5KRtv
+        bjvjTSam+XVvkl/2Z1cZn2xu++PlbDldJmJyc3l2wIuVNlOaGNbcv2UsY/rk80oriW9CzrhAEsgf
+        l0+Blj8uaPEUncMXEmbJZd/zvbYXtD3/qtMb+cGoE86c3b0CpMZ/OyIHY9iCSFxIbjkTfAMnSIud
+        aCiU4VbpNRK1GvCd+0h0Um+YpH43DAd+L+z0+gNIfH/IwijqDeIQdwZJ2AUPgaUmATJrCzNyXVbw
+        0wW3WRmRAG51hJuDxZArDW3Bo7YFY41L3/N5viYmBqyLIJc4GPfFZ6N+b3j4PhmN2yAJCQLSzmNV
+        Skxjr+WsQPOUx8xyTA9Uc/8MmKcpEwZajgZmaMsppeELiTsth34wW2rUX5ZCtJyCrYViCKLH3du5
+        +QoXM5uL+aHKT8L7ksDuD32FrObo3FenVlO33TquBmPz2ACEWnAKnMmqKsc9aj9Bvx90D9vRZfD9
+        x0TEy2lncjXdkI0V5rg+9qZaNH5dLaUBHStpMZ2qwindyvKH1VkPLSx0baPqeP8qOrJl3Eeez8fw
+        8b1UCaHuEHtM9bCmD8y7DyBktf/N5aK5AQRtXWUzQJ2Q/o6c5tgnmliqAFvsJNhZeEImDEqsIWli
+        pIYgmTuJPLZVC6tslZGJNS+otBvROgCiIaUXTPJN1SMaGUIgpWTVU5u4VAEQCCvMrkbIPWLrFpqv
+        WLwmGTTEwFeoaXNrR1A0ZtcFXUzXGHFSmFuYsySnMqva5fEF+V6C9bX6XoLNKue9BPeXFjazg+p9
+        UQkWTFPfcEY/f2FBzgWXt/iAkyKI9C0mv0gzGWc4+D38L6AL64nlhgMHTZH3tpBwoZWF2D6ZweqV
+        ekQDySJxMKH9LjldGngT2NLMkVq8dxhkqnQM1cgnsP0RR5WmKGJ1c/+pNXo8E094vk+/fDw+Egk7
+        cuUV+bD7C94s5P5ZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:18 GMT
+      etag:
+      - W/"989e48f2d0c85c36de1061f520f9a708"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80F94A:C7FC7E5:5ED6618A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2826'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:19 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80F9C1:C7FC899:5ED6618A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2825'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPSQDzYUCqVFXpYSuRVdStIqiqyMAQzNoQ2WZXSZT/3nHTQ3vb
+        ldoDCM/jzZt5M74S03OSkw7CLvOZD3WX+DzM4jCFGtKkzSCtWZbRpKkZxC1ZknFq4SBaJBWbMtnR
+        zNZ76RdDGT1uHs74vD6qSha0jItN81rtv6jt8KkvLs9Bcellqb5FW7WLq6debC/PcTFUQzm0crvf
+        fcDks5aYuLf2ZHLP4yexPgrbz/W6mZSn4TQZT4Hlxk4aVlLUKwvGGs+9Dwd1bjliYD0kechQArF3
+        tNZbJQ9/l/CH/FuE76Lv0eSz7SdN8isZuQJs/mvPe64Xn1/0NKIjoLhwnuCcMLwGF/54dEHnCf6A
+        PTsa9am/8pOVT5+CKKdJHrCK3JbkXpGF/yhhNWAF19+rFHR+1nY0ZCylEQuiOIWW0oyzuo7ShiGS
+        tiwE/99O29VgvDdrozEKjOFHZ93DKKzgUlxg4RZo8WvPBK7YGWs8cQ2jNST//mNJXkCLTjTcCpwN
+        dnw/A16GjksDS6KBGweReTTiOCKyJO6D21mj1DhL6VKe5cSR5I6320/pH+7GhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:19 GMT
+      etag:
+      - W/"f101f4132db4d5c7c686db34159d6624"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FA87:C7FC989:5ED6618B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2824'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"0677b5c7fd1d0e1e8a3710e431fa1ed44661c455","node_id":"MDY6Q29tbWl0MjY4ODIyODIwOjA2NzdiNWM3ZmQxZDBlMWU4YTM3MTBlNDMxZmExZWQ0NDY2MWM0NTU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0677b5c7fd1d0e1e8a3710e431fa1ed44661c455","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/0677b5c7fd1d0e1e8a3710e431fa1ed44661c455","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:19Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:19Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fe3f9070ebf60a39538ebe86d9e8b79926cb7e5d"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:20 GMT
+      etag:
+      - '"e1322f97fedc97a581a19248cd76bae8"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0677b5c7fd1d0e1e8a3710e431fa1ed44661c455
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FAEE:C7FCA12:5ED6618B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2823'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBCG38Uz4KgpSZwZlbaSxURQWSI7vtRGcRzZB1WKeHcOdezSocP9y913
+        /3dlEXpWPzJxC8ok7lVCiGzBxmCgdYa2ciOLvW+8PH087zZvM83XbnwfjqO8qG1jj6/yog8v32bb
+        zASe40CQRZxSzbma3OrToT3rVRc8jzAFKgGkmhBhOTi9REiY+CPb1s9G0Q6QE0TXv72CPkGHrL6y
+        ZBUV9ZD3Iisz0H2RqVys8wo0VIURUOlSiKei0yWsDZnhPAER5OEd/q/pz8/E/2xzu90BDznDhn0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:20 GMT
+      etag:
+      - W/"9b3056a701b14e04d70db88c6ec5e0d9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FBC2:C7FCB12:5ED6618C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2822'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "0677b5c7fd1d0e1e8a3710e431fa1ed44661c455"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsU7DMBCG38UzrWPVSVDmqgUkqxNBdIns+IJdxXFkX4tC1XfnKkYWBob7l7vv
+        /u/KEgysuWfmDrTNPOiMkNgDm6KFzlvaqq2qXkMb1OldHrbPC83nYXoZj5O66H3rjk/qYt52X3bf
+        LgSe00iQQ5xzw7me/frDozubdR8DTzBHKgGkmphgNXqzQsiY+T27LixW0w6QE0TXv72iOUGPrLmy
+        7DQVFVVdm7KvBytsAQIe9aYWBciNGLQAK2VViV6WJZnhMgMR5BE8/q/pz8/M/2xzu30D1n+u0n0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:21 GMT
+      etag:
+      - W/"2341ba63cbe34f1c41f7eac5ae65049e"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FC30:C7FCB8B:5ED6618C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2821'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:21 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FDA4:C7FCD5B:5ED6618D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2820'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHDdKsgcW2wLaLFkgDFD1s9yJQEi0xlkSVpOw6Qv77vkNK
+        luw6iePwmMNmbZp8Zvgxw+HbTmQ6mc+ub25ms5vZ9GxSqVRE1Da5/fzr+q74o0i+fHjgX/9aJdVy
+        8+d9dnV7/zv+/fJxgs68FOhphbFRVG5SbrkRFj8smqKIul9LgVartDgvZHxOfQ37/4hayxW3oC14
+        YcTZRK0roSfzdlKoTFYwcgADQ+Tp9fX0J3h/uef85m75YfNt9lvDv9Z5+qVYxff/zG4/J5vb++w/
+        DOWwx3XU6AL03NrazBnzjebHi0zavIkbI3SiKisqe5GokjWsN/Zp9fEKkEx3GLdkaNjD1bIj+eHA
+        GXZ4Jrktiz1nvA9u5OExC1UUag3m/iyONMu2ANozB5NV9jYYAC1TNhdYWkz3kRZJYs9PpbrBLaP/
+        cC4JZ7BtWqSnArvhcJKO2GPLtKiV4zaxSbSsrVTVye7uQABVOuOVfOBvggJiwCJHT3bMDQZErHCY
+        T6b40S1z4ZpsaNm0SIRcYT/eRt7DAGw3NWWXu9EK0i5JKyKelpQUXK54PEP0vjJ2DiSgVGw3fzKv
+        kL8oIvRym5CeDWy3uIeC9IAhor6w/kfjEMCAYVWWYhOMSayW4W8XbwkSA4+V5kjiwYzsQFs2/kqH
+        ygpeBrPlYIDmSoVbeQcDVBrTiKPO/vG76piG9cFWNWXsM+kxIXa8GU/DHLgxMquECLbiW2DL+ksg
+        1rxK8nAmel7L/Cd3angWbArEAjIuVByMiQudOWDLTM791WijkF6TBeLtGNBiEXQKxNsasDrguXHu
+        E3CLx21tcYSC+d/zWNvtQMGrrOFZOAtbIF1WKFUy/vBihXZ8zA5E4Kk01TJuwibmgUkz8EUR8k+4
+        LRiQgwFXdT1f0r1ikUaVnFumspQv1TzH0zvcTogFNkFxsG+Gvr9cur1uGsRr2XC/+MussxRqN7rb
+        rPd/bK97WwU7Wj2PtT/U3OaUYWG25lqEmkyHY22Mp+7jxcVFmwvuniWl0AGziKcBy3WSo7wO5X/b
+        81A5lty658+C3E/xHCoUT4PtxRYIuD8CoebgaeNzVKNeD+a4g43ppSygWqgq3B0xEMd2KmXlQibH
+        vBWPD/MdaPvJyCoRZxzPG0SFlYlEnODJTicARb4It4qehulBI/LPxEIgZILtkhae1zKvCqSiLtQm
+        aIYcISmRaAGBKo24xaN0Np1Nz6fX59PZ35dX0M/ml9ff0KepoYE92Wc2pT51Y/Knu1xSF6T/Llbw
+        CarU80LQ/huTFCdAjMkHyM8DYn5AS3oCkRQ49HtRe5ovq/27/XUYTCdXpahRp/WPcyMf8BmK5ajG
+        SlRTYXfQuOYWjw3ULENTX5f1gJybyGeSydzqBpojtdRa3YvEmnHbkMlGHddyKXcGUg25VQv8I38w
+        XkqtVSc2enGhy8OQDTvFM5WGx4UYGlQtqs7D8TRkIiqzXQYvANCUR913lsB9ScWCN4WN/FuJ5FRo
+        shBYcRyFLrEMpHmR3NopK35B6Kj2c6Ss6D9DcLGirCN/OqxaCtJngUJWUevI/NtwHD13gfWD/S+u
+        CVOhamz3Fy3oOt0dkyLAIfV4jyMUhx2xF4jHstC7TtzE7zrxu078rhN7pZ2uvwM6cSXsGoLpKJuO
+        n7d9tn78DgWYtkEVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:21 GMT
+      etag:
+      - W/"ef98ba3eddfd4ed6a7e33a104ac6ac79"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FE09:C7FCDEA:5ED6618D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2819'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:21 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FE81:C7FCE7C:5ED6618D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2818'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHDdKsgcW2wLaLFkgDFD1s9yJQEi0xlkSVpOw6Qv77vkNK
+        luw6iePwmMNmbZp8Zvgxw+HbTmQ6mc+ub25ms5vZ9GxSqVRE1Da5/fzr+q74o0i+fHjgX/9aJdVy
+        8+d9dnV7/zv+/fJxgs68FOhphbFRVG5SbrkRFj8smqKIul9LgVartDgvZHxOfQ37/4hayxW3oC14
+        YcTZRK0roSfzdlKoTFYwcgADQ+Tp9fX0J3h/uef85m75YfNt9lvDv9Z5+qVYxff/zG4/J5vb++w/
+        DOWwx3XU6AL03NrazBnzjebHi0zavIkbI3SiKisqe5GokjWsN/Zp9fEKkEx3GLdkaNjD1bIj+eHA
+        GXZ4Jrktiz1nvA9u5OExC1UUag3m/iyONMu2ANozB5NV9jYYAC1TNhdYWkz3kRZJYs9PpbrBLaP/
+        cC4JZ7BtWqSnArvhcJKO2GPLtKiV4zaxSbSsrVTVye7uQABVOuOVfOBvggJiwCJHT3bMDQZErHCY
+        T6b40S1z4ZpsaNm0SIRcYT/eRt7DAGw3NWWXu9EK0i5JKyKelpQUXK54PEP0vjJ2DiSgVGw3fzKv
+        kL8oIvRym5CeDWy3uIeC9IAhor6w/kfjEMCAYVWWYhOMSayW4W8XbwkSA4+V5kjiwYzsQFs2/kqH
+        ygpeBrPlYIDmSoVbeQcDVBrTiKPO/vG76piG9cFWNWXsM+kxIXa8GU/DHLgxMquECLbiW2DL+ksg
+        1rxK8nAmel7L/Cd3angWbArEAjIuVByMiQudOWDLTM791WijkF6TBeLtGNBiEXQKxNsasDrguXHu
+        E3CLx21tcYSC+d/zWNvtQMGrrOFZOAtbIF1WKFUy/vBihXZ8zA5E4Kk01TJuwibmgUkz8EUR8k+4
+        LRiQgwFXdT1f0r1ikUaVnFumspQv1TzH0zvcTogFNkFxsG+Gvr9cur1uGsRr2XC/+MussxRqN7rb
+        rPd/bK97WwU7Wj2PtT/U3OaUYWG25lqEmkyHY22Mp+7jxcVFmwvuniWl0AGziKcBy3WSo7wO5X/b
+        81A5lty658+C3E/xHCoUT4PtxRYIuD8CoebgaeNzVKNeD+a4g43ppSygWqgq3B0xEMd2KmXlQibH
+        vBWPD/MdaPvJyCoRZxzPG0SFlYlEnODJTicARb4It4qehulBI/LPxEIgZILtkhae1zKvCqSiLtQm
+        aIYcISmRaAGBKo24xaN0Np1Nz6fX59PZ35dX0M/ml9ff0KepoYE92Wc2pT51Y/Knu1xSF6T/Llbw
+        CarU80LQ/huTFCdAjMkHyM8DYn5AS3oCkRQ49HtRe5ovq/27/XUYTCdXpahRp/WPcyMf8BmK5ajG
+        SlRTYXfQuOYWjw3ULENTX5f1gJybyGeSydzqBpojtdRa3YvEmnHbkMlGHddyKXcGUg25VQv8I38w
+        XkqtVSc2enGhy8OQDTvFM5WGx4UYGlQtqs7D8TRkIiqzXQYvANCUR913lsB9ScWCN4WN/FuJ5FRo
+        shBYcRyFLrEMpHmR3NopK35B6Kj2c6Ss6D9DcLGirCN/OqxaCtJngUJWUevI/NtwHD13gfWD/S+u
+        CVOhamz3Fy3oOt0dkyLAIfV4jyMUhx2xF4jHstC7TtzE7zrxu078rhN7pZ2uvwM6cSXsGoLpKJuO
+        n7d9tn78DgWYtkEVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:22 GMT
+      etag:
+      - W/"ef98ba3eddfd4ed6a7e33a104ac6ac79"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FEF7:C7FCEFE:5ED6618D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2817'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0677b5c7fd1d0e1e8a3710e431fa1ed44661c455
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJJYt24oNhXbJHvbgLKFZQlJKGNnjWFt/BEveJl3y3zsiXWhv
+        CaQHC2tGozfvzUPvzFTAUsZjKVWUy7LwC44+zkBIn2Mo/BJ8LMIwjv08jCI2Zm1X4E4XVJTNN/Ey
+        SKxa1zx73YTP86cTfT+fX78Ei1+FXqwzsW2Wx+38oc7WL+FmlYls9VAv5tlx2zwet+slX8w3QbbO
+        +GL18okuH/qaLq6sPZjU8+Cgp3ttq0FN867xejx0xmvQgrFdj5Naq4lFY43n1t2uORVAObQeFXlU
+        0WjK3UCtsk29+7eFv+CvAb6A3oIJg626nqXvrIUGifzXCiroR49vfdeSItiAdprQnCg8RRf+vHdB
+        pwkdIM6uLOABn/B4woOVH6ZBnPrJlp3H7NKRxf8IYXukDt7/WElKnMUiLEOhuMjLMk6KUIZRzhVK
+        xFIECnNQsbPSHaftejDe1dgkTIPGwN5J99Rqq6EeOfccIP9B0dFFNurxAD221rD02wfBEkWZcMlR
+        lTEHkURihoo4FwnOlEySIM6VxKi4L8EPO9+Afjc7X415/j5mb9jrUudgNfmXXHHZIz0YJdQGx6xH
+        MC7FhtbofUuZMXM/YIeextEOde1kP9UdUJHbns+/Ad29jvOoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:22 GMT
+      etag:
+      - W/"e1322f97fedc97a581a19248cd76bae8"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FF78:C7FCFA6:5ED6618E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2816'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=0677b5c7fd1d0e1e8a3710e431fa1ed44661c455
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hqbMsOjNGYrTiwjnUPc0IhSNbZVipLxlIastLvvnMbWJft
+        IevG2IPEoZPu/+N/p4fA8A6CWSC55z2v7ngDk42zJjgLeu7bX2dcyzGRAksrmXHJMsguLqYiTJOY
+        siSWEhJgcZiFWSqSEEs59RVFsuQs2A4an7be925GCO/VpFG+3YpJZTsyQG8d6cBz5+0A51qJcw/O
+        OzLu63W3HzEdeFJZ48Fg4pj77QD1mzBhTMQVqyWVIVBI+ZTREKIprTkFGUVJQqsojpGs9Z1e/wj1
+        AugUFKGtIKcq/sSLCKh3RPBqW7AUGXkc+Y3mSLsz2nJ5BDHw3aE3WwfDwfCnNp3iyp8Y4vf9OJK1
+        0oD2HJTxAHa2KfLFdvmF6mKDcUfj1dX7cFlea5kXrrh8yu9X5fW9LBebVflBfVRzkavL5tYU+ZyN
+        UZGPa7Fbljf2ucpNK6/e3YtSf3/5Od5U06V6vj/Pbs0YlZ96jBAJTGWlMg0yCRzHJMKztVbmzgWz
+        h8CBrv+rGcep+Bs8rxqu8X+9EP+3f+vx8RuM/XoE4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:22 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A80FFE2:C7FD029:5ED6618E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2815'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "Invalid tag name", "tag": "", "type": "commit",
+      "object": "0677b5c7fd1d0e1e8a3710e431fa1ed44661c455"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"message":"Could not verify tag name","documentation_url":"https://developer.github.com/v3/git/tags/#create-a-tag-object"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '123'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A810106:C7FD169:5ED6618E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2814'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:23 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A8101FD:C7FD23F:5ED6618F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2813'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHG6RZA4ttgW0XLZAGKHrY7kWgJFpiLIkqSdl1hPz3vkNK
+        luw6iePwmMNmbZp8Zvgxw+HbTmQ6mc+ub25ms5vZ9GxSqVRE1Da5/fLL+q74vUi+fnzg3/5cJdVy
+        88d9dnV7/xv+/fxpgs68FOhphbFRVG5SbrkRFj8smqKIul9LgVartDgvZHxOfQ37/4hayxW3oC14
+        YcTZRK0roSfzdlKoTFYwcgADQ+Tp9fX0R3h/uef85m75cfN99mvDv9V5+rVYxfd/z26/JJvb++xf
+        DOWwx3XU6AL03NrazBnzjebDRSZt3sSNETpRlRWVvUhUyRrWG/u8+nQFSKY7jFsyNOzhatmR/HDg
+        DDs8k9yWxZ4z3gc38vCYhSoKtQZzfxZHmmVbAO2Zg8kqexsMgJYpmwssLab7SIskseenUt3gltF/
+        OJeEM9g2LdJTgd1wOElH7LFlWtTKcZvYJFrWVqrqZHd3IIAqnfFKPvA3QQExYJGjJzvmBgMiVjjM
+        J1P86Ja5cE02tGxaJEKusB9vI+9hALabmrLL3WgFaZekFRFPS0oKLlc8niF6Xxk7BxJQKrabP5lX
+        yF8UEXq5TUjPBrZb3ENBesAQUV9Y/6NxCGDAsCpLsQnGJFbL8LeLtwSJgcdKcyTxYEZ2oC0bf6VD
+        ZQUvg9lyMEBzpcKtvIMBKo1pxFFn//hddUzD+mCrmjL2mfSYEDvejKdhDtwYmVVCBFvxLbBl/SUQ
+        a14leTgTPa9l/pM7NTwLNgViARkXKg7GxIXOHLBlJuf+arRRSK/JAvF2DGixCDoF4m0NWB3w3Dj3
+        CbjF47a2OELB/O95rO12oOBV1vAsnIUtkC4rlCoZf3ixQjs+Zgci8FSaahk3YRPzwKQZ+KII+Sfc
+        FgzIwYCrup4v6V6xSKNKzi1TWcqXap7j6R1uJ8QCm6A42DdD318u3V43DeK1bLhf/GXWWQq1G91t
+        1vs/tte9rYIdrZ7H2h9qbnPKsDBbcy1CTabDsTbGU/fx4uKizQV3z5JS6IBZxNOA5TrJUV6H8r/t
+        eagcS27d82dB7qd4DhWKp8H2YgsE3B+BUHPwtPE5qlGvB3Pcwcb0UhZQLVQV7o4YiGM7lbJyIZNj
+        3orHh/kOtP1sZJWIM47nDaLCykQiTvBkpxOAIl+EW0VPw/SgEflnYiEQMsF2SQvPa5lXBVJRF2oT
+        NEOOkJRItIBAlUbc4lE6m86m59Pr8+nsr8sr6Gfzy+vv6NPU0MCe7DP7QH3qxuRPd7mkLkj/Xazg
+        E1Sp54Wg/TcmKU6AGJMPkJ8GxPyAlvQEIilw6Pei9jRfVvt3++swmE6uSlGjTusf50Y+4DMUy1GN
+        laimwu6gcc0tHhuoWYamvi7rATk3kc8kk7nVDTRHaqm1uheJNeO2IZONOq7lUu4MpBpyqxb4R/5g
+        vJRaq05s9OJCl4chG3aKZyoNjwsxNKhaVJ2H42nIRFRmuwxeAKApj7rvLIH7kooFbwob+bcSyanQ
+        ZCGw4jgKXWIZSPMiubVTVvyC0FHt50hZ0X+G4GJFWUf+dFi1FKTPAoWsotaR+afhOHruAusH+19c
+        E6ZC1djuL1rQdbo7JkWAQ+rxHkcoDjtiLxCPZaF3nbiJ33Xid534XSf2Sjtdfwd04krYNQTTUTYd
+        P2/7bP34H/EJVa4VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:24 GMT
+      etag:
+      - W/"9344f67866c33882c6053aa2055c1332"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A8102A6:C7FD34B:5ED6618F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2812'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:26:24 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99E:33B7B:A810378:C7FD486:5ED66190
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2811'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_create_invalid_names[with space].yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_create_invalid_names[with space].yaml
@@ -1,0 +1,1693 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:54 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A4695D1:C3B375E:5ED66171
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2870'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:54 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A4696C7:C3B3852:5ED66172
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2869'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822735,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI3MzU=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:25:54Z","updated_at":"2020-06-02T14:25:54Z","pushed_at":"2020-06-02T14:25:55Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:56 GMT
+      etag:
+      - '"75e4ee19509913500aae211004c8be1f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46973F:C3B38E0:5ED66172
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2868'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"3895a74c21c96dea5e74be3d6769a82c2ea1604a","node_id":"MDY6Q29tbWl0MjY4ODIyNzM1OjM4OTVhNzRjMjFjOTZkZWE1ZTc0YmUzZDY3NjlhODJjMmVhMTYwNGE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3895a74c21c96dea5e74be3d6769a82c2ea1604a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/3895a74c21c96dea5e74be3d6769a82c2ea1604a","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:56Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:56Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:57 GMT
+      etag:
+      - '"6f1e302a76db3291c2642ad46b18bba1"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469AA4:C3B3CA1:5ED66174
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2867'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XXW/aMBT9K1WeaRNCSACp2h7aTZ0EaBttB9OEHOeGmDp2Zjt0gPrfdx3SD3jo
+        mqp76wtK7Jzjcz992TqC5OAMnJxoA8ppOVTmOTPOYOvojOBGp9fvkiigfpv2wwRIF6Ighk4SRmGf
+        9HzqA2mHXkAQKmQCc5YgaHg2Db/6fRNfc2+4nAbjs4v1aDNsj5fDYDy5ykabb8vh8tNyPJndzK7P
+        27MJ9ab55WZ2Nu2Mljwbn31ZDvOrbDiZ3o4+n5/u6SKlyaSyCmvt3zOSEXV0vlJS4JeQE8ZRBOrH
+        5ROwyx8XdvEEjcMPEmKsyb7ne8deeOz5k3Yw8LuDbjhz7u49YL3x347IQWuysCIuBDOMcLaBI5RF
+        jhQUUjMj1RqFGgX4zX0k2qnXT1K/E0U9P4jaQbcHie/3SRTHQY9GuNNLog54CCyVdUBmTKEHrksK
+        drJgJitj6wC3OsLNwWDIpYJjzuJjA9po1/7O5/naKtFgXAS5VoN2X3w2+u8ND98lo3YbJKGFgDBz
+        KkuBaey1nBUoljJKDMP0QG/u3gHzNCVcQ8tRQLTdckqh2ULgTsuxD8SUCv0vSs5bTkHWXBIE2de7
+        tzPzFSZmJufzfS8/Ce9LArs79BVu1Qfnvjq1mprt1nHVGJvHBsDlgtnA6ayqctyz7SfsdsPOfjv6
+        Gl79GHG6nLZHk+nGcqwwx9WhNdWi9utqKTUoKoXBdKoKp3Qr5g+r0wAZFqrmqDrev4rOcmn3Uefz
+        MXz8LpWcy1vEHkrdr+k9evcBhKp2z0wsmhMgaOtKkwH6CeXfWaMZ9okmTBVgi50EOwtLLIVGFytI
+        mpDUEBRzK1DHtmphFVcZa6pYYUu7kaw9IBJJtSCCbaoe0YgIgTYlq57axKQKgEBYYXY1Qu4QW7dQ
+        bEXo2rpBAQW2Qp82ZzuAIplZF/ZiusSIWw8zA3OS5LbMqnZ5eEG+l2B9rb6XYLPKeS/B3aWFzWyv
+        el9UggVRtm84g5+/sCDnnIkbfMFJEXj6FpNfrIigGQ5+D/8L7IX1hLnhwGGnyHsuFFwoaYCaJzNY
+        vVKPaCBIzPcmtN8ls5cG3gSm1HOURncGg0ilolCNfBzbn9Uo0xSdWN3cf2ofPZ6JJzzfp18+Hh84
+        CTtyZZW14e4vYWzl61kNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:57 GMT
+      etag:
+      - W/"f5ce7f0a0a41b4ec46779f5a7dba997c"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469C63:C3B3EED:5ED66175
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2866'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:57 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469CD7:C3B3F7E:5ED66175
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2865'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3895a74c21c96dea5e74be3d6769a82c2ea1604a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY/TMBD9K5XPaZM435GQOLSgRUorIOwqQaiaJNPGIR+V7Sxqq/53xpQD3HYl
+        uFjxvMy8N2/GV6ZaYCnz4iSAyK+5WydhgxBg5FfoNWEUJhDzmiO4oeMDs9g4NbgXDSVl6yL8yBNd
+        PfVO1hX+bv1w3l4yd9dl/i5/bLeXT13Wvet2efm9fNq4ZV47xfDlUq4Lb9v17W79ocuGxzbLix/b
+        95s3VHyWPRVutT6p1LbhJFZHodu5WtXTYEs8TcoeUIPSk8RlL6qlRqWVbc79fjg3QBhqm5JsyhgE
+        Ya9ordVDv/9bwh/0LyG+k76GE2bdTpKlVzbCgNT85xZakIvNs5xGcgQHEMYTmhOFV2jCb48maDyh
+        H6hnk8Yd7iydcOnw3PVTHqRBWLKbxe6KNP5HCi2RFFx/r5J7cJLmwL0oirkfuX4QY8N5AlFV+XEd
+        ERI3kYfOv5220aDsF3OTMQMqBUdj3cMotIBeXHBhFmjxa88ErdiZNJ5A4qgVS79+s9gzSnEQNWhB
+        s6GO73ekx3CAXqHFJIIyEJtHJY4jIRYzH6BnSVTj3Pem5LmfgJLM9Xb7CZfK1tGEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:57 GMT
+      etag:
+      - W/"5f8727a64f3642900fd088bf290d43ae"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469D9D:C3B4055:5ED66175
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2864'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["3895a74c21c96dea5e74be3d6769a82c2ea1604a"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"e03d240a183a0c0dadd0174ad483fad2711c54ab","node_id":"MDY6Q29tbWl0MjY4ODIyNzM1OmUwM2QyNDBhMTgzYTBjMGRhZGQwMTc0YWQ0ODNmYWQyNzExYzU0YWI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e03d240a183a0c0dadd0174ad483fad2711c54ab","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/e03d240a183a0c0dadd0174ad483fad2711c54ab","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:58Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:58Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"3895a74c21c96dea5e74be3d6769a82c2ea1604a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3895a74c21c96dea5e74be3d6769a82c2ea1604a","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/3895a74c21c96dea5e74be3d6769a82c2ea1604a"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:58 GMT
+      etag:
+      - '"2c711e36a21a1efe17ee17cb466e9c6a"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e03d240a183a0c0dadd0174ad483fad2711c54ab
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469E09:C3B40E0:5ED66175
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2863'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngpsQHJIZFajkMjVVWaJLfDRGcRzZB1JA/Pce6tilQ5e3vPvu
+        fTcR8CjKR0bZIZgoHUTCIJ7E4A3W1nCr11q9u8rp02e2X++mt6tO9sNrfxj0BTZVd9jqS/PxcjWb
+        amLwHHqGOqIxllLCaOdflrpzM2+9kwFHzyNIPOMDznrbzAgjRfnIunaTAe6QJEN8/dvLNydsSZQ3
+        ETvgocWqWEKetWnSFsogLDHPGlwYlasCVmmbIiTqOQM2o2lEJtjDWfpf05+fUf7Z5n7/BiDvy8x9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:58 GMT
+      etag:
+      - W/"ee28fe44d95b201c3d9e908e8243201b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469EE4:C3B41E8:5ED66176
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2862'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "e03d240a183a0c0dadd0174ad483fad2711c54ab"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngmOSFpQZQVvJZWqqskSX3FEbxUlkH0gB8d97qGOXDl3e8u67
+        911VpIMq75m0I8CkAySmqB5UPyDVHqW1a/v0Hqpgj5/Fbv0yvV2s2fWv3b63Z9hWbv9sz83H5oLb
+        ahLwFDuBHPOYSq1h9PMvz+7UzNsh6EjjICPEMjNEmnW+mTElTvqedR0mBOmItUBy/dtraI7Usiqv
+        KjmQIcpyXBQZmFUOWZshIGZmWQAWq/wAuFga0z4W0IgZTyMJIR7B8/+a/vxM+s82t9s39LPp7n0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:59 GMT
+      etag:
+      - W/"1be2a1e6b8dccd050733b747075bab3d"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A469F61:C3B4282:5ED66176
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2861'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A0CB:C3B4441:5ED66177
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2860'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2Y32/bNhDH/xe/LglT50cbA0X30K3YgCzAsAFdXwRKoiXGkqiRlD1HyP/e75GS
+        JXtu4jh8zEti0+Tnjse74/HaiUwns+n1hw/T6fuLq5NJpVIR0djk9vMvq7vi9yL5cvPAv/65TKrF
+        +o/77PL2/reL24e/P04wmZcCM60wNorKdcotN8Lih3lTFFH3aykwapUWp4WMT2muYf9fUWu55Ba0
+        OS+MOJmoVSX0ZNZOCpXJCkL2YCCINL2+Pn8/nX54t6P8+m5xs/42/bXhX+s8/VIs4/t/prefk/Xt
+        ffYflnLI4zpqdAF6bm1tZoz5QXNxlkmbN3FjhE5UZUVlzxJVsob1wj4tP14CkukO40yGgR1cLTuS
+        Xw6cYft3ktuy2FHG6+BW7l8zV0WhVmDu7uJAsWwDoDNzMFllr4MB0DJlcwHTYruPZCSJMz+W6ha3
+        jP7BLwlncGxapMcCu+VQklzssWVa1Mpxm9gkWtZWqupodbcggCqd8Uo+8FdBATFgkaJHK+YWAyKW
+        cOajKX51y1y4JmsymxaJkEucx+vIOxiA7bqm7HI3siCdkrQi4mlJScHliscTRO8LY2dPAkrF5vAn
+        swr5iyJCLzYJ6cnAdsbdF6R7BBH1GfsfjEMAAwarLMQ6GJNYLcPfLt4SJAYeK82RxIMJ2YK2bPyV
+        nMoKXgaT5WCA5kqFs7yDASqNacRBvn/4qTqmYX2wVU0Z+0x6SIgdLsbTsAdujMwqIYJZfANsWX8J
+        xJpXSR5ORM9rmf/kvIZnwbZALCDjQsXBmLjQmQO2zOTcX402Cqk1SSDelgAt5kG3QLyNAKsD+o1T
+        n4AbPG5rCxcKpn/PY213AgWvsoZn4SRsgHRZoVTJ+MOzFdrhMTsQgafSVMu4CZuYBybtwBdFyD/h
+        jmBADgJc1fV0SfcCI40qOWemspTP1TyH0zvcVogFFkFxsCuGvj9fur1sG8Rr2XC/+MuskxTqNLrb
+        rNd/LK97WwVzrZ7H2p9qbnPKsBBbcy1CbabDsTbGU/fx7OyszQV3z5JS6IBZxNOA5TrJUV6H0r/t
+        eagcS27d82dO6qd4DhWKp8HOYgME3LtAqD142tiPatTrwRR3sDG9lAW6FqoKd0cMxLGcSlk5l8kh
+        b8XDw3wL2n4yskrECcfzBlFhZSIRJ3iykwegyBfhrOhp2B56RP6ZWAiETLBT0sLzWua7AqmoC7UO
+        miFHSEokWqBBlUbc4lE6PZ+en55fn55P/3p3OZteza4uv2FOU6MH9uM5NzSnbkz+zBSk/y5W8Ald
+        qacbQbtvTOo4QY4x+QD5eUDM9vSSfoBICjj9TtQep8ty925/GQbbyVUpatRp/ePcyAd8Pt+qsRLV
+        VDgdDK64xWMDNcsw1NdlPSDnJvKZZDKzukHPkUZqre5FYs14bMhko4kruZBbC6mG3HQL/CN/EF5K
+        rVXXbPTNhS4Po23YdTxTaXhciGFA1aLqNBxvQyaiMhsz+AYAbXk0fcsE7ksq5rwpbOTfStRORU8W
+        DVa4o9AlzEA9L2q3dp0VbxBy1X6PlBX9ZzRcrCjryHuHVQtB/VmgkFXUKjL/Nhyu5y6wfrH/xQ1h
+        K1SNbf+iBV2n22tSBDhaPV7jCMVhR+wbxOO20FufuInf+sRvfeK3PrHvtNP1t6dPXAm7QsN0lE3H
+        z9s+Wz9+Bz9cL1wVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:59 GMT
+      etag:
+      - W/"b11d909827f7b2ea5b2fc3b510a0f2cb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A147:C3B44E0:5ED66177
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2859'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:00 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A1D5:C3B4588:5ED66177
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2858'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2Y32/bNhDH/xe/LglT50cbA0X30K3YgCzAsAFdXwRKoiXGkqiRlD1HyP/e75GS
+        JXtu4jh8zEti0+Tnjse74/HaiUwns+n1hw/T6fuLq5NJpVIR0djk9vMvq7vi9yL5cvPAv/65TKrF
+        +o/77PL2/reL24e/P04wmZcCM60wNorKdcotN8Lih3lTFFH3aykwapUWp4WMT2muYf9fUWu55Ba0
+        OS+MOJmoVSX0ZNZOCpXJCkL2YCCINL2+Pn8/nX54t6P8+m5xs/42/bXhX+s8/VIs4/t/prefk/Xt
+        ffYflnLI4zpqdAF6bm1tZoz5QXNxlkmbN3FjhE5UZUVlzxJVsob1wj4tP14CkukO40yGgR1cLTuS
+        Xw6cYft3ktuy2FHG6+BW7l8zV0WhVmDu7uJAsWwDoDNzMFllr4MB0DJlcwHTYruPZCSJMz+W6ha3
+        jP7BLwlncGxapMcCu+VQklzssWVa1Mpxm9gkWtZWqupodbcggCqd8Uo+8FdBATFgkaJHK+YWAyKW
+        cOajKX51y1y4JmsymxaJkEucx+vIOxiA7bqm7HI3siCdkrQi4mlJScHliscTRO8LY2dPAkrF5vAn
+        swr5iyJCLzYJ6cnAdsbdF6R7BBH1GfsfjEMAAwarLMQ6GJNYLcPfLt4SJAYeK82RxIMJ2YK2bPyV
+        nMoKXgaT5WCA5kqFs7yDASqNacRBvn/4qTqmYX2wVU0Z+0x6SIgdLsbTsAdujMwqIYJZfANsWX8J
+        xJpXSR5ORM9rmf/kvIZnwbZALCDjQsXBmLjQmQO2zOTcX402Cqk1SSDelgAt5kG3QLyNAKsD+o1T
+        n4AbPG5rCxcKpn/PY213AgWvsoZn4SRsgHRZoVTJ+MOzFdrhMTsQgafSVMu4CZuYBybtwBdFyD/h
+        jmBADgJc1fV0SfcCI40qOWemspTP1TyH0zvcVogFFkFxsCuGvj9fur1sG8Rr2XC/+MuskxTqNLrb
+        rNd/LK97WwVzrZ7H2p9qbnPKsBBbcy1CbabDsTbGU/fx7OyszQV3z5JS6IBZxNOA5TrJUV6H0r/t
+        eagcS27d82dO6qd4DhWKp8HOYgME3LtAqD142tiPatTrwRR3sDG9lAW6FqoKd0cMxLGcSlk5l8kh
+        b8XDw3wL2n4yskrECcfzBlFhZSIRJ3iykwegyBfhrOhp2B56RP6ZWAiETLBT0sLzWua7AqmoC7UO
+        miFHSEokWqBBlUbc4lE6PZ+en55fn55P/3p3OZteza4uv2FOU6MH9uM5NzSnbkz+zBSk/y5W8Ald
+        qacbQbtvTOo4QY4x+QD5eUDM9vSSfoBICjj9TtQep8ty925/GQbbyVUpatRp/ePcyAd8Pt+qsRLV
+        VDgdDK64xWMDNcsw1NdlPSDnJvKZZDKzukHPkUZqre5FYs14bMhko4kruZBbC6mG3HQL/CN/EF5K
+        rVXXbPTNhS4Po23YdTxTaXhciGFA1aLqNBxvQyaiMhsz+AYAbXk0fcsE7ksq5rwpbOTfStRORU8W
+        DVa4o9AlzEA9L2q3dp0VbxBy1X6PlBX9ZzRcrCjryHuHVQtB/VmgkFXUKjL/Nhyu5y6wfrH/xQ1h
+        K1SNbf+iBV2n22tSBDhaPV7jCMVhR+wbxOO20FufuInf+sRvfeK3PrHvtNP1t6dPXAm7QsN0lE3H
+        z9s+Wz9+Bz9cL1wVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:00 GMT
+      etag:
+      - W/"b11d909827f7b2ea5b2fc3b510a0f2cb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A253:C3B461E:5ED66178
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2857'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e03d240a183a0c0dadd0174ad483fad2711c54ab
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJJZl+RJDoSxZljw4IW2WJVtKGMvjWFtfgqXsNhvy7zsiXWjf
+        EkhfZGlGR2fmzMFHZipgKUMeFEJy8JMAuOIFFAX3YwmFTIISChH7vgol5GzI2q7AjS4IlE3X0VJM
+        bP5U8+xlLRfT2WH+nvmL5vEtE8vDfHpXZavt+3p195I9fKueH5Zv2Urx9dOSL6bzhr50//73+v2R
+        YrMv9Pi+r+nhytqdST0Pdnq81bba52PVNV6Pu854DVowtutxVOt8ZNFY47l1s2kOBVAOrUcgjxCN
+        ptwVrVW2qTf/lvAX/SXEZ9JrOGFvq65n6ZG10CA1/72CCvrB/WvftaQINqCdJjQnCo/Rhb9uXdBp
+        QheoZwcTXPARj0ZcrHyZijANk2d2GrJzRRb/I4XtkSo4/rFSHGMSBbKUQc4DVZbRpJCxDBXPMUYs
+        A5GjgjwKbzttV4PxLuYmYRo0BrZOulmrrYZ64NyzA/WLooOzbFTjDnpsrWHpj88Gg2QSQiyV8NUk
+        KhBCjGWOQRHF0QQSoQSCH3EJt23w085XsN/Mzhdznn4O2Sv2utQKrCb/kivOZ6QfRgm1wSHrEYxL
+        sX1r9LalzJC5Ddh9T+No93XtZD/UHRDIHU+nD/Dul9KoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:01 GMT
+      etag:
+      - W/"2c711e36a21a1efe17ee17cb466e9c6a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A2DA:C3B46BC:5ED66178
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2856'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=e03d240a183a0c0dadd0174ad483fad2711c54ab
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5Ec/w+M0pitONCWdS/qhEKQrIutVJaMpTRkpd995zbQLt2L
+        rBtjLyQOnXTPj+dOj55mLXgTTzDHOlbdsxpGa2u0d+J1zDW/ztiGYSKFJK1ExkSSQTYeB5ymceQn
+        cSQExJBENKNZymOKpaz8jiJZfOJteoVPG+c6OyGEdXJUS9ds+KgyLemhM5a04Jh1podTJfmpA+ss
+        Gfblst0NmBYcqYx2oDFxyH3Ww+oT0ECMQ8r8NGC0ooIJQf0kZCJMgxUT48T3qyhkHMka16rlz1Bv
+        gI5B4cpwcqziO15EQL0Dgg/bgqXIwGPJbzRHmK1WhokDiJ5t973ZWOj3hj+36RhX/sQQt+uGkVxJ
+        BWjPXhkPYGvqIp9t5re+KtYYt360uPhC5+WVEnlhi/Pn/G5RXj2IcrZelJfyWk55Ls/rO13k02SI
+        inxYs+28vDEvVW4acfH5gZfq9eW3aF0Fc/lyf5rd6SEqv3YYIRLoygipa2TiOI5xiGdLJfW99SaP
+        ngW1+q9mHKfib/B8aLiG//VG/N/+raenH7lmyTTgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:01 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A3FE:C3B4829:5ED66179
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2855'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "Invalid tag name", "tag": "with space", "type":
+      "commit", "object": "e03d240a183a0c0dadd0174ad483fad2711c54ab"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"message":"Could not verify tag name","documentation_url":"https://developer.github.com/v3/git/tags/#create-a-tag-object"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '123'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A542:C3B49A6:5ED66179
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2854'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:02 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A619:C3B4AAC:5ED66179
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2853'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTUJH+diNgcX2sO2iBdIARQts9yJQEi0xlkSVpOw6Qv77viNK
+        luw6iePwmEti0+Qzw+HMcDjNRCaTWXD98WMQfLi4OpmUKhEhjU1uv/yyust/z+OvNw/825/LuFys
+        /7hPL2/vf7u4ffj70wSTeSEw0wpjw7BYJ9xyIyx+mNd5Hna/FgKjVmlxmsvolOYa9v8VlZZLbkGb
+        89yIk4lalUJPZs0kV6ksIWQPBoJI0+vr6Ycg+Hi+o/z6bnGz/h78WvNvVZZ8zZfR/T/B7Zd4fXuf
+        /oelHPK4Dmudg55ZW5kZY27QXJyl0mZ1VBuhY1VaUdqzWBWsZr2wz8tPl4CkusO0JsPADq6SHckt
+        B86w/TvJbJHvKON0aFfuXzNXea5WYO7u4kCxbAOgM2thskzfBgOgYcpmAqbFdh/JSBJnfiy1Xdww
+        +ge/JJzBsWmRHAvslkNJcrHHhmlRqZZbRybWsrJSlUeruwUBVOmUl/KBvwkKiAGLFD1asXYxIGIJ
+        Zz6a4lY3rA3XeE1m0yIWconzeBt5BwOwXVeUXe5GFqRTklaEPCkoKbS54vEE0fvK2NmTgBKxOfzJ
+        rET+oojQi01CejawW+PuC9I9goj6gv0PxiGAAYNVFmLtjUmshuFvF28xEgOPlOZI4t6EbEEbNv5K
+        TmUFL7zJamGAZkr5s3wLA1QaU4uDfP/wU22ZhvXBVtZF5DLpISF2uBhHwx64MTIthfBm8Q2wYf0l
+        EGlexpk/ET2vYe5T6zU89bYFYgEZ5SryxsSFzlpgw0zG3dVoQ59akwTibQnQYu51C8TbCLDao9+0
+        6hNwg8dtbeFC3vTveazpTiDnZVrz1J+EDZAuK5QqKX94sUI7PGYHIvBUmmoZ1X4T88CkHbiiCPnH
+        3xEMyEFAW3U9X9K9wkijSq41U1HIl2qew+kdbivEPIugONgVQ99fLt1etw3iNWy4X9xl1knydRrd
+        bdbrP5bXva28uVbPY81PFbcZZViIrbgWvjbT4VgT4an7eHZ21mSCt8+SQmiPWcTRgOU6zlBe+9K/
+        6XmoHAtu2+fPnNRP8BzKFU+8ncUGCLhzAV97cLSxH1Wo170p3sLG9ELm6Fqo0t8dMRDHckpl5VzG
+        h7wVDw/zLWjz2cgyFicczxtEhZWxRJzgyU4egCJf+LOio2F76BG5Z2IuEDLeTkkLx2uY6wokosrV
+        2muGHCEpkWiBBlUScotHaTANpqfT69Np8Nf55Sy4ml1dfsecukIP7Ik517PpOc2papM9MQWYG5qC
+        9N/FCj6hK/V8I2j3jUkdJ0CMyQbIzwNitqeX9AQizuH0O1F7nC7L3bv9dRhsJ1OFqFCn9Y9zIx/w
+        ebpVY8WqLnE6GFxxi8cGapZhqK/LekDGTegyyWRmdY2eI41UWt2L2Jrx2JDJRhNXciG3FlINuekW
+        uEf+ILyQWquu2eiaC10eRtuw63gm0vAoF8OAqkTZaTjehoxFaTZmcA0A2vJo+pYJ2i+JmPM6t6F7
+        K1E7FT1ZNFjhjkIXMAP1vKjd2nVWnEHIVfs9UlZ0n9FwsaKoQucdVi0E9WeBQlZRq9D8W3O4XnuB
+        9YvdL+0QtkLV2PYvWtB1ur0mQYCj1eM0DlEcdsS+QTxuC733ievovU/83id+7xO7Tjtdf3v6xKWw
+        KzRMR9l0/Lzts/XjDxt4EhIVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:02 GMT
+      etag:
+      - W/"4dbeeda2738d71dabc97943971dced63"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A727:C3B4B80:5ED6617A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2852'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:26:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99A:16100:A46A878:C3B4D54:5ED6617A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2851'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_create_invalid_names[with\n].yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_create_invalid_names[with\n].yaml
@@ -1,0 +1,1693 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:03 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191760:149821B:5ED6617B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2850'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:04 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:119178D:149823F:5ED6617B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2849'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822771,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI3NzE=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:26:04Z","updated_at":"2020-06-02T14:26:04Z","pushed_at":"2020-06-02T14:26:05Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:05 GMT
+      etag:
+      - '"1136456337c7381e6cc84e8b2effdfc5"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:11917CF:1498270:5ED6617C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2848'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"156f40b033698f8b90ee6c2d1f50287fe95ab027","node_id":"MDY6Q29tbWl0MjY4ODIyNzcxOjE1NmY0MGIwMzM2OThmOGI5MGVlNmMyZDFmNTAyODdmZTk1YWIwMjc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/156f40b033698f8b90ee6c2d1f50287fe95ab027","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/156f40b033698f8b90ee6c2d1f50287fe95ab027","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:06Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:06Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:06 GMT
+      etag:
+      - '"f8f48f42b63a5bb18800cf3e5afdd05c"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191899:149836E:5ED6617D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2847'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XS2/aQBD+K5HPEBsD5iFFbaWkUQ6AqtKkpKrQ2h7jTda77u6aBFD+e2eM84BD
+        iqP0lkuEd/eb+eY92TiSZeAMnYwZC9ppOJHKMm6d4cYxKcOLVjdIOl7otdvBoJ/0w4EHEER+3Eq6
+        nt/vJTDostDzewiVKoY5jxE0Op0F3/yBDa+EN7qZdSanF6vxOrqf3Jy1xtnMG51f3I3WI38yTbPJ
+        +UV3dH4pxtlodX36NRtPv6wmp3F2Pb1tza7w3U10ssOLFTZVmhhW3L+nLGX66GyplcSXkDEukATy
+        x+NjoOPPCzo8RuPwQcwsmex7vtf0gqbnT1udoR8MveDaeXj0AHnjv6nIwBi2IBIXklvOBF/DEdJi
+        RxpyZbhVeoVErQZ88xSJxBvEid/u9fp+p9fqdPsQ+/6A9cKw0496eNOPe23wEFhockBqbW6Grsty
+        frzgNi1CcoBbqnAzsBhypaEpeNi0YKxx6e98nq2IiQHrIsglDsZtHaob/feOyrfJiOoPT0KCgLTz
+        SBUS09hrOEvQPOERsxzTA725/QbM04QJAw1HAzN05RTS8IXEm4ZDP5gtNPpfFkI0nJythGIIos+H
+        9zPzDSamNhPzXS+/CO8hgd0qfYNbzZ7eN6dWXbPdKq4GY/PcAIRacAqcScsqxztqP0G3G7R329G3
+        4PLnWEQ3s9Z4OluTjCXmuN63pjw0flUthQEdKWkxncrCKdxS8qflSQclLHQlo+x4/yo6kmXcZ56v
+        x/D5XaKEUHeI3ae6W9M74t0nELLa/uZyUV8Agjausimgn5D+AxnNsU/UkVQCNthJsLPwmEQYdLGG
+        uI6QCoJk7iTy2JQtrJRVhCbSPKfSrkVrB4iClF4wyddlj6glCIGUkmVPrWNSCUAgLDG7aiG3iI2b
+        a75k0YrcoCECvkSf1pe2B0VhdpXTYPqBEScPcwtzFmdUZmW73B+QHyVYjdWPEqxXOR8luB1a2Mx2
+        qvegEsyZpr7hDH/9xoKcCy5v8QM3RRDJe2x+oWYySnHxe/q/gAbWC8k1Fw7aIh9lIeFcKwuRfbGD
+        VSfVigaShWJnQ/tTcBoaOAlsYeZILdoaDDJROoJy5RPY/oijShJ0Yjm57ysfPetEDa/36cPX4z0n
+        YUcurSIbHv4CEwVA21kNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:06 GMT
+      etag:
+      - W/"6cea18402499cbba19682ec10398731e"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:119190D:14983E5:5ED6617E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2846'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:07 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:119192B:149840E:5ED6617E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2845'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/156f40b033698f8b90ee6c2d1f50287fe95ab027
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTXYvbMBD8K0HPSSwr/oZCC7mGPDimNNyRHCXI9jpWKtlBkq91Qv57Vw2F3tsd
+        tC9G2tXszM6ur8S0nGTED6MmoCVdLKI0aZIypQBRxWq/CSlL4gbSkJeUxWRKur6Gg6gRlC930ReW
+        2vJJ0vy0C4rletxcqp/F6cHfqB3NV+sf+SVnxbZVxWod5qtHuVH5uF9+Vpvtp7FY1mq//e7vnvDd
+        qfqAxQctsXBr7dlknsfPYn4Uth3KedUrT8O5N54Cy43tNcykKGcWjDWe+x4Oaqw55sB6CPIQoQTm
+        3tFaa5U8vJbwF/1biO+k7+Hkg217TbIr6bgCbP5ry1uuJw8vuu/QEVBcOE9wThiegwt/PLqg8wQf
+        YM8OxiijMxrNKNv6QcaijEZ7cpuSuyIL/5HCakAF1z+r1NC0btgijhMWxH4QJlAzlvK4LIOkijGT
+        1PEC6L+dttOAs34rNxqjwBh+dNatO2EFl+ICE7dAk997JnDFRtR45ho6a0j2/G1KXkCLRlTcCpwN
+        dny/A/4MDZcGpkQDNy5Fhs6IY4eZKXEHbgeNVN0gpSs5yp4jyF1vt1+p8+ILhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:07 GMT
+      etag:
+      - W/"81b0bbd660a854e845899ec772284b42"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:06 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191964:1498445:5ED6617F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2844'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["156f40b033698f8b90ee6c2d1f50287fe95ab027"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"d07264e16c88b6dab034bb71e973273128adac14","node_id":"MDY6Q29tbWl0MjY4ODIyNzcxOmQwNzI2NGUxNmM4OGI2ZGFiMDM0YmI3MWU5NzMyNzMxMjhhZGFjMTQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d07264e16c88b6dab034bb71e973273128adac14","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/d07264e16c88b6dab034bb71e973273128adac14","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:07Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:26:07Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"156f40b033698f8b90ee6c2d1f50287fe95ab027","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/156f40b033698f8b90ee6c2d1f50287fe95ab027","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/156f40b033698f8b90ee6c2d1f50287fe95ab027"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:08 GMT
+      etag:
+      - '"ff50e9160bdeaf922a30f958e35b6965"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d07264e16c88b6dab034bb71e973273128adac14
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:119197C:149846E:5ED6617F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2843'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngk0gIcmMSlspZWqqskR2fK6N4jiKD9SA+O891LELA8tb3n33
+        vgsbwbDylpFbkDpyLyPCyJ5YHzQ0TlNbbarsw9e+OnytdpvX6f3c/uz6t27fVye5re3+pTqpz+ez
+        3tYTgcexI8giDrHkXA5u/u3QHtW8DZ6PMAQaAaSZMMKsc2qGEDHyWzaNn7SkDpATRNf/vYI6QIus
+        vLBoJQ0t0syshBLLZVbkJleFAMjaRC9MKpJ8baBIpRLJmsxwGoAI8vAOH2v69zPyu22u118SAmRu
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:08 GMT
+      etag:
+      - W/"b88b96cd0804f0e8c3568c91b4523334"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:06 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:11919B5:14984AE:5ED66180
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2842'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "d07264e16c88b6dab034bb71e973273128adac14"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy27CMBBF/8XrgslDSZo1KgXJZdVUZRP5Ma2N4jiyB9SA+PcO6rKbLrq5mztn
+        7rmyCB+svWfiFqRJ3MuEENkDG4OB3hlqxVpUr77z4vhe7tfb+eWiv/bjbjiM4iw3nT08i7N6e7qY
+        TTcTeIoDQRZxSi3ncnLLT4f2pJY6eB5hCjQCSDMhwmJwaoGQMPF79r2fjaQOkBNE17+9gjqCRtZe
+        WbKShsyqzqsSsko3jaqMVKuiVKrO4LEu8rrI8kYaqbOSzHCegAjy8A7/1/TnZ+J/trndvgHHxoJt
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:09 GMT
+      etag:
+      - W/"99f99dd59a82697718ae0dd0d2de90b8"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:11919CC:14984CB:5ED66180
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2841'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:09 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191A2B:1498534:5ED66181
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2840'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/bOBCG/4uvm4SuGySpgaJ7aLfYBdIAiz10exEoiZYYS6KWpOx1hPz3fYeU
+        LNnrJo7DYy6JTZPPDD9mOHzbiUwn89nVzc1sdn397mxSqVRE1Da5/fxlfVf8USRfPzzw73+ukmq5
+        +XafXd7e//7+28OXjxN05qVATyuMjaJyk3LLjbD4YdEURdT9Wgq0WqXFeSHjc+pr2P9H1FquuAVt
+        wQsjziZqXQk9mbeTQmWygpEDGBgiT6+uptez2c2+85u75YfNj9lvDf9e5+nXYhXf/z27/Zxsbu+z
+        fzGUwx7XUaML0HNrazNnzDea9xeZtHkTN0boRFVWVPYiUSVrWG/s0+rjJSCZ7jBuydCwh6tlR/LD
+        gTPs8ExyWxZ7zngf3MjDYxaqKNQazP1ZHGmWbQG0Zw4mq+x1MABapmwusLSY7iMtksSen0p1g1tG
+        /3AuCWewbVqkpwK74XCSjthjy7SoleM2sUm0rK1U1cnu7kAAVTrjlXzgr4ICYsAiR092zA0GRKxw
+        mE+m+NEtc+GabGjZtEiEXGE/XkfewwBsNzVll7vRCtIuSSsinpaUFFyueDxD9L4wdg4koFRsN38y
+        r5C/KCL0cpuQngxst7iHgvSAIaI+s/5H4xDAgGFVlmITjEmsluFvF28JEgOPleZI4sGM7EBbNv5K
+        h8oKXgaz5WCA5kqFW3kHA1Qa04ijzv7xu+qYhvXBVjVl7DPpMSF2vBlPwxy4MTKrhAi24ltgy/pL
+        INa8SvJwJnpey/wnd2p4FmwKxAIyLlQcjIkLnTlgy0zO/dVoo5BekwXi7RjQYhF0CsTbGrA64Llx
+        7hNwi8dtbXGEgvnf81jb7UDBq6zhWTgLWyBdVihVMv7wbIV2fMwOROCpNNUybsIm5oFJM/BFEfJP
+        uC0YkIMBV3U9XdK9YJFGlZxbprKUz9U8x9M73E6IBTZBcbBvhr4/X7q9bBrEa9lwv/jLrLMUaje6
+        26z3f2yve1sFO1o9j7W/1NzmlGFhtuZahJpMh2NtjKfu48XFRZsL7p4lpdABs4inAct1kqO8DuV/
+        2/NQOZbcuufPgtxP8RwqFE+D7cUWCLg/AqHm4Gnjc1SjXg/muION6aUsoFqoKtwdMRDHdipl5UIm
+        x7wVjw/zHWj7ycgqEWcczxtEhZWJRJzgyU4nAEW+CLeKnobpQSPyz8RCIGSC7ZIWntcyrwqkoi7U
+        JmiGHCEpkWgBgSqNuMWjdDadTc+nV+fT2V/vLqGfzaeXP9CnqaGB/bzPB+pTNyZ/pgvSfxcr+ARV
+        6mkhaP+NSYoT7BiTD5BfB8T8gJb0E0RS4NDvRe1pvqz27/aXYTCdXJWiRp3WP86NfMDn6U6Nlaim
+        wu6gcc0tHhuoWYamvi7rATk3kc8kk7nVDTRHaqm1uheJNeO2IZONOq7lUu4MpBpyqxb4R/5gvJRa
+        q05s9OJCl4chG3aKZyoNjwsxNKhaVJ2H42nIRFRmuwxeAKApj7rvLIH7kooFbwob+bcSyanQZCGw
+        4jgKXWIZSPMiubVTVvyC0FHt50hZ0X+G4GJFWUf+dFi1FKTPAoWsotaR+afhOHruAusH+19cE6ZC
+        1djuL1rQdbo7JkWAQ+rxHkcoDjtiLxCPZaE3nbiJ33TiN534TSf2Sjtdfwd04krYNQTTUTYdP2/7
+        bP34H+Uz+SgVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:10 GMT
+      etag:
+      - W/"2f328f93e1748ef55917a18db02b90d6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191A69:149857F:5ED66181
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2839'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:10 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191A8F:14985B8:5ED66182
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2838'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/bOBCG/4uvm4SuGySpgaJ7aLfYBdIAiz10exEoiZYYS6KWpOx1hPz3fYeU
+        LNnrJo7DYy6JTZPPDD9mOHzbiUwn89nVzc1sdn397mxSqVRE1Da5/fxlfVf8USRfPzzw73+ukmq5
+        +XafXd7e//7+28OXjxN05qVATyuMjaJyk3LLjbD4YdEURdT9Wgq0WqXFeSHjc+pr2P9H1FquuAVt
+        wQsjziZqXQk9mbeTQmWygpEDGBgiT6+uptez2c2+85u75YfNj9lvDf9e5+nXYhXf/z27/Zxsbu+z
+        fzGUwx7XUaML0HNrazNnzDea9xeZtHkTN0boRFVWVPYiUSVrWG/s0+rjJSCZ7jBuydCwh6tlR/LD
+        gTPs8ExyWxZ7zngf3MjDYxaqKNQazP1ZHGmWbQG0Zw4mq+x1MABapmwusLSY7iMtksSen0p1g1tG
+        /3AuCWewbVqkpwK74XCSjthjy7SoleM2sUm0rK1U1cnu7kAAVTrjlXzgr4ICYsAiR092zA0GRKxw
+        mE+m+NEtc+GabGjZtEiEXGE/XkfewwBsNzVll7vRCtIuSSsinpaUFFyueDxD9L4wdg4koFRsN38y
+        r5C/KCL0cpuQngxst7iHgvSAIaI+s/5H4xDAgGFVlmITjEmsluFvF28JEgOPleZI4sGM7EBbNv5K
+        h8oKXgaz5WCA5kqFW3kHA1Qa04ijzv7xu+qYhvXBVjVl7DPpMSF2vBlPwxy4MTKrhAi24ltgy/pL
+        INa8SvJwJnpey/wnd2p4FmwKxAIyLlQcjIkLnTlgy0zO/dVoo5BekwXi7RjQYhF0CsTbGrA64Llx
+        7hNwi8dtbXGEgvnf81jb7UDBq6zhWTgLWyBdVihVMv7wbIV2fMwOROCpNNUybsIm5oFJM/BFEfJP
+        uC0YkIMBV3U9XdK9YJFGlZxbprKUz9U8x9M73E6IBTZBcbBvhr4/X7q9bBrEa9lwv/jLrLMUaje6
+        26z3f2yve1sFO1o9j7W/1NzmlGFhtuZahJpMh2NtjKfu48XFRZsL7p4lpdABs4inAct1kqO8DuV/
+        2/NQOZbcuufPgtxP8RwqFE+D7cUWCLg/AqHm4Gnjc1SjXg/muION6aUsoFqoKtwdMRDHdipl5UIm
+        x7wVjw/zHWj7ycgqEWcczxtEhZWJRJzgyU4nAEW+CLeKnobpQSPyz8RCIGSC7ZIWntcyrwqkoi7U
+        JmiGHCEpkWgBgSqNuMWjdDadTc+nV+fT2V/vLqGfzaeXP9CnqaGB/bzPB+pTNyZ/pgvSfxcr+ARV
+        6mkhaP+NSYoT7BiTD5BfB8T8gJb0E0RS4NDvRe1pvqz27/aXYTCdXJWiRp3WP86NfMDn6U6Nlaim
+        wu6gcc0tHhuoWYamvi7rATk3kc8kk7nVDTRHaqm1uheJNeO2IZONOq7lUu4MpBpyqxb4R/5gvJRa
+        q05s9OJCl4chG3aKZyoNjwsxNKhaVJ2H42nIRFRmuwxeAKApj7rvLIH7kooFbwob+bcSyanQZCGw
+        4jgKXWIZSPMiubVTVvyC0FHt50hZ0X+G4GJFWUf+dFi1FKTPAoWsotaR+afhOHruAusH+19cE6ZC
+        1djuL1rQdbo7JkWAQ+rxHkcoDjtiLxCPZaE3nbiJ33TiN534TSf2Sjtdfwd04krYNQTTUTYdP2/7
+        bP34H+Uz+SgVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:10 GMT
+      etag:
+      - W/"2f328f93e1748ef55917a18db02b90d6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191AAE:14985DD:5ED66182
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2837'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d07264e16c88b6dab034bb71e973273128adac14
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTY/aMBD9K8hnII7jOB9SpR5oEYeAUHe1YqsK2cmEmOYDxc4WWPHfOxZdqb2B
+        RC9WPOPxm/fmOe/EVJKkpKARExx8kcexEoVUNOBKRT4kUcCiwGexLGTuczImbVfAVhdYlM02Ys0S
+        q15qmu03fDVbnJbn/Lhq1r+W5wVbzp+Pyybjq/mCvc6/6myW0U2zCLKX53B5zvBsdsz2VYW5ffa0
+        /oSXD32NF1fWHkzqefKgpzttq0FN867xejh0xmvASmO7Hia1VhMLxhrPrdttcyok5sB6WORhRaMx
+        dwe1yjb19t8W/oK/BfgKeg+mHGzV9SR9J61sAMl/q2Ql+9GXt75rURFopHaa4JwwPAUX/rxzQacJ
+        HkDOroxRRidUTCh78nnKREqjV3IZk2tHFv4jhO0BO3j/Y6UoglgEvOQBmigvS5EUPOJhThVEAGXA
+        FORSifCx03Y9GO9mbBSmAWPkzkm3aLXVsh459xxk/hOjo6ts2ONB9tBaQ9LvHwT9UJScIrlAJHEZ
+        q4QCiJwVfhlSFkclJCG+HxY9luCHne9Af5idb8a8/BiTN+h1qXNpNfoXXXHdA/4wSlkbGJMepHEp
+        MrRG71rMjIn7kHbocRztUNdO9lPdSSxy28vlN/WQVfCoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:11 GMT
+      etag:
+      - W/"ff50e9160bdeaf922a30f958e35b6965"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:07 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191AD6:1498613:5ED66182
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2836'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=d07264e16c88b6dab034bb71e973273128adac14
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TX2vbMBTFv4uf2/hfbNmBURqzFQfasu6hTigEybqxlcqSsZSGrPS776oNtEv3
+        kHVj7MHm4mvd8+Pco0dP0Q68iceppT2t72kDo7XRyjvxemrbX3dMS7GRAclqnlNOcsijKGZBliYh
+        SRPOIQWSBHmQZywNcJQR31EkT0+8zSDxaGttbya+T3sxaoRtN2xU684foNfG78BSY/UAp1KwUwvG
+        Gt+9l8tu5zANWL/WyoLCxiH32QCrTzwgUTqGMK0zBOCUBfGYMRJCTuKIxGGUUU7rcIxkre3k8meo
+        N0DHoDCpmX+s4jteREC9A4IP24KjfMdj/N9YDtdbJTXlBxAD3e53szEw7A1/XtMxrvyJIXbXu0iu
+        hAS0Z6+MH2Crm7KYbea3oSzXWHdhsrj4EsyrK8mL0pTnz/3dorp64NVsvaguxbWYskKcN3eqLKbE
+        VWXhntl2Xt3olyk3Lb/4/MAq+XryW7Ku47l4+X+a3ylXVV97rBAJVK25UA0yMYxj6oK0lELdG2/y
+        6BmQq/8q45iKv8HzoXC5+/VG/N/eraenHynVnuHgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:11 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:07 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191AED:1498631:5ED66183
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2835'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "Invalid tag name", "tag": "with\n", "type":
+      "commit", "object": "d07264e16c88b6dab034bb71e973273128adac14"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '120'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"message":"Could not verify tag name","documentation_url":"https://developer.github.com/v3/git/tags/#create-a-tag-object"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '123'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191B08:1498649:5ED66183
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2834'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:11 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191B21:149866C:5ED66183
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2833'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTULHGyRZA4vtYbeLFsgGKHrY7kWgJFpiIokqSdl1hPz3vkNK
+        luw6iePwmEti0+Qzw48ZDt92ItPJfHZ5fT2bXV2dn0wqlYqI2iY3X76ubos/iuTbxwf+489lUt2v
+        v99lFzd3v3/4/vD10wSdeSnQ0wpjo6hcp9xyIyx+WDRFEXW/lgKtVmlxWsj4lPoa9v8RtZZLbkFb
+        8MKIk4laVUJP5u2kUJmsYGQPBobI08vL6dVsdr3r/Pr2/uP65+y3hv+o8/RbsYzv/p7dfEnWN3fZ
+        vxjKYY/rqNEF6Lm1tZkz5hvNh7NM2ryJGyN0oiorKnuWqJI1rDf2efnpApBMdxi3ZGjYwdWyI/nh
+        wBm2fya5LYsdZ7wPbuT+MQtVFGoF5u4sDjTLNgDaMweTVfY2GAAtUzYXWFpM95EWSWLPj6W6wS2j
+        fziXhDPYNi3SY4HdcDhJR+yxZVrUynGb2CRa1laq6mh3tyCAKp3xSj7wN0EBMWCRo0c75gYDIpY4
+        zEdT/OiWuXBN1rRsWiRCLrEfbyPvYAC265qyy+1oBWmXpBURT0tKCi5XPJ4gel8ZO3sSUCo2mz+Z
+        V8hfFBH6fpOQng1st7j7gnSPIaK+sP4H4xDAgGFV7sU6GJNYLcPfLt4SJAYeK82RxIMZ2YK2bPyV
+        DpUVvAxmy8EAzZUKt/IOBqg0phEHnf3Dd9UxDeuDrWrK2GfSQ0LscDOehjlwY2RWCRFsxTfAlvWX
+        QKx5leThTPS8lvlP7tTwLNgUiAVkXKg4GBMXOnPAlpmc+6vRRiG9JgvE2zKgxSLoFIi3MWB1wHPj
+        3CfgBo/b2uIIBfO/57G224GCV1nDs3AWNkC6rFCqZPzhxQrt8JgdiMBTaapl3IRNzAOTZuCLIuSf
+        cFswIAcDrup6vqR7xSKNKjm3TGUpX6p5Dqd3uK0QC2yC4mDXDH1/uXR73TSI17LhfvGXWWcp1G50
+        t1nv/9he97YKdrR6Hmt/qbnNKcPCbM21CDWZDsfaGE/dx7OzszYX3D1LSqEDZhFPA5brJEd5Hcr/
+        tuehciy5dc+fBbmf4jlUKJ4G24sNEHB/BELNwdPG56hGvR7McQcb00tZQLVQVbg7YiCO7VTKyoVM
+        DnkrHh7mW9D2s5FVIk44njeICisTiTjBk51OAIp8EW4VPQ3Tg0bkn4mFQMgE2yUtPK9lXhVIRV2o
+        ddAMOUJSItECAlUacYtH6Ww6m55OL0+ns7/OL6CfzacXP9GnqaGBPdnn/Jz61I3Jn+wy/UhdkP67
+        WMEnqFLPC0G7b0xSnAAxJh8gvw6I+R4t6QlEUuDQ70Ttcb4sd+/212EwnVyVokad1j/OjXzA5+lW
+        jZWopsLuoHHFLR4bqFmGpr4u6wE5N5HPJJO51Q00R2qptboTiTXjtiGTjTqu5L3cGkg15EYt8I/8
+        wXgptVad2OjFhS4PQzbsFM9UGh4XYmhQtag6D8fTkImozGYZvABAUx5131oC9yUVC94UNvJvJZJT
+        oclCYMVxFLrEMpDmRXJrp6z4BaGj2s+RsqL/DMHFirKO/Omw6l6QPgsUsopaReafhuPouQusH+x/
+        cU2YClVj279oQdfp9pgUAQ6px3scoTjsiL1APJaF3nXiJn7Xid914ned2CvtdP3t0YkrYVcQTEfZ
+        dPy87bP143/18ltPFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:26:12 GMT
+      etag:
+      - W/"d4512f83f2c6c13bb88662f6d2079c5d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:26:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191B3A:149868B:5ED66183
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2832'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:26:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C99B:33B77:1191B5A:14986AC:5ED66184
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2831'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_delete.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_delete.yaml
@@ -1,0 +1,8194 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:53 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470550:6425DF5:5ED66135
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3012'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:53 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470590:6425E30:5ED66135
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3011'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822508,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI1MDg=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:24:54Z","updated_at":"2020-06-02T14:24:54Z","pushed_at":"2020-06-02T14:24:55Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:55 GMT
+      etag:
+      - '"8cdf44b0563346c42bbf8a5aad012712"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54705E0:6425E97:5ED66135
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3010'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"ba1ec5869f3ecf6f0c896250507714ed8a52aa0b","node_id":"MDY6Q29tbWl0MjY4ODIyNTA4OmJhMWVjNTg2OWYzZWNmNmYwYzg5NjI1MDUwNzcxNGVkOGE1MmFhMGI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ba1ec5869f3ecf6f0c896250507714ed8a52aa0b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/ba1ec5869f3ecf6f0c896250507714ed8a52aa0b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:55Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:55Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:56 GMT
+      etag:
+      - '"c94439faac1a6a52ac5b3e73cfe713cc"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54707C6:64260E9:5ED66137
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3009'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XXW/TMBT9K1OeuyXNmn5JCJAG05CaCTE2CkKV49wkHo4dbKejrfbfuTfN2NoH
+        WKbxtpcqsXOuzz33w7cbT7ESvKlXMuvAeD2P67IUzptuPFsw3EhYH3g0Hk6yY+DZMAv4eDIMoyAK
+        RqP+ANIxi0LGggShSqewECmCZifz4cdw4pIrGcyu54Pzk7NVfPF2cF5+KGZXl9fxRR6eX83XX6/i
+        Mi7nN/N1HsXXZ/3ZyeebeM1/xaeXP85P3/Vn5ftidnr2aocXq12hDTFsuX8qWMHMwbul0Qq/hJIJ
+        iSSQPy4fAS2/yWnxCJ3DD1LmyOUwCIPDYHgYhBf9wTQcTKPoq3d7pwCp8d+OKMFalhOJMyWcYFKs
+        4QBpsQMDlbbCabNCos4AfnMXiX4WTNIsPB6NxuEAtY/GkIbhhI2SZDDmI9wZp6NjCBBYGxKgcK6y
+        U99nlTjKhSvqhATwmyP8EhyGXBs4lCI5dGCd9el3sShXxMSC8xHkEwfrP/ps1O8ZD98mo/U7JCFB
+        QLkF17XCNA563hKMyARnTmB6oJrbd8A8zZi00PMMMEtbXq2syBXu9Dx6YK42qL+qpex5FVtJzRBE
+        r7fP5+YTXCxcKRe7Kj8I72MCuz30CbLavXOfnFpd3fbbuFqMzX0DkDoXFDhbNFWOe9R+hlE0PN5t
+        Rx+Hl19iya/n/fhiviYbS8xxs+9Ns2jDtlpqC4Zr5TCdmsKp/cby6+WrAVrITWuj6Xj/KjqyZf17
+        nn+P4f13mZZS3yB2n+puTe+Y9/+AkNX2Wai8uwEEbXztCkCdkP4tOS2wT3Sx1AA22Emws4iUTFiU
+        2EDaxUgLQTI3CnlsmhbW2KoTy42oqLQ70doBoiFtcqbEuukRnQwhkFKy6aldXGoACIQlZlcn5Bax
+        8SsjloyvSAYDHMQSNe1ubQ+KxtyqoovpM0acFBYOFiwtqcyadrl/Qb6UYHutvpRgt8p5KcHtpYXN
+        bKd6H1WCFTPUN7zpt+9YkAsp1A98wUkRZPYck19imOIFDn5//hfQhfXAcseBg6bIO1tIuDLaAXcP
+        ZrB2pR3RQLFE7kxoP2tBlwbeBK62C6TGtw6DyrTh0Ix8EtsfcdRZhiI2N/evVqP7M/GEv/fpx4/H
+        eyJhR268Ih9ufwNrhJeQWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:56 GMT
+      etag:
+      - W/"9162dae7d9374cb78261e7ba707ace3c"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470927:6426285:5ED66138
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3008'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54709A0:64262FA:5ED66138
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3007'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ba1ec5869f3ecf6f0c896250507714ed8a52aa0b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY6bMBD9lcjnJBgHAkGq1ErZRqkEUdXsRtmqigYYwCmGyDa7TVb5946bHtrb
+        rtReLDyPmfdm5vmFmQZYwnLwsQjj+aKaYVHNK17Ei7kIecijyA+wjCEUADxnY9b1JR5kSUnpcj//
+        LBY237U8Pe6DzXJ9zrYfgo361KS7h2O2rcVmt7887jKVqf3z/lKH2XHtp8v75+xS/MhWD983qzs/
+        VR+bdLV+R8UH3VLhxtqTSTwPTnJaS9sM+bTolafx1BtPoQVje42TVuYTi8Yaz52HgzqXQBhaj5I8
+        ylCSsDe01ljVHv6W8Af9a4hvpG/hhME2vWbJC+tAITX/pYEG9OjuSfcdTQQVSDcT2hOFp+jC72sX
+        dDOhH6hnlya44BM+n3Cx9YNEBEkYPrLrmN0UWfyPFFYjKXj5bSW/4ouyErMoikVA5gljLIVYQJTn
+        QVxEhMRlNEP+b7ftNBjv1dw0GIXGQO1Gt+6kldDKC46cgUa/fCbJYmfSeAKNnTUs+fptzJ5Qy0oW
+        YCXthjq+3ZEeQwWtwTHTCMZBbOiMrDtCxsx9gB00UXVD27qS57YHSnLX6/Un85MP4oQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      etag:
+      - W/"1af44756a28ecce20d4725cb75b0cb2d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470A13:642639E:5ED66139
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3006'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["ba1ec5869f3ecf6f0c896250507714ed8a52aa0b"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"5050cd25e2ba07db67553199cec363f91e18ea0f","node_id":"MDY6Q29tbWl0MjY4ODIyNTA4OjUwNTBjZDI1ZTJiYTA3ZGI2NzU1MzE5OWNlYzM2M2Y5MWUxOGVhMGY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5050cd25e2ba07db67553199cec363f91e18ea0f","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:57Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:57Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"ba1ec5869f3ecf6f0c896250507714ed8a52aa0b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ba1ec5869f3ecf6f0c896250507714ed8a52aa0b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/ba1ec5869f3ecf6f0c896250507714ed8a52aa0b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      etag:
+      - '"63a48ce3776d76a61a8f91d08945bca2"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470A5C:6426403:5ED66139
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3005'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBRF/4tnWqclSdNsSBUFJNMFgugS+eMFu4rjyH6tFKr+d17FyMLQ5S73
+        nXfPmUXoWH3NxC1Ik7iXCSGyOzYEA60z1IqNKN9948XhM99tnqfXt4d8N7z0+0Gc5Lax+ydxUh+P
+        32bbTAQeY0+QRRxTzbkc3fzLoT2quQ6eRxgDjQDSTIgw652aISRM/Jpt6ycjqQPkBNH1X6+gDqCR
+        1WeWrKQhJRegi6pcd/egu7LLdLUul0VWZKvVIgdTyWIpZabIDKcRiCAP7/C2pr8/E/+3zeXyA+Rb
+        P7Z9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:58 GMT
+      etag:
+      - W/"70a49d9c54265fbc58a2858ed9ea613b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470B07:64264AC:5ED66139
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3004'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "5050cd25e2ba07db67553199cec363f91e18ea0f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghNCQpOtEiptJZelDSpL5I+XOiiOI/uBlCL+ex/qyNKB5S73
+        nXfPmQVoWXXNyC1IE7mTESGwBzZ4A01nqBVrUXy62onD13K7fp3eP56W2+Gt3w/iJDe13b+Ik9o9
+        /5hNPRF4DD1BFnGMFedy7ObfHdqjmmvveIDR0wggzfgAs75TM4SIkV+zadxkJHWAnCC6vvXy6gAa
+        WXVm0UoaypM80WaRw0LJZGVUscrzLC1LDTorsrZMIX0EmbRkhtMIRJCH6/C+pn8/I/+3zeXyCwEK
+        HrF9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:58 GMT
+      etag:
+      - W/"430650ea05f1547eacb0fd135a9b7e9e"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470B4F:6426524:5ED6613A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3003'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470C3F:6426640:5ED6613A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3002'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZtOsgcX2kHbRAmmAooftXgRKoiXGkqiSlF1HyLv3H1Ky
+        ZNebOA6PuSQ2TX4zHM4Mh9NOZDqZz65vbmazD9Obs0mlUhHR2OTu9pf1ffF7kXz5+Mi//rlKquXm
+        j4fs6u7ht8u72+zTBJN5KTDTCmOjqNyk3HIjLH5YNEURdb+WAqNWaXFeyPic5hr2/xW1lituQVvw
+        woiziVpXQk/m7aRQmawg5AAGgkjT6+vpT7PZzeWe8pv75cfNt9mvDf9a5+mXYhU//D27u002dw/Z
+        v1jKIY/rqNEF6Lm1tZkz5gfNjxeZtHkTN0boRFVWVPYiUSVrWC/s8+rTFSCZ7jDOZBjYw9WyI/nl
+        wBl2eCe5LYs9ZbwObuXhNQtVFGoN5v4ujhTLtgA6MweTVfY2GAAtUzYXMC22+0RGkjjzU6luccvo
+        H/yScAbHpkV6KrBbDiXJxZ5apkWtHLeJTaJlbaWqTlZ3BwKo0hmv5CN/ExQQAxYperJibjEgYgVn
+        PpniV7fMhWuyIbNpkQi5wnm8jbyHAdhuasou9yML0ilJKyKelpQUXK54OkP0vjJ2DiSgVGwPfzKv
+        kL8oIvRym5CeDWxn3ENBekAQUV+w/9E4BDBgsMpSbIIxidUy/O3iLUFi4LHSHEk8mJAdaMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGHOX7x5+qYxrWB1vVlLHPpMeE2PFiPA174MbIrBIimMW3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4u0I0GIRdAvE2wqwOqDfOPUJ
+        uMXjtrZwoWD69zzWdidQ8CpreBZOwhZIlxVKlYw/vlihHR+zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdz5d0rzDSqJJzZipL+VLNczy9w+2EWGARFAf7Yuj7y6Xb67ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9oeY2pwwLsTXXItRmOhxrYzx1ny4uLtpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/FqR+iudQoXga7Cy2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlQuZHPNW
+        PD7Md6DtZyOrRJxxPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQm6AZ
+        coSkRKIFGlRpxC0epbPpbHo+vT6fzv66vJrPruYfrr5hTlOjB/b9OTc0p25M/sIUpP8uVvAJXann
+        G0H7b0zqOEGOMfkA+XlAzA/0kr6DSAo4/V7UnqbLav9ufx0G28lVKWrUaf3j3MhHfJ7u1FiJaiqc
+        DgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVYPIrFmPDZkstHEtVzKnYVUQ267Bf6RPwgvpdaq
+        azb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6IniwYr
+        3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxoO13MXWL/Y/+KGsBWq
+        xnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+i9T9zE733i9z7xe5/Yd9rp+jvQJ66EXaNhOsqm4+dt
+        n62f/gP5GEhHFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:59 GMT
+      etag:
+      - W/"de6a71f66203f6206dc6c844379f0c08"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470C86:6426693:5ED6613B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3001'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470CEB:6426704:5ED6613B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3000'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjZtOsgcX2kHbRAmmAooftXgRKoiXGkqiSlF1HyLv3H1Ky
+        ZNebOA6PuSQ2TX4zHM4Mh9NOZDqZz65vbmazD9Obs0mlUhHR2OTu9pf1ffF7kXz5+Mi//rlKquXm
+        j4fs6u7ht8u72+zTBJN5KTDTCmOjqNyk3HIjLH5YNEURdb+WAqNWaXFeyPic5hr2/xW1lituQVvw
+        woiziVpXQk/m7aRQmawg5AAGgkjT6+vpT7PZzeWe8pv75cfNt9mvDf9a5+mXYhU//D27u002dw/Z
+        v1jKIY/rqNEF6Lm1tZkz5gfNjxeZtHkTN0boRFVWVPYiUSVrWC/s8+rTFSCZ7jDOZBjYw9WyI/nl
+        wBl2eCe5LYs9ZbwObuXhNQtVFGoN5v4ujhTLtgA6MweTVfY2GAAtUzYXMC22+0RGkjjzU6luccvo
+        H/yScAbHpkV6KrBbDiXJxZ5apkWtHLeJTaJlbaWqTlZ3BwKo0hmv5CN/ExQQAxYperJibjEgYgVn
+        PpniV7fMhWuyIbNpkQi5wnm8jbyHAdhuasou9yML0ilJKyKelpQUXK54OkP0vjJ2DiSgVGwPfzKv
+        kL8oIvRym5CeDWxn3ENBekAQUV+w/9E4BDBgsMpSbIIxidUy/O3iLUFi4LHSHEk8mJAdaMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGHOX7x5+qYxrWB1vVlLHPpMeE2PFiPA174MbIrBIimMW3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4u0I0GIRdAvE2wqwOqDfOPUJ
+        uMXjtrZwoWD69zzWdidQ8CpreBZOwhZIlxVKlYw/vlihHR+zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdz5d0rzDSqJJzZipL+VLNczy9w+2EWGARFAf7Yuj7y6Xb67ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9oeY2pwwLsTXXItRmOhxrYzx1ny4uLtpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/FqR+iudQoXga7Cy2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlQuZHPNW
+        PD7Md6DtZyOrRJxxPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQm6AZ
+        coSkRKIFGlRpxC0epbPpbHo+vT6fzv66vJrPruYfrr5hTlOjB/b9OTc0p25M/sIUpP8uVvAJXann
+        G0H7b0zqOEGOMfkA+XlAzA/0kr6DSAo4/V7UnqbLav9ufx0G28lVKWrUaf3j3MhHfJ7u1FiJaiqc
+        DgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVYPIrFmPDZkstHEtVzKnYVUQ267Bf6RPwgvpdaq
+        azb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6IniwYr
+        3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxoO13MXWL/Y/+KGsBWq
+        xnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+i9T9zE733i9z7xe5/Yd9rp+jvQJ66EXaNhOsqm4+dt
+        n62f/gP5GEhHFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:00 GMT
+      etag:
+      - W/"de6a71f66203f6206dc6c844379f0c08"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470D78:642679F:5ED6613B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2999'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K7Kf1Ww22cQECr3iIRailGolliKTzcSszYtkN9eq+N9vF3vQfvPA
+        fgnZmcw+L/OQC1ElkJhwyqnIGUeWAQ3zLAg599woEii8wCsiF90JAi3IkDRtjjuZm6FkmgZfWKSz
+        TUWTQ+ovp/PTYvXkLw/rX4vVp8N2One3q88yXT1529mcLc5rNzk/8+VmUaXnhCUs5clm/Xs5+1Ym
+        s/SDubzvKnNxqfVRxY4DRzneS1322Vi0tdPhsVVOjRqUbjscVTIbaVRaOfa529WnHEwPtWOGHDNR
+        S9N7h7RS19XuXwp/wd8DfAN9Dyb0umw7El9IAzUa8V9LKKEbPL90bWMcwRqk9cTsyZTHaMsf97Zo
+        PTEfGM12jFFGRzQYUbZy/Zj5MQ+35DokN0Ya/yOE7tAwuPyJUhjiJPD8wvcy6omiCKLcD30uaIYh
+        YuGxDAVkAX/sti0H5dyNbYypUSnYW+vmjdQSqoFNzxHET1Md3GwzHI/QYaMVib+/CczARcEnQVR4
+        KIqgoGISBczGLAxdH/MJcAZAs8cKfIvzO9AfFue7Ma8/huQFO1lIAVqa/JpU3M5ofhgFVAqHpENQ
+        tkX6Rsl9YzpDYl9A951ZR9NXlbX9VLVghuzxen0Fme+XMqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:00 GMT
+      etag:
+      - W/"63a48ce3776d76a61a8f91d08945bca2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470DD3:6426824:5ED6613C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2998'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv20iOJ9sKjNGYrTiwjnUXc0Ih6OPYVipLxlIastL/XrkNrMt2
+        kXVj7ELioCOd9+E9R/eRYR1Es0gyz3omblkDk42zJjqLeubbX2dcy0IihywXkjKZUaDTacJxnpI4
+        S4mUkEJGMMU05ykOpZz6FkRoehZtBx2ett73boYQ69WkUb7d8omwHRqgtw514JnzdoBzrfi5B+cd
+        Gvf1utuPmA48EtZ4MCFxzP1ugPotwQQLOSUw5QxnkqcZIUlMqQCRpElNY4hzYLgOZK3v9PpHqBdA
+        p6BwbTk6VfEn3oAQ9I4IXm1LKIVGHod+oznS7oy2TB5BDGx36M3WwXAw/KlNp7jyJ4b4fT+OZK00
+        BHsOyuEAdrYpi8V2+TXW5SbEXUxWlx/wsrrSsihdefGU36+qqztZLTar6qP6pOa8UBfNjSmLeTZG
+        ZTGuxW5ZXdvnKtetvHx/xyv9/eUXshHJUj3fn9MbM0bV5z5EAQmMsFKZJjDxMI7pm3C21srcumh2
+        HznQ9X8142Eq/gbPq4Zr/F8vxP/t33p4eATnvLb14AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:00 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470E2B:642688E:5ED6613C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2997'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "5050cd25e2ba07db67553199cec363f91e18ea0f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyNTA4OjQyYjQwZDE3ZDE0MDUxYmY5ZDgzM2IzYmNhZjg5MDcwZTA5NzNjMzY=","sha":"42b40d17d14051bf9d833b3bcaf89070e0973c36","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/42b40d17d14051bf9d833b3bcaf89070e0973c36","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:01Z"},"object":{"sha":"5050cd25e2ba07db67553199cec363f91e18ea0f","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '692'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      etag:
+      - '"79c96ecad85cf67024ab95ba1757f59e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/42b40d17d14051bf9d833b3bcaf89070e0973c36
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5470EFC:6426983:5ED6613C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2996'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "42b40d17d14051bf9d833b3bcaf89070e0973c36", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyNTA4OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"42b40d17d14051bf9d833b3bcaf89070e0973c36","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/42b40d17d14051bf9d833b3bcaf89070e0973c36"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:02 GMT
+      etag:
+      - '"12ac4bbf89f9d5e8ca7183dc142ba9ac"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471012:6426A7C:5ED6613D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2995'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:02 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547119C:6426C69:5ED6613E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2994'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjJmnWwGJ7SLtogTRA0cN2LwIl0RJtSVRJyq4j5N37DylZ
+        suskjsNjLolNk98MhzPD4bQTkU5m4c3tbRheT2/PJpVMeURjk/u7X9YPxe9F8vXTI/v25yqplps/
+        FtnV/eK3y/u77PMEk1nJMdNwbaKo3KTMMM0Nfpg3RRF1v5Yco0Yqfl6I+Jzm6uD/K2olVsyANmeF
+        5mcTua64mszaSSEzUUHIAQwEkaY3N9OfwvD2ck/5zcPy0+Z7+GvDvtV5+rVYxYu/w/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP7xIhMmb+JGc5XIyvDKXCSyDJqgF/Zl9fkKkEx1GGsyDOzhatGR3HLg
+        dHB4J7kpiz1lnA525eE1c1kUcg3m/i6OFBtsAXRmFiaq7H0wANpAmpzDtNjuExlJ4MxPpdrFbUD/
+        4JeE0zg2xdNTgd1yKEku9tQGitfScptYJ0rURsjqZHV3IIBKlbFKPLJ3QQHRYJGiJytmFwPCV3Dm
+        kyludRvYcE02ZDbFEy5WOI/3kfcwAJtNTdnlYWRBOiVheMTSkpKCzRVPZ4jeN8bOgQSU8u3hT2YV
+        8hdFhFpuE9KLgW2NeyhIDwgi6iv2PxqHAAYMVlnyjTcmsdoAf7t4S5AYWCwVQxL3JmQH2gbjr+RU
+        hrPSmywLAzSX0p/lLQxQoXXDj/L940/VMnXQB1vVlLHLpMeE2PFiHA17YFqLrOLcm8W3wDboL4FY
+        sSrJ/YnoeW3gPlmvYZm3LRALyLiQsTcmLvTAAttA58xdjSbyqTVJIN6OAMXnXrdAvK0Aozz6jVWf
+        gFs8bmsDF/Kmf88L2u4EClZlDcv8SdgC6bJCqZKxx1crtONjdiACT6WpEnHjNzEPTNqBK4qQf/wd
+        wYAcBNiq6+WS7g1GGlVy1kxlKV6reY6nd7idEPMsguJgXwx9f710e9s2iNcGw/3iLrNOkq/T6G6z
+        Xv+xvO5t5c21el7Q/lAzk1OGhdiaKe5rMx0uaGM8dZ8uLi7anDP7LCm58phFHA1YppIc5bUv/due
+        h8qxZMY+f+akfornUCFZ6u0stkDAnQv42oOjjf2oRr3uTXELG9NLUaBrISt/d8RAHMuppBFzkRzz
+        Vjw+zHeg7RctqoSfMTxvEBVGJAJxgic7eQCKfO7Pio6G7aFH5J6JBUfIeDslxR2vDVxXIOV1ITde
+        M+QISYlEcTSo0ogZPErDaTg9n96cT8O/Lq9m4dXs+uo75jQ1emDPzLmeTS9pTt3o/PkpIU1B+u9i
+        BZ/QlXq5EbT/xqSOEyBa5wPk5wExO9BLegaRFHD6vag9TZfV/t3+Ngy2k8uS16jT+se5Fo/4PN2p
+        sRLZVDgdDK6ZwWMDNcsw1NdlPSBnOnKZZDIzqkHPkUZqJRc8MXo8NmSy0cS1WIqdhVRDbrsF7pE/
+        CC+FUrJrNrrmQpeH0TbsOp6p0Cwu+DAga151Go63IRJe6a0ZXAOAtjyavmMC+yXlc9YUJnJvJWqn
+        oieLBivckasSZqCeF7Vbu86KMwi5ar9HyoruMxouhpd15LzDyCWn/ixQyCpyHel/GgbXsxdYv9j9
+        YoewFarGdn9RnK7T3TUpAhytHqdxhOKwI/YN4nFb6KNP3MQffeKPPvFHn9h12un6O9AnrrhZo2E6
+        yqbj522frZ/+A4GD0i0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:03 GMT
+      etag:
+      - W/"b5b9f59c406d6e7206d9fd66d94a8130"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471224:6426D16:5ED6613E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2993'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghNCQpOtEiptJZelDSpL5I+XOiiOI/uBlCL+ex/qyNKB5S73
+        nXfPmQVoWXXNyC1IE7mTESGwBzZ4A01nqBVrUXy62onD13K7fp3eP56W2+Gt3w/iJDe13b+Ik9o9
+        /5hNPRF4DD1BFnGMFedy7ObfHdqjmmvveIDR0wggzfgAs75TM4SIkV+zadxkJHWAnCC6vvXy6gAa
+        WXVm0UoaypM80WaRw0LJZGVUscrzLC1LDTorsrZMIX0EmbRkhtMIRJCH6/C+pn8/I/+3zeXyCwEK
+        HrF9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:03 GMT
+      etag:
+      - W/"430650ea05f1547eacb0fd135a9b7e9e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54712A6:6426DB2:5ED6613F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2992'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K7Kf1Ww22cQECr3iIRailGolliKTzcSszYtkN9eq+N9vF3vQfvPA
+        fgnZmcw+L/OQC1ElkJhwyqnIGUeWAQ3zLAg599woEii8wCsiF90JAi3IkDRtjjuZm6FkmgZfWKSz
+        TUWTQ+ovp/PTYvXkLw/rX4vVp8N2One3q88yXT1529mcLc5rNzk/8+VmUaXnhCUs5clm/Xs5+1Ym
+        s/SDubzvKnNxqfVRxY4DRzneS1322Vi0tdPhsVVOjRqUbjscVTIbaVRaOfa529WnHEwPtWOGHDNR
+        S9N7h7RS19XuXwp/wd8DfAN9Dyb0umw7El9IAzUa8V9LKKEbPL90bWMcwRqk9cTsyZTHaMsf97Zo
+        PTEfGM12jFFGRzQYUbZy/Zj5MQ+35DokN0Ya/yOE7tAwuPyJUhjiJPD8wvcy6omiCKLcD30uaIYh
+        YuGxDAVkAX/sti0H5dyNbYypUSnYW+vmjdQSqoFNzxHET1Md3GwzHI/QYaMVib+/CczARcEnQVR4
+        KIqgoGISBczGLAxdH/MJcAZAs8cKfIvzO9AfFue7Ma8/huQFO1lIAVqa/JpU3M5ofhgFVAqHpENQ
+        tkX6Rsl9YzpDYl9A951ZR9NXlbX9VLVghuzxen0Fme+XMqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:03 GMT
+      etag:
+      - W/"63a48ce3776d76a61a8f91d08945bca2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471329:6426E4D:5ED6613F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2991'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv20iOJ9sKjNGYrTiwjnUXc0Ih6OPYVipLxlIastL/XrkNrMt2
+        kXVj7ELioCOd9+E9R/eRYR1Es0gyz3omblkDk42zJjqLeubbX2dcy0IihywXkjKZUaDTacJxnpI4
+        S4mUkEJGMMU05ykOpZz6FkRoehZtBx2ett73boYQ69WkUb7d8omwHRqgtw514JnzdoBzrfi5B+cd
+        Gvf1utuPmA48EtZ4MCFxzP1ugPotwQQLOSUw5QxnkqcZIUlMqQCRpElNY4hzYLgOZK3v9PpHqBdA
+        p6BwbTk6VfEn3oAQ9I4IXm1LKIVGHod+oznS7oy2TB5BDGx36M3WwXAw/KlNp7jyJ4b4fT+OZK00
+        BHsOyuEAdrYpi8V2+TXW5SbEXUxWlx/wsrrSsihdefGU36+qqztZLTar6qP6pOa8UBfNjSmLeTZG
+        ZTGuxW5ZXdvnKtetvHx/xyv9/eUXshHJUj3fn9MbM0bV5z5EAQmMsFKZJjDxMI7pm3C21srcumh2
+        HznQ9X8142Eq/gbPq4Zr/F8vxP/t33p4eATnvLb14AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:04 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547139F:6426EE7:5ED6613F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2990'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:04 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471493:6427010:5ED66140
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2989'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjJmnWwGJ7SLtogTRA0cN2LwIl0RJtSVRJyq4j5N37DylZ
+        suskjsNjLolNk98MhzPD4bQTkU5m4c3tbRheT2/PJpVMeURjk/u7X9YPxe9F8vXTI/v25yqplps/
+        FtnV/eK3y/u77PMEk1nJMdNwbaKo3KTMMM0Nfpg3RRF1v5Yco0Yqfl6I+Jzm6uD/K2olVsyANmeF
+        5mcTua64mszaSSEzUUHIAQwEkaY3N9OfwvD2ck/5zcPy0+Z7+GvDvtV5+rVYxYu/w/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP7xIhMmb+JGc5XIyvDKXCSyDJqgF/Zl9fkKkEx1GGsyDOzhatGR3HLg
+        dHB4J7kpiz1lnA525eE1c1kUcg3m/i6OFBtsAXRmFiaq7H0wANpAmpzDtNjuExlJ4MxPpdrFbUD/
+        4JeE0zg2xdNTgd1yKEku9tQGitfScptYJ0rURsjqZHV3IIBKlbFKPLJ3QQHRYJGiJytmFwPCV3Dm
+        kyludRvYcE02ZDbFEy5WOI/3kfcwAJtNTdnlYWRBOiVheMTSkpKCzRVPZ4jeN8bOgQSU8u3hT2YV
+        8hdFhFpuE9KLgW2NeyhIDwgi6iv2PxqHAAYMVlnyjTcmsdoAf7t4S5AYWCwVQxL3JmQH2gbjr+RU
+        hrPSmywLAzSX0p/lLQxQoXXDj/L940/VMnXQB1vVlLHLpMeE2PFiHA17YFqLrOLcm8W3wDboL4FY
+        sSrJ/YnoeW3gPlmvYZm3LRALyLiQsTcmLvTAAttA58xdjSbyqTVJIN6OAMXnXrdAvK0Aozz6jVWf
+        gFs8bmsDF/Kmf88L2u4EClZlDcv8SdgC6bJCqZKxx1crtONjdiACT6WpEnHjNzEPTNqBK4qQf/wd
+        wYAcBNiq6+WS7g1GGlVy1kxlKV6reY6nd7idEPMsguJgXwx9f710e9s2iNcGw/3iLrNOkq/T6G6z
+        Xv+xvO5t5c21el7Q/lAzk1OGhdiaKe5rMx0uaGM8dZ8uLi7anDP7LCm58phFHA1YppIc5bUv/due
+        h8qxZMY+f+akfornUCFZ6u0stkDAnQv42oOjjf2oRr3uTXELG9NLUaBrISt/d8RAHMuppBFzkRzz
+        Vjw+zHeg7RctqoSfMTxvEBVGJAJxgic7eQCKfO7Pio6G7aFH5J6JBUfIeDslxR2vDVxXIOV1ITde
+        M+QISYlEcTSo0ogZPErDaTg9n96cT8O/Lq9m4dXs+uo75jQ1emDPzLmeTS9pTt3o/PkpIU1B+u9i
+        BZ/QlXq5EbT/xqSOEyBa5wPk5wExO9BLegaRFHD6vag9TZfV/t3+Ngy2k8uS16jT+se5Fo/4PN2p
+        sRLZVDgdDK6ZwWMDNcsw1NdlPSBnOnKZZDIzqkHPkUZqJRc8MXo8NmSy0cS1WIqdhVRDbrsF7pE/
+        CC+FUrJrNrrmQpeH0TbsOp6p0Cwu+DAga151Go63IRJe6a0ZXAOAtjyavmMC+yXlc9YUJnJvJWqn
+        oieLBivckasSZqCeF7Vbu86KMwi5ar9HyoruMxouhpd15LzDyCWn/ixQyCpyHel/GgbXsxdYv9j9
+        YoewFarGdn9RnK7T3TUpAhytHqdxhOKwI/YN4nFb6KNP3MQffeKPPvFHn9h12un6O9AnrrhZo2E6
+        yqbj522frZ/+A4GD0i0VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:04 GMT
+      etag:
+      - W/"b5b9f59c406d6e7206d9fd66d94a8130"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471507:642709D:5ED66140
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2988'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aSBT+K5GfSXw3F6nqdpUqykoQVSXNkqpC4/ExnnR82ZkxKSD++55jTBN4
+        yOIo+5YXBGOfb77znSsbq2A5WCMrZ9qAsnoWL/NcGGu0sXTG8EHohA5PvBC8mDn9JI76Yei7wyEH
+        7kd+OnTBHQBzUjQtygTmIkGj8eUs+uINTXwnnfHDLLi5vF5Npp+Cm4fbx8n0z4f7y2v3fvqXmE0/
+        +fdX195kfeuO15/Dm7uJnK3H3tibheO72183V9+y8dXswwEvVpusVMSw5f41YxlTZ5+XqizwTciZ
+        kEgC+ePxBdDxHws6vEDn8IWEGXLZczzn3InOHW/qBiMvGIX9e2u7V4DU+N+uyEFrtiAS14Uwgskz
+        5MQqxn/i6Vkbgp5lFOA7+0j0+zCI/CAN/NjxeZpGwyToByF3YugDpL4XA2dxFKKHtSIBMmMqPbJt
+        VomLhTBZHZMAtoKq1HYOBkNeKjiXIj43oI226XM+z1dERoOx0cgmDto++W7U7w0v3ymh7Q5JSCZQ
+        mDkv6wLT2OlZS1AiFZwZgemBau5+A+ZpyqSGnqWAaXpk1YUWiwKf9Cz6wkytUP+ilrJnVWwlS4ZG
+        9HP7dm6+wsXM5HJ+qPKz8J4S2N2lr5BVH9376tTq6rbdxlVjbJ4agCwXggKns6bK8Rm1nygMI/+w
+        HX2Jvv09kfxh5k6mszVhLDHH1bE3zaH22mqpNSheFgbTqSmc2m6QPy4/BIiwUC1G0/H+q+gIS9tP
+        PF+O4dN7aSll+Yi2x1QPa/oA3v5thKx230Wx6A6ARhu7NBmgTkh/S04L7BNdkBqDDXYS7CwiIQiN
+        EitIuoC0JkjmsUAem6aFNVh1rLkSFZV2J1oHhghUqgUrxLrpEZ2A0JBSsumpXVxqDNAQlphdnSx3
+        Fhu7UmLJ+IpkUMBBLFHT7mhHpghmVhUNpluMOCksDMxZklOZNe3yeEC+l2A7Vt9LsFvlvJfgbmhh
+        Mzuo3pNKsGKK+oY1+r7fDmPmAg8H0TD1gadR6vDBMPJocer33QCSAQs9xpwY4d9oQduP8A43vzz1
+        OmwuJ9+5/YENay5F8RPFQq1Apm+xGceKFTzDxfj3/yZy7Rlyx4WMtuw9FhKuVGmAm2c7anvSrrBQ
+        sFgebLD/1IKGKk5KU+s5UuM7h6FIS8WhWYkljgfiWKb0b63ZbH41OfSD9tmnG16eY6f/fTgSCSdW
+        4xX5sP0XrDaTfXkOAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:04 GMT
+      etag:
+      - W/"980242a8dde0b62a5de1da5b38da9046"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471591:6427130:5ED66140
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2987'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547160D:64271C9:5ED66140
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2986'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K7Kf1Ww22cQECr3iIRailGolliKTzcSszYtkN9eq+N9vF3vQfvPA
+        fgnZmcw+L/OQC1ElkJhwyqnIGUeWAQ3zLAg599woEii8wCsiF90JAi3IkDRtjjuZm6FkmgZfWKSz
+        TUWTQ+ovp/PTYvXkLw/rX4vVp8N2One3q88yXT1529mcLc5rNzk/8+VmUaXnhCUs5clm/Xs5+1Ym
+        s/SDubzvKnNxqfVRxY4DRzneS1322Vi0tdPhsVVOjRqUbjscVTIbaVRaOfa529WnHEwPtWOGHDNR
+        S9N7h7RS19XuXwp/wd8DfAN9Dyb0umw7El9IAzUa8V9LKKEbPL90bWMcwRqk9cTsyZTHaMsf97Zo
+        PTEfGM12jFFGRzQYUbZy/Zj5MQ+35DokN0Ya/yOE7tAwuPyJUhjiJPD8wvcy6omiCKLcD30uaIYh
+        YuGxDAVkAX/sti0H5dyNbYypUSnYW+vmjdQSqoFNzxHET1Md3GwzHI/QYaMVib+/CczARcEnQVR4
+        KIqgoGISBczGLAxdH/MJcAZAs8cKfIvzO9AfFue7Ma8/huQFO1lIAVqa/JpU3M5ofhgFVAqHpENQ
+        tkX6Rsl9YzpDYl9A951ZR9NXlbX9VLVghuzxen0Fme+XMqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      etag:
+      - W/"63a48ce3776d76a61a8f91d08945bca2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54716C0:642729F:5ED66141
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2985'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["5050cd25e2ba07db67553199cec363f91e18ea0f"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"ddd6d8166ea5d979c682ff2d15517a4dc6202d33","node_id":"MDY6Q29tbWl0MjY4ODIyNTA4OmRkZDZkODE2NmVhNWQ5NzljNjgyZmYyZDE1NTE3YTRkYzYyMDJkMzM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ddd6d8166ea5d979c682ff2d15517a4dc6202d33","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/ddd6d8166ea5d979c682ff2d15517a4dc6202d33","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:05Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:05Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"5050cd25e2ba07db67553199cec363f91e18ea0f","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5050cd25e2ba07db67553199cec363f91e18ea0f"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:06 GMT
+      etag:
+      - '"a62baf251dd36123f12e6d621eee64d1"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471723:6427319:5ED66141
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2984'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghNCQpOtEiptJZelDSpL5I+XOiiOI/uBlCL+ex/qyNKB5S73
+        nXfPmQVoWXXNyC1IE7mTESGwBzZ4A01nqBVrUXy62onD13K7fp3eP56W2+Gt3w/iJDe13b+Ik9o9
+        /5hNPRF4DD1BFnGMFedy7ObfHdqjmmvveIDR0wggzfgAs75TM4SIkV+zadxkJHWAnCC6vvXy6gAa
+        WXVm0UoaypM80WaRw0LJZGVUscrzLC1LDTorsrZMIX0EmbRkhtMIRJCH6/C+pn8/I/+3zeXyCwEK
+        HrF9AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:06 GMT
+      etag:
+      - W/"430650ea05f1547eacb0fd135a9b7e9e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54717CD:64273E2:5ED66142
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2983'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "ddd6d8166ea5d979c682ff2d15517a4dc6202d33"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWpM0cdtsSBUFJNMFgugSObkLdhUnkX2tFKr+d65iZGHo8pZ3
+        373vLAK2orhmlBYNROlNJAziTvQDYOWAW73R6t2XXh8+s93meXp9e8h2/Uu37/XJbEu7f9Kn+uPx
+        G7blxOAxdAxZojEWUprRzb8c2WM9bwYvA44DjyDxzBBw1rl6RhgpymtWlZ/AcIckGeLrv15DfcCG
+        RHEW0RoeAgAFq0QpNDmsl+tGrdK2TSHJ82RpMmhUep/CYsFmNI3IBHt4R7c1/f0Z5b9tLpcfXKJ6
+        rX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:07 GMT
+      etag:
+      - W/"7f8d9b182d24b71ae21d83b5c16157fc"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547181D:6427443:5ED66142
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2982'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:07 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471946:642759E:5ED66143
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2981'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyikwHGZubk+0N60M/RmOn243otHthVbxLZcSU4aPHz3+69k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZz66ur2ezy+n1yaRSqYhobHJ78+v6a/FHkXz5eM+//bVKquXm
+        z7vs4vbu9/Pbm+zTBJN5KTDTCmOjqNyk3HIjLH5YNEURdb+WAqNWaXFayPiU5hr2/xW1lituQVvw
+        woiTiVpXQk/m7aRQmawg5AAGgkjTq6vph9ns+nxP+c3X5cfN99lvDf9W5+mXYhXf/TO7vUk2t3fZ
+        f1jKIY/rqNEF6Lm1tZkz5gfNz2eZtHkTN0boRFVWVPYsUSVrWC/s8+rTBSCZ7jDOZBjYw9WyI/nl
+        wBl2eCe5LYs9ZbwObuXhNQtVFGoN5v4ujhTLtgA6MweTVfY2GAAtUzYXMC22+0BGkjjz11Ld4pbR
+        P/gl4QyOTYv0tcBuOZQkF3tomRa1ctwmNomWtZWqerW6OxBAlc54Je/5m6CAGLBI0Vcr5hYDIlZw
+        5ldT/OqWuXBNNmQ2LRIhVziPt5H3MADbTU3Z5evIgnRK0oqIpyUlBZcrHk4QvS+MnQMJKBXbw5/M
+        K+Qvigi93CakJwPbGfdQkB4QRNRn7H80DgEMGKyyFJtgTGK1DH+7eEuQGHisNEcSDyZkB9qy8Vdy
+        Kit4GUyWgwGaKxXO8g4GqDSmEUf5/vGn6piG9cFWNWXsM+kxIXa8GE/DHrgxMquECGbxLbBl/SUQ
+        a14leTgRPa9l/pPzGp4F2wKxgIwLFQdj4kJnDtgyk3N/NdoopNYkgXg7ArRYBN0C8bYCrA7oN059
+        Am7xuK0tXCiY/j2Ptd0JFLzKGp6Fk7AF0mWFUiXj989WaMfH7EAEnkpTLeMmbGIemLQDXxQh/4Q7
+        ggE5CHBV19Ml3QuMNKrknJnKUj5X8xxP73A7IRZYBMXBvhj6/nzp9rJtEK9lw/3iL7NOUqjT6G6z
+        Xv+xvO5tFcy1eh5rf6q5zSnDQmzNtQi1mQ7H2hhP3Yezs7M2F9w9S0qhA2YRTwOW6yRHeR1K/7bn
+        oXIsuXXPnwWpn+I5VCieBjuLLRBw7wKh9uBpYz+qUa8HU9zBxvRSFuhaqCrcHTEQx3IqZeVCJse8
+        FY8P8x1o+9nIKhEnHM8bRIWViUSc4MlOHoAiX4Szoqdhe+gR+WdiIRAywU5JC89rme8KpKIu1CZo
+        hhwhKZFogQZVGnGLR+lsOpueTq9Op7O/zy/ms4v55cV3zGlq9MAemXM5n57TnLox+eNTPtAUpP8u
+        VvAJXamnG0H7b0zqOAFiTD5AfhkQ8wO9pEcQSQGn34va1+my2r/bX4bBdnJVihp1Wv84N/Ien6c7
+        NVaimgqng8E1t3hsoGYZhvq6rAfk3EQ+k0zmVjfoOdJIrdWdSKwZjw2ZbDRxLZdyZyHVkNtugX/k
+        D8JLqbXqmo2+udDlYbQNu45nKg2PCzEMqFpUnYbjbchEVGZrBt8AoC2Ppu+YwH1JxYI3hY38W4na
+        qejJosEKdxS6hBmo50Xt1q6z4g1CrtrvkbKi/4yGixVlHXnvsGopqD8LFLKKWkfm34bD9dwF1i/2
+        v7ghbIWqsd1ftKDrdHdNigBHq8drHKE47Ih9g3jcFnrvEzfxe5/4vU/83if2nXa6/g70iSth12iY
+        jrLp+HnbZ+uHH0CqdlcVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:07 GMT
+      etag:
+      - W/"d352e67226be87660d802696c269b05a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54719A6:6427611:5ED66143
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2980'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:07 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471A02:642767E:5ED66143
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2979'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyikwHGZubk+0N60M/RmOn243otHthVbxLZcSU4aPHz3+69k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZz66ur2ezy+n1yaRSqYhobHJ78+v6a/FHkXz5eM+//bVKquXm
+        z7vs4vbu9/Pbm+zTBJN5KTDTCmOjqNyk3HIjLH5YNEURdb+WAqNWaXFayPiU5hr2/xW1lituQVvw
+        woiTiVpXQk/m7aRQmawg5AAGgkjTq6vph9ns+nxP+c3X5cfN99lvDf9W5+mXYhXf/TO7vUk2t3fZ
+        f1jKIY/rqNEF6Lm1tZkz5gfNz2eZtHkTN0boRFVWVPYsUSVrWC/s8+rTBSCZ7jDOZBjYw9WyI/nl
+        wBl2eCe5LYs9ZbwObuXhNQtVFGoN5v4ujhTLtgA6MweTVfY2GAAtUzYXMC22+0BGkjjz11Ld4pbR
+        P/gl4QyOTYv0tcBuOZQkF3tomRa1ctwmNomWtZWqerW6OxBAlc54Je/5m6CAGLBI0Vcr5hYDIlZw
+        5ldT/OqWuXBNNmQ2LRIhVziPt5H3MADbTU3Z5evIgnRK0oqIpyUlBZcrHk4QvS+MnQMJKBXbw5/M
+        K+Qvigi93CakJwPbGfdQkB4QRNRn7H80DgEMGKyyFJtgTGK1DH+7eEuQGHisNEcSDyZkB9qy8Vdy
+        Kit4GUyWgwGaKxXO8g4GqDSmEUf5/vGn6piG9cFWNWXsM+kxIXa8GE/DHrgxMquECGbxLbBl/SUQ
+        a14leTgRPa9l/pPzGp4F2wKxgIwLFQdj4kJnDtgyk3N/NdoopNYkgXg7ArRYBN0C8bYCrA7oN059
+        Am7xuK0tXCiY/j2Ptd0JFLzKGp6Fk7AF0mWFUiXj989WaMfH7EAEnkpTLeMmbGIemLQDXxQh/4Q7
+        ggE5CHBV19Ml3QuMNKrknJnKUj5X8xxP73A7IRZYBMXBvhj6/nzp9rJtEK9lw/3iL7NOUqjT6G6z
+        Xv+xvO5tFcy1eh5rf6q5zSnDQmzNtQi1mQ7H2hhP3Yezs7M2F9w9S0qhA2YRTwOW6yRHeR1K/7bn
+        oXIsuXXPnwWpn+I5VCieBjuLLRBw7wKh9uBpYz+qUa8HU9zBxvRSFuhaqCrcHTEQx3IqZeVCJse8
+        FY8P8x1o+9nIKhEnHM8bRIWViUSc4MlOHoAiX4Szoqdhe+gR+WdiIRAywU5JC89rme8KpKIu1CZo
+        hhwhKZFogQZVGnGLR+lsOpueTq9Op7O/zy/ms4v55cV3zGlq9MAemXM5n57TnLox+eNTPtAUpP8u
+        VvAJXamnG0H7b0zqOAFiTD5AfhkQ8wO9pEcQSQGn34va1+my2r/bX4bBdnJVihp1Wv84N/Ien6c7
+        NVaimgqng8E1t3hsoGYZhvq6rAfk3EQ+k0zmVjfoOdJIrdWdSKwZjw2ZbDRxLZdyZyHVkNtugX/k
+        D8JLqbXqmo2+udDlYbQNu45nKg2PCzEMqFpUnYbjbchEVGZrBt8AoC2Ppu+YwH1JxYI3hY38W4na
+        qejJosEKdxS6hBmo50Xt1q6z4g1CrtrvkbKi/4yGixVlHXnvsGopqD8LFLKKWkfm34bD9dwF1i/2
+        v7ghbIWqsd1ftKDrdHdNigBHq8drHKE47Ih9g3jcFnrvEzfxe5/4vU/83if2nXa6/g70iSth12iY
+        jrLp+HnbZ+uHH0CqdlcVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:08 GMT
+      etag:
+      - W/"d352e67226be87660d802696c269b05a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471A5C:64276E7:5ED66143
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2978'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VSXYvbMBD8K4eek1iSIzs2FFpwHlqIw11DD6eUIFvr2Im/sOQDJ+S/36rpQfuW
+        QPoitLtazc7snIkuJAmJUspTC+Z5IIUK/CDzFjzPuWJCMF/OVeZxypXrkglpWgW7UmHTKkq8Zx6Y
+        9LWiq0MyX0dfx3jzZb6uX47baHtcR0se1z+K+PVZxKfqEB/247ZOxm20ZPFm6Sabl2NySsZV9O24
+        Oq0+4edDX+HHhTGdDh1HduVsX5piSGdZWzs9dK12ajBSm7aHaVWmUwPaaMeeu109Kok1MA42OdhR
+        l1i7g1ph6mr37wh/wd8CfAW9B1MOpmh7Ep5JI2tA8t8LWcj+afnWtw0qArUsrSa4J0zPwKY/723S
+        aoIPkLNtw/3QKfWmlG/YPOQipGJLLhNyncjAf4QwPeAE5z9WYpJlMlNpFihfCM/3mXI5FSAAArEQ
+        Pne9lLqMP3bbdgbt3IyNwtSgtdxb6SJ0TSezI0ZPQ2f1VDhcJ3tojCbhzw9mggqaKS6Ap5L6KvWQ
+        n8uCIIPM9dw8YMAWIGn+WGYfPr4D/WE+vhnz8mtC3qAv8zKTpkTjoh2uMWoZ5rLSMCE9SG1LZGh0
+        uW9+q2wv0gw97qEZqsrKPlatxCYbXi7vkrXF9qEEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:08 GMT
+      etag:
+      - W/"a62baf251dd36123f12e6d621eee64d1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471ACB:6427763:5ED66144
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2977'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf21i2Y9kOjNGErSSwjHUPc0IgyD45VipLxlIa0tLv3lNjRpvu
+        IevG2Isk7nR3P+7+9+Ap1nBv5AGzrGXlLdvwwdZo5V14LbP1rz2mZugoCkoqIGkaxiQkWcSSmEQJ
+        hYRSSCmLIEmTsKwIpjLiHosEwfDC23USY2trWzPyfdaKwUbYelcMSt34HW+18RtumbG645dSFJeW
+        G2t8d67XzcFxGm79UivLFTpOwT92vPoAAMgQUMpZDFmSlTQNqyqEII6DhA2hpCEJIYoQrbaNXL+G
+        egF0DkohdeGfW/ENLyJgvROCd7cFU/mOx/i/MR3QeyU1gxOIju372ewM7/qGP4/pnK78SUPsoXWa
+        rITk2J6+Mhr4Xm+mkxnh+VhOt/hu5vcgpmZ69WzfLX4EvT2Il9efySKfS5gc/SuFPw7LfH4H+Wy7
+        zL+Ir2JcTMQVRo6T4+3es/0iv9HH7Dc1XH+6K3J5WKmfkd/jbRktRB+ZuTv/1mYrtzJclRqE2rjt
+        QJnSIdrWUqhb440ePMNl9V9pH9XyN3jeJTq3dy+K/9ude3x8AvcOr1L5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:08 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471B2B:64277D6:5ED66144
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2976'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "Second version", "tag": "version-1.1", "type":
+      "commit", "object": "ddd6d8166ea5d979c682ff2d15517a4dc6202d33"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyNTA4OjVhZWIxODE0YjE1Y2E5OTYxNDFiY2JkZmQ5NzJjYmJjYjZlNjk1YTk=","sha":"5aeb1814b15ca996141bcbdfd972cbbcb6e695a9","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5aeb1814b15ca996141bcbdfd972cbbcb6e695a9","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:09Z"},"object":{"sha":"ddd6d8166ea5d979c682ff2d15517a4dc6202d33","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ddd6d8166ea5d979c682ff2d15517a4dc6202d33"},"tag":"version-1.1","message":"Second
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '693'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      etag:
+      - '"19c1c88afb5283eebf14b81b9a19fe11"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5aeb1814b15ca996141bcbdfd972cbbcb6e695a9
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471B8D:6427850:5ED66144
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2975'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "5aeb1814b15ca996141bcbdfd972cbbcb6e695a9", "ref":
+      "refs/tags/version-1.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.1","node_id":"MDM6UmVmMjY4ODIyNTA4OnJlZnMvdGFncy92ZXJzaW9uLTEuMQ==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1","object":{"sha":"5aeb1814b15ca996141bcbdfd972cbbcb6e695a9","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5aeb1814b15ca996141bcbdfd972cbbcb6e695a9"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      etag:
+      - '"2a6c6604d27baf16f2c340bb361bafd0"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471C2B:642790B:5ED66145
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2974'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:10 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471D1E:6427A33:5ED66145
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2973'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__otherdataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822572,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI1NzI=","name":"test__otherdataset","full_name":"metastore-lib-tests/test__otherdataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__otherdataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/deployments","created_at":"2020-06-02T14:25:10Z","updated_at":"2020-06-02T14:25:10Z","pushed_at":"2020-06-02T14:25:11Z","git_url":"git://github.com/metastore-lib-tests/test__otherdataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__otherdataset.git","clone_url":"https://github.com/metastore-lib-tests/test__otherdataset.git","svn_url":"https://github.com/metastore-lib-tests/test__otherdataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '7043'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:11 GMT
+      etag:
+      - '"d15689217c5213c8b82d10a824fa0d47"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471D80:6427A96:5ED66146
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2972'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__otherdataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md"}},"commit":{"sha":"4348f356d1bb2103b6f3d1b92296450ed996649c","node_id":"MDY6Q29tbWl0MjY4ODIyNTcyOjQzNDhmMzU2ZDFiYjIxMDNiNmYzZDFiOTIyOTY0NTBlZDk5NjY0OWM=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/4348f356d1bb2103b6f3d1b92296450ed996649c","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/4348f356d1bb2103b6f3d1b92296450ed996649c","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:12Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:12Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1815'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:13 GMT
+      etag:
+      - '"dd419c399c89b9906dbe854f91cc6b4c"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5471FB8:6427D56:5ED66147
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2971'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XXW/bNhT9K4GenUiWZfkDKDoM3oA82EYwt50zDAIlXVl0KVIjKbe2kf++e2ml
+        if3QRl32lhdDInUOz/3k9dGTrAJv6lXMWNBez8tUVXHrTY+eKRluRINoXAyGcd5P07AfDNK4GODz
+        JAwncTQMIJ9M4jiaZAiVKoeE5wiaz9bxXTix6ScRzLfraDm73S9W2X65vTssZmU1P3wI72e/8/X2
+        9ut8tuCLan2g9+Xqdr9crYPF6ldxP/s8XGzXwfLT/N2ZLtbYUmlS2Gr/o2Ql01e/7bSS+CVUjAsU
+        gfpx+QZo+ZcNLd6gcfhBziyZHAZhcB3E10G46kfTcDjth/few6MHyBv/2xEVGMM2JOJWcsuZ4Ae4
+        QlnsSkOtDLdK71Go1YDfPEaiXwSTvAgHo9E4jEb9aDiGHKPARmkajbMR7ozz0QACBDaaHFBaW5up
+        77Oa32y4LZuUHOC7I/wKLIZcabgWPL22YKzx6TdJlC1BkxgD1kecTzKM/+Lj0YWve/4pJY3fIRUJ
+        AtImmWokJnPQ83agecEzZjkmCfr09A6YrQUTBnqeBmZoy2uk4RuJOz2PHphtNEZBNkL0vJrthWII
+        oteHV7X0J6wsbSWSc18/i/MLI3w69yecay6O/i9p1tV4vw2wwSA99QOhNpwiaEpX9LhH3SgeDuPB
+        eXe6iz/+uRDZdt1frNYH4thhvutLg9yiCdviaQzoTEmLeeXqqPEd8/vduwgZNrrlcA3wRzVIXMZ/
+        0vn9SD59Vygh1BfEXko9L/Ezev8bCFWdnrncdCdA0NF3zSEh/gcymmPb6MLkAEfsKthoeE4UBl2s
+        Ie9C0kJQzBeJOo6uozmuJjWZ5jXVeCdZZ0AkUnrDJD+4ZtGJCIGUkq7FdjHJARAIO8yuTsgT4ujX
+        mu9Ytic3aMiA79Cn3dkuoEhm9zXdUx8w4uRhbiFheUVl5vrm5X35VoLtLftWgt0q560ET5cWNrOz
+        6n1RCdZMU9/wpn/9jQWZCC4/4wsOjiCKVxoEU81kVuIc+O2fAt1Zz8i7Tx40Vz7SoexaKwuZfTaS
+        tSvtxAaSpeJsYPun4XR14H1gG5OguuxkNshC6QzcBCiwCZJMVRToSnd/f2099XQmnvD9bt1pZr5w
+        FbZmZxiZ8fAvZV4G6nENAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:13 GMT
+      etag:
+      - W/"d7e56a6c6f4d695e99d09de9dfdbbe4d"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547214A:6427F1E:5ED66149
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2970'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"otherdataset\",
+      \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"05b0607cc662220661603d446d71eef5c4719212","size":99,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/05b0607cc662220661603d446d71eef5c4719212"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '686'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      etag:
+      - '"af7fbe6e808b96cd8a71d201501f97eb"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54721D3:6427FC2:5ED66149
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2969'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/4348f356d1bb2103b6f3d1b92296450ed996649c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTYvbMBD9K0FnJ5blb0OhFLeQg22WuixOKUG2x7FSfwRJXuqE/PeOmh7a2y60
+        F6GZ0cx782Z0I6rnJCGe60Wd6wetU9fMoW4ddC7eY8biwPMptHEcBF7cEItMcwtH0WJSllbBE4t1
+        /TzQ7Fx5Rbpf87JZi/PTNU/7Mbt+YYf0k6jO+x9Zmot8rK7GLsr9WpQVzcsPwyH97ufnihbP2Tss
+        vsgBC/daX1Ri2/widieh+6XeNfNoS7jMyh5Bc6VnCdtB1FsNSivbnMfjrHuQLccwaBvzbEwaBYbf
+        0F2vx+H4N4s/GLwS+4H7Fli+6H6WJLmRiY+AEnzuec/l5uOLnCfUBUYujDI4LXTvwLjfn4zTKIMP
+        sG2TxiijWxpsKSsdL2F+4rADuVvkwUjDf4TQEpDB7fdCOR2N2465YRgxL3Q8P4IWl4mHde1FTYiR
+        qA1doP985oaGsl8Nj9qMoBQ/GfX2k9CCD+IKG7NGm18LJ3DXVqR54RImrUjy9ZtFXkCKTjRcCxwP
+        Nv2wAX9FxwcFFpHAlQmRZVLiNGHEIubC9SIRalqGwZRch5ljkjHv95/oyNEFjQMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      etag:
+      - W/"97d103c30c4b934c9d5fa924c608f508"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472260:6428087:5ED6614A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2968'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["4348f356d1bb2103b6f3d1b92296450ed996649c"],
+      "message": "Initial datapackage commit", "tree": "fa0f09c21c1c7f2607347dd929f58fc34575b5fc"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"fb7ae796e664d691d5a477c2d37276a786a0e6a4","node_id":"MDY6Q29tbWl0MjY4ODIyNTcyOmZiN2FlNzk2ZTY2NGQ2OTFkNWE0NzdjMmQzNzI3NmE3ODZhMGU2YTQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/fb7ae796e664d691d5a477c2d37276a786a0e6a4","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/fb7ae796e664d691d5a477c2d37276a786a0e6a4","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:14Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:14Z"},"tree":{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc"},"message":"Initial
+        datapackage commit","parents":[{"sha":"4348f356d1bb2103b6f3d1b92296450ed996649c","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/4348f356d1bb2103b6f3d1b92296450ed996649c","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/4348f356d1bb2103b6f3d1b92296450ed996649c"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1207'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      etag:
+      - '"b778c369ebafc704ae23fdea7922ce31"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/fb7ae796e664d691d5a477c2d37276a786a0e6a4
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54722B6:64280EC:5ED6614A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2967'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWreJa+HMFQWk0AWC6BLZ8QW7iuPIvlYKVf87VzGyMLA8nfT0
+        3fsuLEHPqltm7kDbzIPOCIndsTFaaL2ltt7W8i00oT5+iP32aX557eb9+Dwcxvqsd407PNZn8/7w
+        ZXfNTOApDQQ5xClXnOvJLz89upNZdjHwBFOkEUCaiQkWgzcLhIyZ37JtIzpIVlMNyIkj4LdaNEfo
+        kFUXlp2mLVGK+77cSLs2plivSiP7km5VFEqKzQqsUlIK1ZEczhMQQSrB47/L/rzN/M9C1+s3UNbP
+        qYMBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      etag:
+      - W/"9515e33937185594456020860f80ae2d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547235B:642819F:5ED6614A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2966'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "fb7ae796e664d691d5a477c2d37276a786a0e6a4"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsU7DMBRF/8UzraEEm2auKCCZLhBEl+g5fsWu4jiyXyuFqv/OqxhZGFjucnXu
+        PSeRcSfqSxbpEVyREQphFldiSA7b4Lg1K6PeYhPN/qParJ6ml9du2gzP/XYwR1g3fvtojvb94cut
+        m4nBQ+4Z8kRjqaWEMcw/A/mDnXcpyoxj4hMkvkkZZ32wM8JCRV6ybRN5zA64RpLMMfBbLdk9diTq
+        kyge+GtnNaBeKlSqcmp54+6g0rpbuFu90Ar0vYJrVFCxHE0jMsEqMdC/y/7MFvlnofP5GyLAYRyD
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:15 GMT
+      etag:
+      - W/"ffea34f1ac32c901048ad2a28fec4fb1"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54723B2:642820D:5ED6614A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2965'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:16 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54724C2:6428342:5ED6614B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2964'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOlqStgaJ76FZ0QBpg2EPXF4GSaIuxJGokZc8R8t33P1Ky
+        ZMNNYoePeUlsmvwdj+Qdj/92IrPJLLp5/z6Krt9FZ5NKZSKmtsnt59/Xd8WfRfrlwwP//tcqrZab
+        b/eLq9v7r5ffHr5+nKAzLwV6WmFsHCubC51xy42w+G3eFEXcdSgFWq3S4ryQyTl1N+zgoFrLFbdg
+        znlhxNlErSuhJ7N2UqiFrGDqAAm2aL43N9N3UfT+cs+Fzd3yw+ZH9EfDv9d59qVYJff/RLef083t
+        /eI/DOWwx3Xc6AL03NrazBjzjebXi4W0eZM0RuhUVVZU9iJVJWtYb+zT6uMVIAvdYdzCoWEPV8uO
+        5IcDZ9hhT3JbFnuT8XNwIw+PmauiUGsw9714oVm2BdC2OZisFq+DAdAydyJiWr1HWiSJbT+V6ga3
+        jP7hdBLOYNu0yE4FdsMxSTpijy3TolaO2yQm1bK2UlUnT3cHAqjSC17JB/4qKCAGLJroyRNzgwER
+        Kxzmkyl+dMtcuKYbWjYtUiFX2I/XkfcwANtNTTnmbrSCtEvSiphnJSUFlysezxC9R8bO4RyUie3+
+        T2YVshgFhV5uc9KTse3W91CcHrZF4Gd24RgiIhk8LM9SbEJiCdcy/O1iL0WS4InSHDk9pJ0dbsvG
+        X+mMWcHLkOYcD9xcqaC74HjgSmMa8aKAOGqTHdawPgirpkx8hn1J6B1lyQPhCTdGLiohQq7+ltmy
+        /opINK/SPKiVHtky/8mdI74I6QjhQE0KlYTE4t5njtkyk3N/g9o48NzJCCF3bGgxD+0IIbc2rA57
+        kpwTxNxawO1ucahCetEjWdvtRsGrRcMXQY1smXTFocBZ8Idn67qjInqAwgLVtFomTfAsPmDJD19Q
+        IUcF3Y6BOthwRdvTFeFxqzWqBd16laV8rmo6ykBH3Im+8FYoPvYt0ffnS8CjnSFky4YryV+BnbGA
+        O9Pdgb0XY5PdSy3kYeuRrP2l5janXAzLNdcioEsdkbUJXtCPFxcXbS64e+qUQodNMx4IMtdpjqo9
+        oBdtj0QpWnLrHlZzciLDQ6tQPAu5L1sm+P5EBPTEA8cnq8ZjIOT0HW9soJQFtBFVBb1TBujYVKWs
+        nMv0JS/So5LADrf9ZGSVijOORxSixcpUIn6gDdCBwAtCBF1OD4STUKX8k7QQCKWQO6aFR7bMixCZ
+        qAu1CZ1IR1TKNFpAEstibvEMjqbR9Hx6cz6N/r68mkXXs8vpD/RpaghvP+9zTX3qxuTPdMFF0QUQ
+        PkEHe1p6OvCkJZkLpozJB85vA2V2QMD6OSUtEAl7AX3yjFb7dcHRJPiVq1LUKPl6XcDIB3ye7tRq
+        qWoq7BQa19ziMYOqZ2jq67sekHMT+zwzmVndQPGkllqre5FaM24bUt2o41ou5c5AKke3QoUXFwbj
+        pdRadVKn1zW6XA3RstNbM2l4UoihQdWi6mY4dkOmojLbZfCqA7k86r6zBO5LJua8KWzsH2Ik5kIU
+        hryLoyl0iWUgxY3E3k7X8QtCx7b3kRKm/wy5x4qyjv0ZsWopSB0GCqlGrWPzb8NxBt091w/2v7gm
+        uEKV3O4vWtDFuzsmQ7xDaPIzjlFbdsRenh6LUm8qdZO8qdRvKvWbSu11froHD6jUlbBrqLSjbDp+
+        IPfZ+vF/wdnA6pkbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:16 GMT
+      etag:
+      - W/"20cf2a5e81f3c3fdca814d67832d03e3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472522:64283B8:5ED6614C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2963'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:16 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547259C:642843A:5ED6614C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2962'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOlqStgaJ76FZ0QBpg2EPXF4GSaIuxJGokZc8R8t33P1Ky
+        ZMNNYoePeUlsmvwdj+Qdj/92IrPJLLp5/z6Krt9FZ5NKZSKmtsnt59/Xd8WfRfrlwwP//tcqrZab
+        b/eLq9v7r5ffHr5+nKAzLwV6WmFsHCubC51xy42w+G3eFEXcdSgFWq3S4ryQyTl1N+zgoFrLFbdg
+        znlhxNlErSuhJ7N2UqiFrGDqAAm2aL43N9N3UfT+cs+Fzd3yw+ZH9EfDv9d59qVYJff/RLef083t
+        /eI/DOWwx3Xc6AL03NrazBjzjebXi4W0eZM0RuhUVVZU9iJVJWtYb+zT6uMVIAvdYdzCoWEPV8uO
+        5IcDZ9hhT3JbFnuT8XNwIw+PmauiUGsw9714oVm2BdC2OZisFq+DAdAydyJiWr1HWiSJbT+V6ga3
+        jP7hdBLOYNu0yE4FdsMxSTpijy3TolaO2yQm1bK2UlUnT3cHAqjSC17JB/4qKCAGLJroyRNzgwER
+        Kxzmkyl+dMtcuKYbWjYtUiFX2I/XkfcwANtNTTnmbrSCtEvSiphnJSUFlysezxC9R8bO4RyUie3+
+        T2YVshgFhV5uc9KTse3W91CcHrZF4Gd24RgiIhk8LM9SbEJiCdcy/O1iL0WS4InSHDk9pJ0dbsvG
+        X+mMWcHLkOYcD9xcqaC74HjgSmMa8aKAOGqTHdawPgirpkx8hn1J6B1lyQPhCTdGLiohQq7+ltmy
+        /opINK/SPKiVHtky/8mdI74I6QjhQE0KlYTE4t5njtkyk3N/g9o48NzJCCF3bGgxD+0IIbc2rA57
+        kpwTxNxawO1ucahCetEjWdvtRsGrRcMXQY1smXTFocBZ8Idn67qjInqAwgLVtFomTfAsPmDJD19Q
+        IUcF3Y6BOthwRdvTFeFxqzWqBd16laV8rmo6ykBH3Im+8FYoPvYt0ffnS8CjnSFky4YryV+BnbGA
+        O9Pdgb0XY5PdSy3kYeuRrP2l5janXAzLNdcioEsdkbUJXtCPFxcXbS64e+qUQodNMx4IMtdpjqo9
+        oBdtj0QpWnLrHlZzciLDQ6tQPAu5L1sm+P5EBPTEA8cnq8ZjIOT0HW9soJQFtBFVBb1TBujYVKWs
+        nMv0JS/So5LADrf9ZGSVijOORxSixcpUIn6gDdCBwAtCBF1OD4STUKX8k7QQCKWQO6aFR7bMixCZ
+        qAu1CZ1IR1TKNFpAEstibvEMjqbR9Hx6cz6N/r68mkXXs8vpD/RpaghvP+9zTX3qxuTPdMFF0QUQ
+        PkEHe1p6OvCkJZkLpozJB85vA2V2QMD6OSUtEAl7AX3yjFb7dcHRJPiVq1LUKPl6XcDIB3ye7tRq
+        qWoq7BQa19ziMYOqZ2jq67sekHMT+zwzmVndQPGkllqre5FaM24bUt2o41ou5c5AKke3QoUXFwbj
+        pdRadVKn1zW6XA3RstNbM2l4UoihQdWi6mY4dkOmojLbZfCqA7k86r6zBO5LJua8KWzsH2Ik5kIU
+        hryLoyl0iWUgxY3E3k7X8QtCx7b3kRKm/wy5x4qyjv0ZsWopSB0GCqlGrWPzb8NxBt091w/2v7gm
+        uEKV3O4vWtDFuzsmQ7xDaPIzjlFbdsRenh6LUm8qdZO8qdRvKvWbSu11froHD6jUlbBrqLSjbDp+
+        IPfZ+vF/wdnA6pkbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:16 GMT
+      etag:
+      - W/"20cf2a5e81f3c3fdca814d67832d03e3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472605:64284BF:5ED6614C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2961'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/fb7ae796e664d691d5a477c2d37276a786a0e6a4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXaviMBD9K5JntWnapqawsA96Lz5YkXW56LLItE1trv2QJL2g4n/fCSLsvim4
+        LyGZ6eScOXPSCzEVkISUWQwyFlxyHhZc+EUEYRznrAhiFnOIJxyo5BCSIWm7Qu5UgUWL6YavmLDZ
+        R00Xn5twOZ2f0nV+WjZblbK3Oj0f2Ha9Yen7ii3Xb4f0Y0bTc/G5aFbn9DwP0mYWLKfbavH+k23W
+        q294ea9rvLiy9mgSz4OjGu+VrfpsnHeNp+WxM14jLRjbaTmqVTay0ljjuXW362wldQGYltbDOg+L
+        GoXpJ7qrbFPv/mXxF4MHsW+4z8BCb6tOk+RCWmgkSvCjggr0YPaluxZ1kQ0opwxOC8Nj6cLf9y7o
+        lMEPsG1XxiijI8pHlK39MGFR4odbch2SGyMr/yOE1RIZXO6GAlpSkTM/9/O4ZJzGQRgXhWCijCZl
+        HoRRHGVRmb985o4GTvxReNSmkcbA3qk3b5VVUA+ch46QHzA6uCmHNI+gZWsNSX7dewyDcFIGES/8
+        LGM+DTJeBrgXjAkeRlQWQuBzEq/v8e7rJwi80tcPw15/D8mX1KpUOViFRkZ73M4S/x8l1EYOiZZg
+        XIr0rVH7FjND4jZge41Dafu6duKf6g6wyB2v1z9dlU9QtwQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      etag:
+      - W/"b778c369ebafc704ae23fdea7922ce31"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472669:642853D:5ED6614C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2960'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/datapackage.json?ref=fb7ae796e664d691d5a477c2d37276a786a0e6a4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbUsjMRDHv8u+1mZ3u01uCyJa7koL56GCbkuh5GG2m5pNlk1qqeJ3N9GC2rsX
+        9QG5N8mQycz8mPnPfaRpDVE/EtTRhvIbuoDO0hodHUQNddW/Pbai3hH3WIxjwjnGaZrGGCc47oos
+        w4IkAGWPZyTJ0yT1qay880Xy/CBatcqHVs41to8QbWRnIV21Yh1uatRCYyyqwVHrTAuHSrJDB9ZZ
+        FM753LgK2kBqwSFutAPtfbvoxy2URyUjFEiOAeNM4DwRPZoRwlPRJSnBlPzANAZMMw9XuVrN33K9
+        YtqThinD0L5F/0L2FL7kDsRnmuOzoYBk0TumJMxaK0PFDkdL19shrSy027Y/zWvP3nymLW7TBHmW
+        UoFv0ra4f4C1WYwG49XkOlGjpbfrPKbDq810+CueFGdKDEZ2dPL0ZzMtzm5FMV5Oi9/yjzxlMz2Q
+        J95zSp7vYI/Xk+LCPGe6qMTw5y0r1EvkZW/JuxMZ/s+0j8yDVZw3+SxsCmhuhNQLz8W8NnFQ1VxJ
+        fWOj/n1kQZX/m+a9Pr4I6UNKCyv3qv63r9vDwyMei8Wl+QQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      etag:
+      - W/"05b0607cc662220661603d446d71eef5c4719212"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54726B4:642859D:5ED6614D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2959'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "fb7ae796e664d691d5a477c2d37276a786a0e6a4"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyNTcyOjAxNDA4ODdlYjBjYTE3ZDYwODJhOGRjZDJiODYyYzIxZWY4NjYxZjg=","sha":"0140887eb0ca17d6082a8dcd2b862c21ef8661f8","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/0140887eb0ca17d6082a8dcd2b862c21ef8661f8","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:17Z"},"object":{"sha":"fb7ae796e664d691d5a477c2d37276a786a0e6a4","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/fb7ae796e664d691d5a477c2d37276a786a0e6a4"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '698'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      etag:
+      - '"bb38a1fe12dbbc2f9f86a57a7e4cffd9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/0140887eb0ca17d6082a8dcd2b862c21ef8661f8
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472705:6428606:5ED6614D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2958'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "0140887eb0ca17d6082a8dcd2b862c21ef8661f8", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyNTcyOnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/tags/version-1.0","object":{"sha":"0140887eb0ca17d6082a8dcd2b862c21ef8661f8","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/0140887eb0ca17d6082a8dcd2b862c21ef8661f8"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '397'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:18 GMT
+      etag:
+      - '"235ac5a6468e9d3e46580691c53d2a49"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547278E:64286AF:5ED6614D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2957'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:18 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472860:64287B4:5ED6614E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2956'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyikQCEzN9cH2pt2hjLT6cP1XjyyrdgituVKctLg4bv3v5Id
+        O2kOAuiRF0gU6ber1e5qte1EppP57Or6eja7nF6fTCqViojGJne3v6zvi9+L5MvNI//65yqplps/
+        HrKLu4ffzu9us08TTOalwEwrjI2icpNyy42w+GHRFEXU/VoKjFqlxWkh41Oaa9j/V9RarrgFbcEL
+        I04mal0JPZm3k0JlsoKQAxgIIk2vrqY/zWbX53vKb+6XN5tvs18b/rXO0y/FKn74e3Z3m2zuHrJ/
+        sZRDHtdRowvQc2trM2fMD5ofzzJp8yZujNCJqqyo7FmiStawXtjn1acLQDLdYZzJMLCHq2VH8suB
+        M+zwTnJbFnvKeB3cysNrFqoo1BrM/V0cKZZtAXRmDiar7H0wAFqmbC5gWmz3iYwkceZvpbrFLaN/
+        8EvCGRybFulbgd1yKEku9tQyLWrluE1sEi1rK1X1ZnV3IIAqnfFKPvJ3QQExYJGib1bMLQZErODM
+        b6b41S1z4ZpsyGxaJEKucB7vI+9hALabmrLL/ciCdErSioinJSUFlyueThC9r4ydAwkoFdvDn8wr
+        5C+KCL3cJqRnA9sZ91CQHhBE1BfsfzQOAQwYrLIUm2BMYrUMf7t4S5AYeKw0RxIPJmQH2rLxV3Iq
+        K3gZTJaDAZorFc7yDgaoNKYRR/n+8afqmIb1wVY1Zewz6TEhdrwYT8MeuDEyq4QIZvEtsGX9JRBr
+        XiV5OBE9r2X+k/MangXbArGAjAsVB2PiQmcO2DKTc3812iik1iSBeDsCtFgE3QLxtgKsDug3Tn0C
+        bvG4rS1cKJj+PY+13QkUvMoanoWTsAXSZYVSJeOPL1Zox8fsQASeSlMt4yZsYh6YtANfFCH/hDuC
+        ATkIcFXX8yXdK4w0quScmcpSvlTzHE/vcDshFlgExcG+GPr+cun2um0Qr2XD/eIvs05SqNPobrNe
+        /7G87m0VzLV6Hmt/qLnNKcNCbM21CLWZDsfaGE/dp7OzszYX3D1LSqEDZhFPA5brJEd5HUr/tueh
+        ciy5dc+fBamf4jlUKJ4GO4stEHDvAqH24GljP6pRrwdT3MHG9FIW6FqoKtwdMRDHcipl5UImx7wV
+        jw/zHWj72cgqEScczxtEhZWJRJzgyU4egCJfhLOip2F76BH5Z2IhEDLBTkkLz2uZ7wqkoi7UJmiG
+        HCEpkWiBBlUacYtH6Ww6m55Or06ns7/OL+azi/nlxTfMaWr0wL4z53I+vaE5dWPyF6Yg/Xexgk/o
+        Sj3fCNp/Y1LHCXKMyQfIzwNifqCX9B1EUsDp96L2bbqs9u/212GwnVyVokad1j/OjXzE5+lOjZWo
+        psLpYHDNLR4bqFmGob4u6wE5N5HPJJO51Q16jjRSa/UgEmvGY0MmG01cy6XcWUg15LZb4B/5g/BS
+        aq26ZqNvLnR5GG3DruOZSsPjQgwDqhZVp+F4GzIRldmawTcAaMuj6TsmcF9SseBNYSP/VqJ2Knqy
+        aLDCHYUuYQbqeVG7teuseIOQq/Z7pKzoP6PhYkVZR947rFoK6s8Chayi1pH5p+FwPXeB9Yv9L24I
+        W6FqbPcXLeg63V2TIsDR6vEaRygOO2LfIB63hT76xE380Sf+6BN/9Il9p52uvwN94krYNRqmo2w6
+        ft722frpPzWoiXgVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:19 GMT
+      etag:
+      - W/"fdb349a45d6e15672f19e1dffaff72cf"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547289A:64287FF:5ED6614E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2955'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72RyWrDMBCG38XnOLJseVEgh0Da0lA3FNItpRgt48QhXrDkgBv87p30WEoJdLkM
+        A5p/9Enfy9FpIXcmp2qIFRtDDtCaoq5cOvackVPVGrJC40Q6T6P78qFMd89sOb/ub1cztqwW+3WV
+        HvTVZaV67q+fFm/ikXc3q4sunU2nuKBr9xjeWtuYCSGiKcabwm47OVZ1SVpoakNKsMLYugV3X0jX
+        grGIgjXLyl4LPANLMITTXzPWcgfKOpOjY7YCL2O+ZJ6msabMC6nMuU6CQAZSiTzhXuyBx+NABRHS
+        2b4BTODDfxf14yfP5hiG0Xce6M883P2HhxPjZw+hAEkTyiQNleA8ooxKJXWueewriW0EEQ8F/2sP
+        Z3MMw+s7fydieBEDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:19 GMT
+      etag:
+      - W/"b0bc9f60e83214ae5ea2844cb8a847a4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54728E2:642884C:5ED6614F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2954'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/42b40d17d14051bf9d833b3bcaf89070e0973c36
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9lUXPcSxfFMeGQhe8W/bBWZamBfsljO2xLeMbkrxbZ8m/d0T6AS30
+        QUIzZ86ZM4M+2TTXeJE1S1iWZoef356nrM/D1/RlO50fw9f+bcv7t48ifQro8Cz98Ssfc1Gk7TXz
+        X675eOqKvhVZWn0U50dxup767Jp/YTumOyDR0C9DXntR7YVceGUT18cgKIOyguYY84gjj6OgCg5E
+        WNVAhM6YRSeuC4vct9J0a7mv5tFVuMzaHdGANrNCZ5ClY1Ab7dr7chm3GghD4xLJNdBq9x9aU32L
+        iiWfbIIRycX3DjpQD0/vap7IGo4grTmaidJ7tOmvrU1ac1RAzS3N5z53+MHh/tkLE18k3CvYbcfm
+        ssfKWP37VgQXvKp9gX4JPKrLQyRE4MVxhbSKoIk99I4IvCFlsy1WmdqM0vzfLd01tfvXbmgS2hS5
+        eUel5Tw53p6TpRG1hta6fJZKm4c/KCH0ko2swFCxnf4eI/22BgaNO6YQtIXYOmnZToTQx6EHmFWR
+        4LQOw44tsA0zEMmGt9tvQEQd17QCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:20 GMT
+      etag:
+      - W/"79c96ecad85cf67024ab95ba1757f59e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472918:642889C:5ED6614F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2953'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:20 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472993:6428932:5ED66150
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2952'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyikQCEzN9cH2pt2hjLT6cP1XjyyrdgituVKctLg4bv3v5Id
+        O2kOAuiRF0gU6ber1e5qte1EppP57Or6eja7nF6fTCqViojGJne3v6zvi9+L5MvNI//65yqplps/
+        HrKLu4ffzu9us08TTOalwEwrjI2icpNyy42w+GHRFEXU/VoKjFqlxWkh41Oaa9j/V9RarrgFbcEL
+        I04mal0JPZm3k0JlsoKQAxgIIk2vrqY/zWbX53vKb+6XN5tvs18b/rXO0y/FKn74e3Z3m2zuHrJ/
+        sZRDHtdRowvQc2trM2fMD5ofzzJp8yZujNCJqqyo7FmiStawXtjn1acLQDLdYZzJMLCHq2VH8suB
+        M+zwTnJbFnvKeB3cysNrFqoo1BrM/V0cKZZtAXRmDiar7H0wAFqmbC5gWmz3iYwkceZvpbrFLaN/
+        8EvCGRybFulbgd1yKEku9tQyLWrluE1sEi1rK1X1ZnV3IIAqnfFKPvJ3QQExYJGib1bMLQZErODM
+        b6b41S1z4ZpsyGxaJEKucB7vI+9hALabmrLL/ciCdErSioinJSUFlyueThC9r4ydAwkoFdvDn8wr
+        5C+KCL3cJqRnA9sZ91CQHhBE1BfsfzQOAQwYrLIUm2BMYrUMf7t4S5AYeKw0RxIPJmQH2rLxV3Iq
+        K3gZTJaDAZorFc7yDgaoNKYRR/n+8afqmIb1wVY1Zewz6TEhdrwYT8MeuDEyq4QIZvEtsGX9JRBr
+        XiV5OBE9r2X+k/MangXbArGAjAsVB2PiQmcO2DKTc3812iik1iSBeDsCtFgE3QLxtgKsDug3Tn0C
+        bvG4rS1cKJj+PY+13QkUvMoanoWTsAXSZYVSJeOPL1Zox8fsQASeSlMt4yZsYh6YtANfFCH/hDuC
+        ATkIcFXX8yXdK4w0quScmcpSvlTzHE/vcDshFlgExcG+GPr+cun2um0Qr2XD/eIvs05SqNPobrNe
+        /7G87m0VzLV6Hmt/qLnNKcNCbM21CLWZDsfaGE/dp7OzszYX3D1LSqEDZhFPA5brJEd5HUr/tueh
+        ciy5dc+fBamf4jlUKJ4GO4stEHDvAqH24GljP6pRrwdT3MHG9FIW6FqoKtwdMRDHcipl5UImx7wV
+        jw/zHWj72cgqEScczxtEhZWJRJzgyU4egCJfhLOip2F76BH5Z2IhEDLBTkkLz2uZ7wqkoi7UJmiG
+        HCEpkWiBBlUacYtH6Ww6m55Or06ns7/OL+azi/nlxTfMaWr0wL4z53I+vaE5dWPyF6Yg/Xexgk/o
+        Sj3fCNp/Y1LHCXKMyQfIzwNifqCX9B1EUsDp96L2bbqs9u/212GwnVyVokad1j/OjXzE5+lOjZWo
+        psLpYHDNLR4bqFmGob4u6wE5N5HPJJO51Q16jjRSa/UgEmvGY0MmG01cy6XcWUg15LZb4B/5g/BS
+        aq26ZqNvLnR5GG3DruOZSsPjQgwDqhZVp+F4GzIRldmawTcAaMuj6TsmcF9SseBNYSP/VqJ2Knqy
+        aLDCHYUuYQbqeVG7teuseIOQq/Z7pKzoP6PhYkVZR947rFoK6s8Chayi1pH5p+FwPXeB9Yv9L24I
+        W6FqbPcXLeg63V2TIsDR6vEaRygOO2LfIB63hT76xE380Sf+6BN/9Il9p52uvwN94krYNRqmo2w6
+        ft722frpPzWoiXgVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:20 GMT
+      etag:
+      - W/"fdb349a45d6e15672f19e1dffaff72cf"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54729CA:6428977:5ED66150
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2951'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K7Kf1Ww22cQECr3iIRailGolliKTzcSszYtkN9eq+N9vF3vQfvPA
+        fgnZmcw+L/OQC1ElkJhwyqnIGUeWAQ3zLAg599woEii8wCsiF90JAi3IkDRtjjuZm6FkmgZfWKSz
+        TUWTQ+ovp/PTYvXkLw/rX4vVp8N2One3q88yXT1529mcLc5rNzk/8+VmUaXnhCUs5clm/Xs5+1Ym
+        s/SDubzvKnNxqfVRxY4DRzneS1322Vi0tdPhsVVOjRqUbjscVTIbaVRaOfa529WnHEwPtWOGHDNR
+        S9N7h7RS19XuXwp/wd8DfAN9Dyb0umw7El9IAzUa8V9LKKEbPL90bWMcwRqk9cTsyZTHaMsf97Zo
+        PTEfGM12jFFGRzQYUbZy/Zj5MQ+35DokN0Ya/yOE7tAwuPyJUhjiJPD8wvcy6omiCKLcD30uaIYh
+        YuGxDAVkAX/sti0H5dyNbYypUSnYW+vmjdQSqoFNzxHET1Md3GwzHI/QYaMVib+/CczARcEnQVR4
+        KIqgoGISBczGLAxdH/MJcAZAs8cKfIvzO9AfFue7Ma8/huQFO1lIAVqa/JpU3M5ofhgFVAqHpENQ
+        tkX6Rsl9YzpDYl9A951ZR9NXlbX9VLVghuzxen0Fme+XMqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:20 GMT
+      etag:
+      - W/"63a48ce3776d76a61a8f91d08945bca2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472A1B:64289E4:5ED66150
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2950'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5050cd25e2ba07db67553199cec363f91e18ea0f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXWvbMBSG/4uv20iOJ9sKjNGYrTiwjnUXc0Ih6OPYVipLxlIastL/XrkNrMt2
+        kXVj7ELioCOd9+E9R/eRYR1Es0gyz3omblkDk42zJjqLeubbX2dcy0IihywXkjKZUaDTacJxnpI4
+        S4mUkEJGMMU05ykOpZz6FkRoehZtBx2ett73boYQ69WkUb7d8omwHRqgtw514JnzdoBzrfi5B+cd
+        Gvf1utuPmA48EtZ4MCFxzP1ugPotwQQLOSUw5QxnkqcZIUlMqQCRpElNY4hzYLgOZK3v9PpHqBdA
+        p6BwbTk6VfEn3oAQ9I4IXm1LKIVGHod+oznS7oy2TB5BDGx36M3WwXAw/KlNp7jyJ4b4fT+OZK00
+        BHsOyuEAdrYpi8V2+TXW5SbEXUxWlx/wsrrSsihdefGU36+qqztZLTar6qP6pOa8UBfNjSmLeTZG
+        ZTGuxW5ZXdvnKtetvHx/xyv9/eUXshHJUj3fn9MbM0bV5z5EAQmMsFKZJjDxMI7pm3C21srcumh2
+        HznQ9X8142Eq/gbPq4Zr/F8vxP/t33p4eATnvLb14AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:21 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:57 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472A5F:6428A34:5ED66150
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2949'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5aeb1814b15ca996141bcbdfd972cbbcb6e695a9
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61SbWvbMBD+K0Wf48hybTU2DDZIOlpIwljocL6Es3S25fgNSy7NSv77Tst+QAv7
+        IHG6u+e55x70zvpB48lolrHteitfvj/22yaP9+uny+7wLd43L/Xx19Pbfr0J82Yj8miT7A/52279
+        aPLo+XzsfiS7389N3tFpju2uOYv8cP7CFszWQKQJYCFWIi5EoiBNpYhFoQpd6vQhUgWFEmWaQEqA
+        eWoJUDs32oxzGM2yMq6ei6UaOj7hOFjeoQPrhgmD1hSBQ+ss9/fp1F00UA0dJxB3UFn+idHUX+HE
+        snfWQ4ek4mcNNUx3m9dp6EkadmC8ONqJ0kv06a+VT3px1EDDPSwKozAIZRBGBxFnUZKF6ZFdF2wo
+        GlTO899c0VpLvRJSIiTkRKrkKirLSIskEQ8QayWJSd/fE7O7jJ6ZxnTG/V+XbpyWf1gNbUJOkZpX
+        nKwZ+kAsBUnq0Fqo/tqGauj13b8ylSgypVHgqNuvf3sjfbcSWosLNiFYX2Jzb03VU4V+DgXg5okY
+        +7ltF2yESzsAgfzzev0DneCwX7UCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:21 GMT
+      etag:
+      - W/"19c1c88afb5283eebf14b81b9a19fe11"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472AAB:6428A8F:5ED66151
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2948'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:21 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472AF0:6428AEF:5ED66151
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2947'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyikQCEzN9cH2pt2hjLT6cP1XjyyrdgituVKctLg4bv3v5Id
+        O2kOAuiRF0gU6ber1e5qte1EppP57Or6eja7nF6fTCqViojGJne3v6zvi9+L5MvNI//65yqplps/
+        HrKLu4ffzu9us08TTOalwEwrjI2icpNyy42w+GHRFEXU/VoKjFqlxWkh41Oaa9j/V9RarrgFbcEL
+        I04mal0JPZm3k0JlsoKQAxgIIk2vrqY/zWbX53vKb+6XN5tvs18b/rXO0y/FKn74e3Z3m2zuHrJ/
+        sZRDHtdRowvQc2trM2fMD5ofzzJp8yZujNCJqqyo7FmiStawXtjn1acLQDLdYZzJMLCHq2VH8suB
+        M+zwTnJbFnvKeB3cysNrFqoo1BrM/V0cKZZtAXRmDiar7H0wAFqmbC5gWmz3iYwkceZvpbrFLaN/
+        8EvCGRybFulbgd1yKEku9tQyLWrluE1sEi1rK1X1ZnV3IIAqnfFKPvJ3QQExYJGib1bMLQZErODM
+        b6b41S1z4ZpsyGxaJEKucB7vI+9hALabmrLL/ciCdErSioinJSUFlyueThC9r4ydAwkoFdvDn8wr
+        5C+KCL3cJqRnA9sZ91CQHhBE1BfsfzQOAQwYrLIUm2BMYrUMf7t4S5AYeKw0RxIPJmQH2rLxV3Iq
+        K3gZTJaDAZorFc7yDgaoNKYRR/n+8afqmIb1wVY1Zewz6TEhdrwYT8MeuDEyq4QIZvEtsGX9JRBr
+        XiV5OBE9r2X+k/MangXbArGAjAsVB2PiQmcO2DKTc3812iik1iSBeDsCtFgE3QLxtgKsDug3Tn0C
+        bvG4rS1cKJj+PY+13QkUvMoanoWTsAXSZYVSJeOPL1Zox8fsQASeSlMt4yZsYh6YtANfFCH/hDuC
+        ATkIcFXX8yXdK4w0quScmcpSvlTzHE/vcDshFlgExcG+GPr+cun2um0Qr2XD/eIvs05SqNPobrNe
+        /7G87m0VzLV6Hmt/qLnNKcNCbM21CLWZDsfaGE/dp7OzszYX3D1LSqEDZhFPA5brJEd5HUr/tueh
+        ciy5dc+fBamf4jlUKJ4GO4stEHDvAqH24GljP6pRrwdT3MHG9FIW6FqoKtwdMRDHcipl5UImx7wV
+        jw/zHWj72cgqEScczxtEhZWJRJzgyU4egCJfhLOip2F76BH5Z2IhEDLBTkkLz2uZ7wqkoi7UJmiG
+        HCEpkWiBBlUacYtH6Ww6m55Or06ns7/OL+azi/nlxTfMaWr0wL4z53I+vaE5dWPyF6Yg/Xexgk/o
+        Sj3fCNp/Y1LHCXKMyQfIzwNifqCX9B1EUsDp96L2bbqs9u/212GwnVyVokad1j/OjXzE5+lOjZWo
+        psLpYHDNLR4bqFmGob4u6wE5N5HPJJO51Q16jjRSa/UgEmvGY0MmG01cy6XcWUg15LZb4B/5g/BS
+        aq26ZqNvLnR5GG3DruOZSsPjQgwDqhZVp+F4GzIRldmawTcAaMuj6TsmcF9SseBNYSP/VqJ2Knqy
+        aLDCHYUuYQbqeVG7teuseIOQq/Z7pKzoP6PhYkVZR947rFoK6s8Chayi1pH5p+FwPXeB9Yv9L24I
+        W6FqbPcXLeg63V2TIsDR6vEaRygOO2LfIB63hT76xE380Sf+6BN/9Il9p52uvwN94krYNRqmo2w6
+        ft722frpPzWoiXgVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:21 GMT
+      etag:
+      - W/"fdb349a45d6e15672f19e1dffaff72cf"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472B34:6428B42:5ED66151
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2946'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VSXYvbMBD8K4eek1iSIzs2FFpwHlqIw11DD6eUIFvr2Im/sOQDJ+S/36rpQfuW
+        QPoitLtazc7snIkuJAmJUspTC+Z5IIUK/CDzFjzPuWJCMF/OVeZxypXrkglpWgW7UmHTKkq8Zx6Y
+        9LWiq0MyX0dfx3jzZb6uX47baHtcR0se1z+K+PVZxKfqEB/247ZOxm20ZPFm6Sabl2NySsZV9O24
+        Oq0+4edDX+HHhTGdDh1HduVsX5piSGdZWzs9dK12ajBSm7aHaVWmUwPaaMeeu109Kok1MA42OdhR
+        l1i7g1ph6mr37wh/wd8CfAW9B1MOpmh7Ep5JI2tA8t8LWcj+afnWtw0qArUsrSa4J0zPwKY/723S
+        aoIPkLNtw/3QKfWmlG/YPOQipGJLLhNyncjAf4QwPeAE5z9WYpJlMlNpFihfCM/3mXI5FSAAArEQ
+        Pne9lLqMP3bbdgbt3IyNwtSgtdxb6SJ0TSezI0ZPQ2f1VDhcJ3tojCbhzw9mggqaKS6Ap5L6KvWQ
+        n8uCIIPM9dw8YMAWIGn+WGYfPr4D/WE+vhnz8mtC3qAv8zKTpkTjoh2uMWoZ5rLSMCE9SG1LZGh0
+        uW9+q2wv0gw97qEZqsrKPlatxCYbXi7vkrXF9qEEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:22 GMT
+      etag:
+      - W/"a62baf251dd36123f12e6d621eee64d1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472B90:6428BAC:5ED66151
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2945'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf21i2Y9kOjNGErSSwjHUPc0IgyD45VipLxlIa0tLv3lNjRpvu
+        IevG2Isk7nR3P+7+9+Ap1nBv5AGzrGXlLdvwwdZo5V14LbP1rz2mZugoCkoqIGkaxiQkWcSSmEQJ
+        hYRSSCmLIEmTsKwIpjLiHosEwfDC23USY2trWzPyfdaKwUbYelcMSt34HW+18RtumbG645dSFJeW
+        G2t8d67XzcFxGm79UivLFTpOwT92vPoAAMgQUMpZDFmSlTQNqyqEII6DhA2hpCEJIYoQrbaNXL+G
+        egF0DkohdeGfW/ENLyJgvROCd7cFU/mOx/i/MR3QeyU1gxOIju372ewM7/qGP4/pnK78SUPsoXWa
+        rITk2J6+Mhr4Xm+mkxnh+VhOt/hu5vcgpmZ69WzfLX4EvT2Il9efySKfS5gc/SuFPw7LfH4H+Wy7
+        zL+Ir2JcTMQVRo6T4+3es/0iv9HH7Dc1XH+6K3J5WKmfkd/jbRktRB+ZuTv/1mYrtzJclRqE2rjt
+        QJnSIdrWUqhb440ePMNl9V9pH9XyN3jeJTq3dy+K/9ude3x8AvcOr1L5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:22 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472BD9:6428BF8:5ED66152
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2944'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:22 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472C25:6428C58:5ED66152
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2943'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyikQCEzN9cH2pt2hjLT6cP1XjyyrdgituVKctLg4bv3v5Id
+        O2kOAuiRF0gU6ber1e5qte1EppP57Or6eja7nF6fTCqViojGJne3v6zvi9+L5MvNI//65yqplps/
+        HrKLu4ffzu9us08TTOalwEwrjI2icpNyy42w+GHRFEXU/VoKjFqlxWkh41Oaa9j/V9RarrgFbcEL
+        I04mal0JPZm3k0JlsoKQAxgIIk2vrqY/zWbX53vKb+6XN5tvs18b/rXO0y/FKn74e3Z3m2zuHrJ/
+        sZRDHtdRowvQc2trM2fMD5ofzzJp8yZujNCJqqyo7FmiStawXtjn1acLQDLdYZzJMLCHq2VH8suB
+        M+zwTnJbFnvKeB3cysNrFqoo1BrM/V0cKZZtAXRmDiar7H0wAFqmbC5gWmz3iYwkceZvpbrFLaN/
+        8EvCGRybFulbgd1yKEku9tQyLWrluE1sEi1rK1X1ZnV3IIAqnfFKPvJ3QQExYJGib1bMLQZErODM
+        b6b41S1z4ZpsyGxaJEKucB7vI+9hALabmrLL/ciCdErSioinJSUFlyueThC9r4ydAwkoFdvDn8wr
+        5C+KCL3cJqRnA9sZ91CQHhBE1BfsfzQOAQwYrLIUm2BMYrUMf7t4S5AYeKw0RxIPJmQH2rLxV3Iq
+        K3gZTJaDAZorFc7yDgaoNKYRR/n+8afqmIb1wVY1Zewz6TEhdrwYT8MeuDEyq4QIZvEtsGX9JRBr
+        XiV5OBE9r2X+k/MangXbArGAjAsVB2PiQmcO2DKTc3812iik1iSBeDsCtFgE3QLxtgKsDug3Tn0C
+        bvG4rS1cKJj+PY+13QkUvMoanoWTsAXSZYVSJeOPL1Zox8fsQASeSlMt4yZsYh6YtANfFCH/hDuC
+        ATkIcFXX8yXdK4w0quScmcpSvlTzHE/vcDshFlgExcG+GPr+cun2um0Qr2XD/eIvs05SqNPobrNe
+        /7G87m0VzLV6Hmt/qLnNKcNCbM21CLWZDsfaGE/dp7OzszYX3D1LSqEDZhFPA5brJEd5HUr/tueh
+        ciy5dc+fBamf4jlUKJ4GO4stEHDvAqH24GljP6pRrwdT3MHG9FIW6FqoKtwdMRDHcipl5UImx7wV
+        jw/zHWj72cgqEScczxtEhZWJRJzgyU4egCJfhLOip2F76BH5Z2IhEDLBTkkLz2uZ7wqkoi7UJmiG
+        HCEpkWiBBlUacYtH6Ww6m55Or06ns7/OL+azi/nlxTfMaWr0wL4z53I+vaE5dWPyF6Yg/Xexgk/o
+        Sj3fCNp/Y1LHCXKMyQfIzwNifqCX9B1EUsDp96L2bbqs9u/212GwnVyVokad1j/OjXzE5+lOjZWo
+        psLpYHDNLR4bqFmGob4u6wE5N5HPJJO51Q16jjRSa/UgEmvGY0MmG01cy6XcWUg15LZb4B/5g/BS
+        aq26ZqNvLnR5GG3DruOZSsPjQgwDqhZVp+F4GzIRldmawTcAaMuj6TsmcF9SseBNYSP/VqJ2Knqy
+        aLDCHYUuYQbqeVG7teuseIOQq/Z7pKzoP6PhYkVZR947rFoK6s8Chayi1pH5p+FwPXeB9Yv9L24I
+        W6FqbPcXLeg63V2TIsDR6vEaRygOO2LfIB63hT76xE380Sf+6BN/9Il9p52uvwN94krYNRqmo2w6
+        ft722frpPzWoiXgVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:22 GMT
+      etag:
+      - W/"fdb349a45d6e15672f19e1dffaff72cf"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472C70:6428CB0:5ED66152
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2942'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QP2+DMBDFv4vngk1MQ0DKEClN1KhulvRfFmTjIxABRviIRKN89147d+jQ5S33
+        3t3v3ZUNULLsWz1HffL8AoOvXRdEoWB3rHMW8tqSQ63V/KV9bdX5I96vH6fnwyred7vm2KmL3W66
+        Ykpnx/fdp35Lx6fDw6hWyyUtGIeGwhVi7zPOdV+Hpxqr0YSFa/kAvfO8BdQe3QBBU5sAwSOhkOZ5
+        O1lNM0BOIXL/zujMGQpk2ZX5StOxeGZiYaPERrG4j0yZ2oWURppCl4tUJAJEmshCzokOpx4oQcX/
+        F/Xnk3/muN2+ANFEuYeHAQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:23 GMT
+      etag:
+      - W/"12ac4bbf89f9d5e8ca7183dc142ba9ac"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472CBD:6428D08:5ED66152
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2941'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:25:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472D02:6428D64:5ED66153
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2940'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:24 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472E07:6428E94:5ED66153
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2939'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyj4gEJmbq4PtDftDGWm04frvXhkW7FFbMuV5KTBw3e//1p2
+        7KQBQtAjL5Ao0m9Xq93VapuJTCaz4Or6Oggup9cnk1IlIqSxyd3tr6v7/I88/nrzyL/9tYzLxfrP
+        h/Ti7uH387vb9PMEk3khMNMKY8OwWCfcciMsfpjXeR52vxYCo1ZpcZrL6JTmGvb/FZWWS25Bm/Pc
+        iJOJWpVCT2bNJFepLCFkDwaCSNOrq+nPQXB9vqP8+n5xs/4e/Fbzb1WWfM2X0cM/wd1tvL57SP/D
+        Ug55XIe1zkHPrK3MjDE3aD6dpdJmdVQboWNVWlHas1gVrGa9sC/LzxeApLrDtCbDwA6ukh3JLQfO
+        sP07yWyR7yjjdGhX7l8zV3muVmDu7uJAsWwDoDNrYbJM3wcDoGHKZgKmxXafyEgSZ34stV3cMPoH
+        vyScwbFpkRwL7JZDSXKxp4ZpUamWW0cm1rKyUpVHq7sFAVTplJfykb8LCogBixQ9WrF2MSBiCWc+
+        muJWN6wN13hNZtMiFnKJ83gfeQcDsF1XlF3uRxakU5JWhDwpKCm0ueLpBNH7xtjZk4ASsTn8yaxE
+        /qKI0ItNQnoxsFvj7gvSPYKI+or9D8YhgAGDVRZi7Y1JrIbhbxdvMRIDj5TmSOLehGxBGzb+Sk5l
+        BS+8yWphgGZK+bN8CwNUGlOLg3z/8FNtmYb1wVbWReQy6SEhdrgYR8MeuDEyLYXwZvENsGH9JRBp
+        XsaZPxE9r2HuU+s1PPW2BWIBGeUq8sbEhc5aYMNMxt3VaEOfWpME4m0J0GLudQvE2wiw2qPftOoT
+        cIPHbW3hQt7073ms6U4g52Va89SfhA2QLiuUKil/fLVCOzxmByLwVJpqGdV+E/PApB24ogj5x98R
+        DMhBQFt1vVzSvcFIo0quNVNRyNdqnsPpHW4rxDyLoDjYFUPfXy/d3rYN4jVsuF/cZdZJ8nUa3W3W
+        6z+W172tvLlWz2PNTxW3GWVYiK24Fr420+FYE+Gp+3R2dtZkgrfPkkJoj1nE0YDlOs5QXvvSv+l5
+        qBwLbtvnz5zUT/AcyhVPvJ3FBgi4cwFfe3C0sR9VqNe9Kd7CxvRC5uhaqNLfHTEQx3JKZeVcxoe8
+        FQ8P8y1o88XIMhYnHM8bRIWVsUSc4MlOHoAiX/izoqNhe+gRuWdiLhAy3k5JC8drmOsKJKLK1dpr
+        hhwhKZFogQZVEnKLR2kwDaan06vTafD3+cUsuJhdXnzHnLpCD+yZOZez6Q3NqWqTPTsl+ERTkP67
+        WMEndKVebgTtvjGp4wSIMdkA+WVAzPb0kp5BxDmcfidqj9NluXu3vw2D7WSqEBXqtP5xbuQjPk+3
+        aqxY1SVOB4MrbvHYQM0yDPV1WQ/IuAldJpnMrK7Rc6SRSqsHEVszHhsy2WjiSi7k1kKqITfdAvfI
+        H4QXUmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3GDK4BQFseTd8yQfslEXNe5zZ0byVq
+        p6IniwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qFoP4sUMgqahWaf2sO12svsH6x
+        +6UdwlaoGtv+RQu6TrfXJAhwtHqcxiGKw47YN4jHbaGPPnEdffSJP/rEH31i12mn629Pn7gUdoWG
+        6Sibjp+3fbZ++gGOJUtWFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:24 GMT
+      etag:
+      - W/"2acfb6d6e22ccf21e9c545f380f6a2e2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472E6D:6428F07:5ED66154
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2938'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT0vDQBDFv8ueTZYtSXQDPQhVsRiLULVWJOyfabMl2Q3ZSSGWfndHzx48eHkM
+        zHszv5n3Extgx8pvjRzVPvIjDNEFn4hUsAvmg4XaWXJUi6p47l666vCWrRb30+P6Olv5Zbv11dHe
+        3Xozydl2s/xUr3J8WN+M1dN8TgPGoaVwg9jHknPVu3TvsBl1akLHB+hD5B2gihgGSFqnE4SIhEJa
+        191kFfUAOYXI/Ttj0AcwyMoTi42iZbkCLa5EpkVulJSFyIQ22u6svJwZTWUBhcyVJDqceqAEHf6/
+        qD+f/DPH+fzxBUPQJ8+JAQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:25 GMT
+      etag:
+      - W/"23d153de6f8348316150043fde62dd63"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472F18:6428FF1:5ED66154
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2937'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5aeb1814b15ca996141bcbdfd972cbbcb6e695a9
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61SbWvbMBD+K0Wf48hybTU2DDZIOlpIwljocL6Es3S25fgNSy7NSv77Tst+QAv7
+        IHG6u+e55x70zvpB48lolrHteitfvj/22yaP9+uny+7wLd43L/Xx19Pbfr0J82Yj8miT7A/52279
+        aPLo+XzsfiS7389N3tFpju2uOYv8cP7CFszWQKQJYCFWIi5EoiBNpYhFoQpd6vQhUgWFEmWaQEqA
+        eWoJUDs32oxzGM2yMq6ei6UaOj7hOFjeoQPrhgmD1hSBQ+ss9/fp1F00UA0dJxB3UFn+idHUX+HE
+        snfWQ4ek4mcNNUx3m9dp6EkadmC8ONqJ0kv06a+VT3px1EDDPSwKozAIZRBGBxFnUZKF6ZFdF2wo
+        GlTO899c0VpLvRJSIiTkRKrkKirLSIskEQ8QayWJSd/fE7O7jJ6ZxnTG/V+XbpyWf1gNbUJOkZpX
+        nKwZ+kAsBUnq0Fqo/tqGauj13b8ylSgypVHgqNuvf3sjfbcSWosLNiFYX2Jzb03VU4V+DgXg5okY
+        +7ltF2yESzsAgfzzev0DneCwX7UCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:25 GMT
+      etag:
+      - W/"19c1c88afb5283eebf14b81b9a19fe11"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472F71:6429051:5ED66155
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2936'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:25 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5472FBD:64290B8:5ED66155
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2935'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyj4gEJmbq4PtDftDGWm04frvXhkW7FFbMuV5KTBw3e//1p2
+        7KQBQtAjL5Ao0m9Xq93VapuJTCaz4Or6Oggup9cnk1IlIqSxyd3tr6v7/I88/nrzyL/9tYzLxfrP
+        h/Ti7uH387vb9PMEk3khMNMKY8OwWCfcciMsfpjXeR52vxYCo1ZpcZrL6JTmGvb/FZWWS25Bm/Pc
+        iJOJWpVCT2bNJFepLCFkDwaCSNOrq+nPQXB9vqP8+n5xs/4e/Fbzb1WWfM2X0cM/wd1tvL57SP/D
+        Ug55XIe1zkHPrK3MjDE3aD6dpdJmdVQboWNVWlHas1gVrGa9sC/LzxeApLrDtCbDwA6ukh3JLQfO
+        sP07yWyR7yjjdGhX7l8zV3muVmDu7uJAsWwDoDNrYbJM3wcDoGHKZgKmxXafyEgSZ34stV3cMPoH
+        vyScwbFpkRwL7JZDSXKxp4ZpUamWW0cm1rKyUpVHq7sFAVTplJfykb8LCogBixQ9WrF2MSBiCWc+
+        muJWN6wN13hNZtMiFnKJ83gfeQcDsF1XlF3uRxakU5JWhDwpKCm0ueLpBNH7xtjZk4ASsTn8yaxE
+        /qKI0ItNQnoxsFvj7gvSPYKI+or9D8YhgAGDVRZi7Y1JrIbhbxdvMRIDj5TmSOLehGxBGzb+Sk5l
+        BS+8yWphgGZK+bN8CwNUGlOLg3z/8FNtmYb1wVbWReQy6SEhdrgYR8MeuDEyLYXwZvENsGH9JRBp
+        XsaZPxE9r2HuU+s1PPW2BWIBGeUq8sbEhc5aYMNMxt3VaEOfWpME4m0J0GLudQvE2wiw2qPftOoT
+        cIPHbW3hQt7073ms6U4g52Va89SfhA2QLiuUKil/fLVCOzxmByLwVJpqGdV+E/PApB24ogj5x98R
+        DMhBQFt1vVzSvcFIo0quNVNRyNdqnsPpHW4rxDyLoDjYFUPfXy/d3rYN4jVsuF/cZdZJ8nUa3W3W
+        6z+W172tvLlWz2PNTxW3GWVYiK24Fr420+FYE+Gp+3R2dtZkgrfPkkJoj1nE0YDlOs5QXvvSv+l5
+        qBwLbtvnz5zUT/AcyhVPvJ3FBgi4cwFfe3C0sR9VqNe9Kd7CxvRC5uhaqNLfHTEQx3JKZeVcxoe8
+        FQ8P8y1o88XIMhYnHM8bRIWVsUSc4MlOHoAiX/izoqNhe+gRuWdiLhAy3k5JC8drmOsKJKLK1dpr
+        hhwhKZFogQZVEnKLR2kwDaan06vTafD3+cUsuJhdXnzHnLpCD+yZOZez6Q3NqWqTPTsl+ERTkP67
+        WMEndKVebgTtvjGp4wSIMdkA+WVAzPb0kp5BxDmcfidqj9NluXu3vw2D7WSqEBXqtP5xbuQjPk+3
+        aqxY1SVOB4MrbvHYQM0yDPV1WQ/IuAldJpnMrK7Rc6SRSqsHEVszHhsy2WjiSi7k1kKqITfdAvfI
+        H4QXUmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3GDK4BQFseTd8yQfslEXNe5zZ0byVq
+        p6IniwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qFoP4sUMgqahWaf2sO12svsH6x
+        +6UdwlaoGtv+RQu6TrfXJAhwtHqcxiGKw47YN4jHbaGPPnEdffSJP/rEH31i12mn629Pn7gUdoWG
+        6Sibjp+3fbZ++gGOJUtWFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:25 GMT
+      etag:
+      - W/"2acfb6d6e22ccf21e9c545f380f6a2e2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473032:642914A:5ED66155
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2934'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VSXYvbMBD8K4eek1iSIzs2FFpwHlqIw11DD6eUIFvr2Im/sOQDJ+S/36rpQfuW
+        QPoitLtazc7snIkuJAmJUspTC+Z5IIUK/CDzFjzPuWJCMF/OVeZxypXrkglpWgW7UmHTKkq8Zx6Y
+        9LWiq0MyX0dfx3jzZb6uX47baHtcR0se1z+K+PVZxKfqEB/247ZOxm20ZPFm6Sabl2NySsZV9O24
+        Oq0+4edDX+HHhTGdDh1HduVsX5piSGdZWzs9dK12ajBSm7aHaVWmUwPaaMeeu109Kok1MA42OdhR
+        l1i7g1ph6mr37wh/wd8CfAW9B1MOpmh7Ep5JI2tA8t8LWcj+afnWtw0qArUsrSa4J0zPwKY/723S
+        aoIPkLNtw/3QKfWmlG/YPOQipGJLLhNyncjAf4QwPeAE5z9WYpJlMlNpFihfCM/3mXI5FSAAArEQ
+        Pne9lLqMP3bbdgbt3IyNwtSgtdxb6SJ0TSezI0ZPQ2f1VDhcJ3tojCbhzw9mggqaKS6Ap5L6KvWQ
+        n8uCIIPM9dw8YMAWIGn+WGYfPr4D/WE+vhnz8mtC3qAv8zKTpkTjoh2uMWoZ5rLSMCE9SG1LZGh0
+        uW9+q2wv0gw97qEZqsrKPlatxCYbXi7vkrXF9qEEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:26 GMT
+      etag:
+      - W/"a62baf251dd36123f12e6d621eee64d1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473075:6429199:5ED66155
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2933'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=ddd6d8166ea5d979c682ff2d15517a4dc6202d33
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf21i2Y9kOjNGErSSwjHUPc0IgyD45VipLxlIa0tLv3lNjRpvu
+        IevG2Isk7nR3P+7+9+Ap1nBv5AGzrGXlLdvwwdZo5V14LbP1rz2mZugoCkoqIGkaxiQkWcSSmEQJ
+        hYRSSCmLIEmTsKwIpjLiHosEwfDC23USY2trWzPyfdaKwUbYelcMSt34HW+18RtumbG645dSFJeW
+        G2t8d67XzcFxGm79UivLFTpOwT92vPoAAMgQUMpZDFmSlTQNqyqEII6DhA2hpCEJIYoQrbaNXL+G
+        egF0DkohdeGfW/ENLyJgvROCd7cFU/mOx/i/MR3QeyU1gxOIju372ewM7/qGP4/pnK78SUPsoXWa
+        rITk2J6+Mhr4Xm+mkxnh+VhOt/hu5vcgpmZ69WzfLX4EvT2Il9efySKfS5gc/SuFPw7LfH4H+Wy7
+        zL+Ir2JcTMQVRo6T4+3es/0iv9HH7Dc1XH+6K3J5WKmfkd/jbRktRB+ZuTv/1mYrtzJclRqE2rjt
+        QJnSIdrWUqhb440ePMNl9V9pH9XyN3jeJTq3dy+K/9ude3x8AvcOr1L5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:26 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54730BE:64291EC:5ED66156
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2932'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:27 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473158:64292BA:5ED66156
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2931'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTSJHzSZZA4vtYdvFFsgGKHrY7kWgJFqiLYkqSdl1hPz3vkNK
+        lmw4H3Z4zCWxafIZDskZDt92ItLJLLy+vQ3DDzfh2aSSKY+obXL35ff1ffFnkXz9+MB+/LVKquXm
+        +yK7ult8u/z+8O3TBJ1ZydHTcG2iSJqcq5QZprnBb/OmKKKuQ8nRaqTi54WIz6m7Dg4OqpVYMQPm
+        nBWan03kuuJqMmsnhcxEBVMHSLBF872+nt6E4e3lngub++XHzc/wj4b9qPP0a7GKF/+Ed1+Szd0i
+        +w9DGewxFTWqAD03ptazIHCN+teLTJi8iRvNVSIrwytzkcgyaILe2OfVpytAMtVh7MKhYQ9Xi47k
+        hgOng8Oe5KYs9ibj5mBHHh4zl0Uh12Due/FKs8EWQNtmYaLK3gYDoA3siYho9R5pkQS2/VSqHdwG
+        9A+nk3Aa26Z4eiqwG45J0hF7bAPFa2m5TawTJWojZHXydHcggEqVsUo8sDdBAdFg0URPnpgdDAhf
+        4TCfTHGj28CGa7KhZVM84WKF/XgbeQ8DsNnUlGPuRytIuyQMj1haUlKwueLxDNF7ZOwczkEp3+7/
+        ZFYhi1FQqOU2Jz0b23Z9D8XpYVsEfmEXjiEiksHD8iz5xieWcG2Av13sJUgSLJaKIaf7tLPDbYPx
+        VzpjhrPSpznLAzeX0usuWB64QuuGvyogjtpki9VBH4RVU8Yuw74m9I6y5IDwhGktsopzn6u/ZbZB
+        f0XEilVJ7tVKj2wD98meI5b5dIRwoMaFjH1ice8HltkGOmfuBjWR57mTEULu2FB87tsRQm5tGOX3
+        JFkniLm1gNvd4FD59KJHBm23GwWrsoZlXo1smXTFocDJ2MOLdd1RET1AYYFqWiXixnsWH7Dkhyuo
+        kKO8bsdAHWzYou35ivC41RrVgna9ylK8VDUdZaAj7kSffysUH/uW6PvLJeDRzhCyDYYryV2BnTGP
+        O9Pdgb0XY5PdS83nYeuRQftLzUxOuRiWa6a4R5c6YtDGeEE/XlxctDln9qlTcuU3zTggyEwlOap2
+        j160PRKlaMmMfVjNyYkUD61CstTnvmyZ4LsT4dETBxyfrBqPAZ/Tt7yxgVIU0EZk5fVOGaBjU5U0
+        Yi6S17xIj0oCO9z2sxZVws8YHlGIFiMSgfiBNkAHAi8I7nU5HRBOQpVyT9KCI5R87pjiDtkGToRI
+        eV3Ije9EOqJSplEcklgaMYNncDgNp+fT6/Np+Pfl1Sz8MLuc/kSfpobw9nSfG+pTNzp/usstdcFF
+        0QUQPkEHe156OvCkJZkLHK3zgfPbQJkdELCepiQFImEvoE+e0Wq/LjiaBL9yWfIaJV+vC2jxgM/T
+        nVotkU2FnULjmhk8ZlD1DE19fdcDcqYjl2cmM6MaKJ7UUiu54InR47Yh1Y06rsVS7AykcnQrVDhx
+        YTBeCqVkJ3U6XaPL1RAtO701FZrFBR8aZM2rboZjN0TCK71dBqc6kMuj7jtLYL+kfM6awkTuIUZi
+        LkRhyLs4mlyVWAZS3Ejs7XQdtyB0bHsfKWG6z5B7DC/ryJ0RI5ec1GGgkGrkOtL/Ngxn0N5z/WD3
+        i22CK1TJ7f6iOF28u2NSxDuEJjfjCLVlR+zl6bEo9a5SN/G7Sv2uUr+r1E7np3vwgEpdcbOGSjvK
+        puMHcp+tH/8H9bwB25kbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:27 GMT
+      etag:
+      - W/"ce852c0809c59ca1a18f4c59fce50273"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54731BE:642931E:5ED66157
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2930'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QPU/DQAyG/8vNJJdE1fUaqQNSAVERuhQoRSi6D6dJleSiO6dSqPrfcZkZGFje
+        xX7sx/44Mw8Vy68ZOKpD4CfwoXF9lMYJu2G9s1A2ljqKVSFeuteuOL7PNqvH6Xlrpk2/bvd9cbIP
+        972ZFtl+t/5Sb4vxaXs3FrfLJQ0YfUtwjTiEnHM1NPGhwXrUsXEd9zC4wDtAFdB5iNpGRwgBSYWy
+        LB3W4K2iMiAnjoDfNZ0+gkGWn1moFe1L0lki5Rx0YlQ6tyKRmZLW2ExLkZkshUoKkVaSBHEagAi6
+        /d9tf/75Z5XL5fMbk7kG848BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:27 GMT
+      etag:
+      - W/"fd02a09a1532fcec4068465d42909f77"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473201:6429379:5ED66157
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2929'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/0140887eb0ca17d6082a8dcd2b862c21ef8661f8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S22rcMBD9laDn9VpWHNkxFJriJCSwa2iXFvtlGdtjW8Y3JDndbdh/74jtByTQ
+        FzEzZ86ZM4Pe2TTXeFQ1S9gu3cmfz0/Trs/DLH057w/VOesfTvv0gfJ6yPtvfX54vC3S/HeWvnbZ
+        8/e+SF9Vlubn/M/LqfiVh/s+PxV9+4VtmOmARHkQ8jiOsOQVBFEteSwgrqtalLEUlQiwiaUMmpgI
+        qx6I0Fm7mMT3YVHbVtluLbfVPPoal9n4I1owdtboDar0LBprfPcej7PtUNdAMFqfeL6F1vifmE79
+        LWqWvLMJRiQjPzroQN88vul5Inc4gnL+aC0qb9GVv7au6PxRAw13NMEF97j0uDgEYSLukiAq2GXD
+        5rLHyjr962GaMgKM7iVKGdbyPqjvIIyiStS3kYgkRLEEjhJCUrbnxSnTmFHZ/36oq6zxP2yIlqFj
+        kaE31EbNkxdsObka0RhondEnpY29+YcSQpFqVAWWmt0BrjnSn2tgMLhhGsE4iK2TUe1ECH0fCsCu
+        mgSndRg2bIHzMAORXHq5/AV452ALugIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:27 GMT
+      etag:
+      - W/"bb38a1fe12dbbc2f9f86a57a7e4cffd9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473248:64293CE:5ED66157
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2928'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:28 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473287:642941E:5ED66157
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2927'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTSJHzSZZA4vtYdvFFsgGKHrY7kWgJFqiLYkqSdl1hPz3vkNK
+        lmw4H3Z4zCWxafIZDskZDt92ItLJLLy+vQ3DDzfh2aSSKY+obXL35ff1ffFnkXz9+MB+/LVKquXm
+        +yK7ult8u/z+8O3TBJ1ZydHTcG2iSJqcq5QZprnBb/OmKKKuQ8nRaqTi54WIz6m7Dg4OqpVYMQPm
+        nBWan03kuuJqMmsnhcxEBVMHSLBF872+nt6E4e3lngub++XHzc/wj4b9qPP0a7GKF/+Ed1+Szd0i
+        +w9DGewxFTWqAD03ptazIHCN+teLTJi8iRvNVSIrwytzkcgyaILe2OfVpytAMtVh7MKhYQ9Xi47k
+        hgOng8Oe5KYs9ibj5mBHHh4zl0Uh12Due/FKs8EWQNtmYaLK3gYDoA3siYho9R5pkQS2/VSqHdwG
+        9A+nk3Aa26Z4eiqwG45J0hF7bAPFa2m5TawTJWojZHXydHcggEqVsUo8sDdBAdFg0URPnpgdDAhf
+        4TCfTHGj28CGa7KhZVM84WKF/XgbeQ8DsNnUlGPuRytIuyQMj1haUlKwueLxDNF7ZOwczkEp3+7/
+        ZFYhi1FQqOU2Jz0b23Z9D8XpYVsEfmEXjiEiksHD8iz5xieWcG2Av13sJUgSLJaKIaf7tLPDbYPx
+        VzpjhrPSpznLAzeX0usuWB64QuuGvyogjtpki9VBH4RVU8Yuw74m9I6y5IDwhGktsopzn6u/ZbZB
+        f0XEilVJ7tVKj2wD98meI5b5dIRwoMaFjH1ice8HltkGOmfuBjWR57mTEULu2FB87tsRQm5tGOX3
+        JFkniLm1gNvd4FD59KJHBm23GwWrsoZlXo1smXTFocDJ2MOLdd1RET1AYYFqWiXixnsWH7Dkhyuo
+        kKO8bsdAHWzYou35ivC41RrVgna9ylK8VDUdZaAj7kSffysUH/uW6PvLJeDRzhCyDYYryV2BnTGP
+        O9Pdgb0XY5PdS83nYeuRQftLzUxOuRiWa6a4R5c6YtDGeEE/XlxctDln9qlTcuU3zTggyEwlOap2
+        j160PRKlaMmMfVjNyYkUD61CstTnvmyZ4LsT4dETBxyfrBqPAZ/Tt7yxgVIU0EZk5fVOGaBjU5U0
+        Yi6S17xIj0oCO9z2sxZVws8YHlGIFiMSgfiBNkAHAi8I7nU5HRBOQpVyT9KCI5R87pjiDtkGToRI
+        eV3Ije9EOqJSplEcklgaMYNncDgNp+fT6/Np+Pfl1Sz8MLuc/kSfpobw9nSfG+pTNzp/usstdcFF
+        0QUQPkEHe156OvCkJZkLHK3zgfPbQJkdELCepiQFImEvoE+e0Wq/LjiaBL9yWfIaJV+vC2jxgM/T
+        nVotkU2FnULjmhk8ZlD1DE19fdcDcqYjl2cmM6MaKJ7UUiu54InR47Yh1Y06rsVS7AykcnQrVDhx
+        YTBeCqVkJ3U6XaPL1RAtO701FZrFBR8aZM2rboZjN0TCK71dBqc6kMuj7jtLYL+kfM6awkTuIUZi
+        LkRhyLs4mlyVWAZS3Ejs7XQdtyB0bHsfKWG6z5B7DC/ryJ0RI5ec1GGgkGrkOtL/Ngxn0N5z/WD3
+        i22CK1TJ7f6iOF28u2NSxDuEJjfjCLVlR+zl6bEo9a5SN/G7Sv2uUr+r1E7np3vwgEpdcbOGSjvK
+        puMHcp+tH/8H9bwB25kbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:28 GMT
+      etag:
+      - W/"ce852c0809c59ca1a18f4c59fce50273"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54732C1:6429466:5ED66158
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2926'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/fb7ae796e664d691d5a477c2d37276a786a0e6a4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXaviMBD9K5JntWnapqawsA96Lz5YkXW56LLItE1trv2QJL2g4n/fCSLsvim4
+        LyGZ6eScOXPSCzEVkISUWQwyFlxyHhZc+EUEYRznrAhiFnOIJxyo5BCSIWm7Qu5UgUWL6YavmLDZ
+        R00Xn5twOZ2f0nV+WjZblbK3Oj0f2Ha9Yen7ii3Xb4f0Y0bTc/G5aFbn9DwP0mYWLKfbavH+k23W
+        q294ea9rvLiy9mgSz4OjGu+VrfpsnHeNp+WxM14jLRjbaTmqVTay0ljjuXW362wldQGYltbDOg+L
+        GoXpJ7qrbFPv/mXxF4MHsW+4z8BCb6tOk+RCWmgkSvCjggr0YPaluxZ1kQ0opwxOC8Nj6cLf9y7o
+        lMEPsG1XxiijI8pHlK39MGFR4odbch2SGyMr/yOE1RIZXO6GAlpSkTM/9/O4ZJzGQRgXhWCijCZl
+        HoRRHGVRmb985o4GTvxReNSmkcbA3qk3b5VVUA+ch46QHzA6uCmHNI+gZWsNSX7dewyDcFIGES/8
+        LGM+DTJeBrgXjAkeRlQWQuBzEq/v8e7rJwi80tcPw15/D8mX1KpUOViFRkZ73M4S/x8l1EYOiZZg
+        XIr0rVH7FjND4jZge41Dafu6duKf6g6wyB2v1z9dlU9QtwQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:28 GMT
+      etag:
+      - W/"b778c369ebafc704ae23fdea7922ce31"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547331F:64294D2:5ED66158
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2925'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/datapackage.json?ref=fb7ae796e664d691d5a477c2d37276a786a0e6a4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbUsjMRDHv8u+1mZ3u01uCyJa7koL56GCbkuh5GG2m5pNlk1qqeJ3N9GC2rsX
+        9QG5N8mQycz8mPnPfaRpDVE/EtTRhvIbuoDO0hodHUQNddW/Pbai3hH3WIxjwjnGaZrGGCc47oos
+        w4IkAGWPZyTJ0yT1qay880Xy/CBatcqHVs41to8QbWRnIV21Yh1uatRCYyyqwVHrTAuHSrJDB9ZZ
+        FM753LgK2kBqwSFutAPtfbvoxy2URyUjFEiOAeNM4DwRPZoRwlPRJSnBlPzANAZMMw9XuVrN33K9
+        YtqThinD0L5F/0L2FL7kDsRnmuOzoYBk0TumJMxaK0PFDkdL19shrSy027Y/zWvP3nymLW7TBHmW
+        UoFv0ra4f4C1WYwG49XkOlGjpbfrPKbDq810+CueFGdKDEZ2dPL0ZzMtzm5FMV5Oi9/yjzxlMz2Q
+        J95zSp7vYI/Xk+LCPGe6qMTw5y0r1EvkZW/JuxMZ/s+0j8yDVZw3+SxsCmhuhNQLz8W8NnFQ1VxJ
+        fWOj/n1kQZX/m+a9Pr4I6UNKCyv3qv63r9vDwyMei8Wl+QQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:29 GMT
+      etag:
+      - W/"05b0607cc662220661603d446d71eef5c4719212"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547335F:6429525:5ED66158
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2924'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:29 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54733C5:642958C:5ED66159
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2923'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTSJHzSZZA4vtYdvFFsgGKHrY7kWgJFqiLYkqSdl1hPz3vkNK
+        lmw4H3Z4zCWxafIZDskZDt92ItLJLLy+vQ3DDzfh2aSSKY+obXL35ff1ffFnkXz9+MB+/LVKquXm
+        +yK7ult8u/z+8O3TBJ1ZydHTcG2iSJqcq5QZprnBb/OmKKKuQ8nRaqTi54WIz6m7Dg4OqpVYMQPm
+        nBWan03kuuJqMmsnhcxEBVMHSLBF872+nt6E4e3lngub++XHzc/wj4b9qPP0a7GKF/+Ed1+Szd0i
+        +w9DGewxFTWqAD03ptazIHCN+teLTJi8iRvNVSIrwytzkcgyaILe2OfVpytAMtVh7MKhYQ9Xi47k
+        hgOng8Oe5KYs9ibj5mBHHh4zl0Uh12Due/FKs8EWQNtmYaLK3gYDoA3siYho9R5pkQS2/VSqHdwG
+        9A+nk3Aa26Z4eiqwG45J0hF7bAPFa2m5TawTJWojZHXydHcggEqVsUo8sDdBAdFg0URPnpgdDAhf
+        4TCfTHGj28CGa7KhZVM84WKF/XgbeQ8DsNnUlGPuRytIuyQMj1haUlKwueLxDNF7ZOwczkEp3+7/
+        ZFYhi1FQqOU2Jz0b23Z9D8XpYVsEfmEXjiEiksHD8iz5xieWcG2Av13sJUgSLJaKIaf7tLPDbYPx
+        VzpjhrPSpznLAzeX0usuWB64QuuGvyogjtpki9VBH4RVU8Yuw74m9I6y5IDwhGktsopzn6u/ZbZB
+        f0XEilVJ7tVKj2wD98meI5b5dIRwoMaFjH1ice8HltkGOmfuBjWR57mTEULu2FB87tsRQm5tGOX3
+        JFkniLm1gNvd4FD59KJHBm23GwWrsoZlXo1smXTFocDJ2MOLdd1RET1AYYFqWiXixnsWH7Dkhyuo
+        kKO8bsdAHWzYou35ivC41RrVgna9ylK8VDUdZaAj7kSffysUH/uW6PvLJeDRzhCyDYYryV2BnTGP
+        O9Pdgb0XY5PdS83nYeuRQftLzUxOuRiWa6a4R5c6YtDGeEE/XlxctDln9qlTcuU3zTggyEwlOap2
+        j160PRKlaMmMfVjNyYkUD61CstTnvmyZ4LsT4dETBxyfrBqPAZ/Tt7yxgVIU0EZk5fVOGaBjU5U0
+        Yi6S17xIj0oCO9z2sxZVws8YHlGIFiMSgfiBNkAHAi8I7nU5HRBOQpVyT9KCI5R87pjiDtkGToRI
+        eV3Ije9EOqJSplEcklgaMYNncDgNp+fT6/Np+Pfl1Sz8MLuc/kSfpobw9nSfG+pTNzp/usstdcFF
+        0QUQPkEHe156OvCkJZkLHK3zgfPbQJkdELCepiQFImEvoE+e0Wq/LjiaBL9yWfIaJV+vC2jxgM/T
+        nVotkU2FnULjmhk8ZlD1DE19fdcDcqYjl2cmM6MaKJ7UUiu54InR47Yh1Y06rsVS7AykcnQrVDhx
+        YTBeCqVkJ3U6XaPL1RAtO701FZrFBR8aZM2rboZjN0TCK71dBqc6kMuj7jtLYL+kfM6awkTuIUZi
+        LkRhyLs4mlyVWAZS3Ejs7XQdtyB0bHsfKWG6z5B7DC/ryJ0RI5ec1GGgkGrkOtL/Ngxn0N5z/WD3
+        i22CK1TJ7f6iOF28u2NSxDuEJjfjCLVlR+zl6bEo9a5SN/G7Sv2uUr+r1E7np3vwgEpdcbOGSjvK
+        puMHcp+tH/8H9bwB25kbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:29 GMT
+      etag:
+      - W/"ce852c0809c59ca1a18f4c59fce50273"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473405:64295F7:5ED66159
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2922'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:25:30 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473480:642968A:5ED66159
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2921'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:30 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:547352A:6429761:5ED6615A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2920'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyj4gEJmbq4PtDftDGWm04frvXhkW7FFbMuV5KTBw3e//1p2
+        7KQBQtAjL5Ao0m9Xq93VapuJTCaz4Or6Oggup9cnk1IlIqSxyd3tr6v7/I88/nrzyL/9tYzLxfrP
+        h/Ti7uH387vb9PMEk3khMNMKY8OwWCfcciMsfpjXeR52vxYCo1ZpcZrL6JTmGvb/FZWWS25Bm/Pc
+        iJOJWpVCT2bNJFepLCFkDwaCSNOrq+nPQXB9vqP8+n5xs/4e/Fbzb1WWfM2X0cM/wd1tvL57SP/D
+        Ug55XIe1zkHPrK3MjDE3aD6dpdJmdVQboWNVWlHas1gVrGa9sC/LzxeApLrDtCbDwA6ukh3JLQfO
+        sP07yWyR7yjjdGhX7l8zV3muVmDu7uJAsWwDoDNrYbJM3wcDoGHKZgKmxXafyEgSZ34stV3cMPoH
+        vyScwbFpkRwL7JZDSXKxp4ZpUamWW0cm1rKyUpVHq7sFAVTplJfykb8LCogBixQ9WrF2MSBiCWc+
+        muJWN6wN13hNZtMiFnKJ83gfeQcDsF1XlF3uRxakU5JWhDwpKCm0ueLpBNH7xtjZk4ASsTn8yaxE
+        /qKI0ItNQnoxsFvj7gvSPYKI+or9D8YhgAGDVRZi7Y1JrIbhbxdvMRIDj5TmSOLehGxBGzb+Sk5l
+        BS+8yWphgGZK+bN8CwNUGlOLg3z/8FNtmYb1wVbWReQy6SEhdrgYR8MeuDEyLYXwZvENsGH9JRBp
+        XsaZPxE9r2HuU+s1PPW2BWIBGeUq8sbEhc5aYMNMxt3VaEOfWpME4m0J0GLudQvE2wiw2qPftOoT
+        cIPHbW3hQt7073ms6U4g52Va89SfhA2QLiuUKil/fLVCOzxmByLwVJpqGdV+E/PApB24ogj5x98R
+        DMhBQFt1vVzSvcFIo0quNVNRyNdqnsPpHW4rxDyLoDjYFUPfXy/d3rYN4jVsuF/cZdZJ8nUa3W3W
+        6z+W172tvLlWz2PNTxW3GWVYiK24Fr420+FYE+Gp+3R2dtZkgrfPkkJoj1nE0YDlOs5QXvvSv+l5
+        qBwLbtvnz5zUT/AcyhVPvJ3FBgi4cwFfe3C0sR9VqNe9Kd7CxvRC5uhaqNLfHTEQx3JKZeVcxoe8
+        FQ8P8y1o88XIMhYnHM8bRIWVsUSc4MlOHoAiX/izoqNhe+gRuWdiLhAy3k5JC8drmOsKJKLK1dpr
+        hhwhKZFogQZVEnKLR2kwDaan06vTafD3+cUsuJhdXnzHnLpCD+yZOZez6Q3NqWqTPTsl+ERTkP67
+        WMEndKVebgTtvjGp4wSIMdkA+WVAzPb0kp5BxDmcfidqj9NluXu3vw2D7WSqEBXqtP5xbuQjPk+3
+        aqxY1SVOB4MrbvHYQM0yDPV1WQ/IuAldJpnMrK7Rc6SRSqsHEVszHhsy2WjiSi7k1kKqITfdAvfI
+        H4QXUmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3GDK4BQFseTd8yQfslEXNe5zZ0byVq
+        p6IniwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qFoP4sUMgqahWaf2sO12svsH6x
+        +6UdwlaoGtv+RQu6TrfXJAhwtHqcxiGKw47YN4jHbaGPPnEdffSJP/rEH31i12mn629Pn7gUdoWG
+        6Sibjp+3fbZ++gGOJUtWFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:30 GMT
+      etag:
+      - W/"2acfb6d6e22ccf21e9c545f380f6a2e2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:09 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:5473575:64297C5:5ED6615A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2919'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:25:31 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C995:2668B:54735F1:6429832:5ED6615A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2918'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_delete_no_package.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_delete_no_package.yaml
@@ -1,0 +1,1938 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:43 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE3BA2:6DC8576:5ED66167
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2893'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:43 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE3BEA:6DC85B0:5ED66167
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2892'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822702,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI3MDI=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:25:43Z","updated_at":"2020-06-02T14:25:43Z","pushed_at":"2020-06-02T14:25:45Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:45 GMT
+      etag:
+      - '"867d68bcd1167daad1f7cafd22891d2e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE3C3F:6DC8618:5ED66167
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2891'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"7e20ebbcd97d44df390773a4b909524aef75e14d","node_id":"MDY6Q29tbWl0MjY4ODIyNzAyOjdlMjBlYmJjZDk3ZDQ0ZGYzOTA3NzNhNGI5MDk1MjRhZWY3NWUxNGQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7e20ebbcd97d44df390773a4b909524aef75e14d","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/7e20ebbcd97d44df390773a4b909524aef75e14d","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:45Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:45Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:46 GMT
+      etag:
+      - '"239e74f23c06487b431c64648df76fb3"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE3E7A:6DC88D4:5ED66169
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2890'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XXW/aMBT9K1WeaRNCIAVp2oeYqk6Cqlu3DqYJOckNMXXszHZoAfHfd29I18LD
+        1lTdW19QYuccn/vpy8aRLAdn4OTMWNBOy4lVnnPrDDaOyRhuhOB7EEVx0g+TIEjSTt8Lww4Lor7X
+        7/oBgzTsQjtIECpVAjOeIGg0nPQu/b6NroU3WkyCi+H5arx+v7pYJGK0+CAm+afFdHjTmQ4vvenZ
+        ZH1x9b4zXo+z8dl5dzS8aY8Wn7Pp9aQzvv56Nz67fLOni5U2U5oU1tq/ZCxj+ujjUiuJX0LOuEAR
+        qB+XT4CW381p8QSNww8SZslk3/O9Y6937PlX7WDgdwdBd+ps7z1A3vhvR+RgDJuTiHPJLWeCr+EI
+        ZbEjDYUy3Cq9QqFWA35zH4l26vWT1O+E4akfhO2gewqJ7/dZGEXBaRzizmkSdsBDYKnJAZm1hRm4
+        Liv4yZzbrIzIAW51hJuDxZArDceCR8cWjDUu/c5m+YqUGLAuglzSYNwnn43+e8HDd8lo3AZJSBCQ
+        dharUmIaey1nCZqnPGaWY3qgN3fvgHmaMmGg5WhghracUho+l7jTcuiB2VKj/2UpRMsp2EoohiB6
+        3b6cmc8wMbO5mO17+VF4nxLY3aHPcKs5OPfZqdXUbLeOq8HYPDQAoeacAmeyqspxj9pPr9vtdfbb
+        0WXv2/exiBeT9vhqsiaOJea4PrSmWjR+XS2lAR0raTGdqsIp3Yr57fJNgAxzXXNUHe9fRUdcxn3Q
+        +fcYPnyXKiHULWIPpe7X9B69+weEqnbPXM6bEyBo4yqbAfoJ5W/JaI59oglTBdhgJ8HOwhOiMOhi
+        DUkTkhqCYm4l6thULaziKiMTa15QaTeStQdEIqXnTPJ11SMaESGQUrLqqU1MqgAIhCVmVyPkDrFx
+        C82XLF6RGzTEwJfo0+ZsB1Aks6uCLqavGHHyMLcwY0lOZVa1y8ML8rUE62v1tQSbVc5rCe4uLWxm
+        e9X7pBIsmKa+4Qx+/MSCnAkub/AFJ0UQ6UtMfpFmMs5w8Pvzv4AurEfMDQcOmiLvuVBwoZWF2D6a
+        weqVekQDySKxN6H9KjldGngT2NLMUFq8MxhkqnQM1cgnsP2RRpWm6MTq5r6rffRwJp7w9z799PH4
+        wEnYkSuryIbtb440kB1ZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:46 GMT
+      etag:
+      - W/"4562edecaf107bee5cb3a77dd01cae75"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE3FEF:6DC8A84:5ED6616A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2889'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:47 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4047:6DC8AF6:5ED6616A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2888'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7e20ebbcd97d44df390773a4b909524aef75e14d
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY7aMBD9FeQzEMdx1iRSpW5FhahEEO1WCKoKOXhCzDoJsp1VAfHvHZce2tuu
+        1F6seF5m3ps34ytxtSQ5EcAolOVeZUJxrqoko0IkkpcZzVLGJVQihZgrMiRtp2CnFSYtppuHFct8
+        uTZ0cdzw5XR+Li6P5+VRmcXxg9k0n47b6XOyna7odra5LJ8ek+JS1MVsni6mz/Hi+LnerjdJsf76
+        o5it3mHx3hosXHt/cnkUyZMeH7Sv+3K875rIwqlzUQNeOt9ZGBldjjw476Jw7nbNWUnEwEeYFGFG
+        oxF7Q2u1b8zubwl/0L+G+E76Fk7Z+7qzJL+SVjaAzX+pZS3t4OOL7Vp0BBqpgyc4JwyPIYTfH0Iw
+        eII/YM8hjVFGR/RhRNlTzHOW5jzdktuQ3BV5+I8U3gIquP5epbiimapYIsSEcRHzdAKKsUyKsuST
+        vUBkokQC9N9OO2hw0au50ZgGnJOHYN281V5Loy8wCAs0+LVnGlfsjBpP0kLrHcm/fR+SF7C60nvp
+        Nc4GO77fAR9DJY2DIbEgXYBI3zp9aBEZkvAhfW+Rqu2NCSXPppOYFK6320/lJHX/hAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:47 GMT
+      etag:
+      - W/"5008bcf3f5728ea3b76f5a4f095d7d4a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE40EE:6DC8B9E:5ED6616B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2887'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["7e20ebbcd97d44df390773a4b909524aef75e14d"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"5191a57d8d5bf20f92613aa0f70c01330104d7a5","node_id":"MDY6Q29tbWl0MjY4ODIyNzAyOjUxOTFhNTdkOGQ1YmYyMGY5MjYxM2FhMGY3MGMwMTMzMDEwNGQ3YTU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5191a57d8d5bf20f92613aa0f70c01330104d7a5","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5191a57d8d5bf20f92613aa0f70c01330104d7a5","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:47Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:47Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"7e20ebbcd97d44df390773a4b909524aef75e14d","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7e20ebbcd97d44df390773a4b909524aef75e14d","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/7e20ebbcd97d44df390773a4b909524aef75e14d"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:47 GMT
+      etag:
+      - '"a10ae19838b0e87be18a8909c350259e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5191a57d8d5bf20f92613aa0f70c01330104d7a5
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4137:6DC8C23:5ED6616B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2886'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vnglMwjZKtEioFyWVqqrJEdnypjeI4sg8kg/jvPdSxS4cub3n3
+        3fuuLELP6nsmbkGZxL1KCJE9sDEYaJ2hVq7l07tvvDx+iv16m98uz3k/7obDKM9q09jDqzzrj5eL
+        2TSZwFMcCLKIU6o5V5Obfzm0Jz3vgucRpkAjgDQTIswGp2cICRO/Z9v6bBR1gJwguv7tFfQROmT1
+        lSWraKiERQFad6YqjRCmX1ZFWS6V0FVRrRZCQV+u4FEYMsM8ARHk4R3+r+nPz8T/bHO7fQPBggID
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:48 GMT
+      etag:
+      - W/"99aa310c4e8be5f2b51ac88e6c09c289"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE41E0:6DC8CE3:5ED6616B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2885'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "5191a57d8d5bf20f92613aa0f70c01330104d7a5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngh1CSMmGhEpbyWVqqrJEdnypjeI4sg+kgPjvPdSxS4cub3n3
+        3fuuLELHqnsmbkGZxL1KCJE9sCEYaJyhVm7l6t3XXh4/l/vty/R22Uz74bU/DPKsdrU9PMuz/ni6
+        mF09EXiKPUEWcUwV52p08y+H9qTnbfA8whhoBJBmQoRZ7/QMIWHi92waPxlFHSAniK5/ewV9hBZZ
+        dWXJKhoqsnWmitI8mkJ3C9GtF6ssV0p0pWhFluciE0tTqoLMcBqBCPLwDv/X9Odn4n+2ud2+ARZI
+        X119AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:48 GMT
+      etag:
+      - W/"49e99d4800f194f3cf2c74780ea15cbc"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4228:6DC8D3B:5ED6616C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2884'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:49 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4318:6DC8E61:5ED6616C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2883'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4Suk6WpgaJ7yFZ0QFZg2EPXF4GSaImxJGokZc8R8t33P1Ky
+        ZM9NHIePeUlsmvzd8Xh3PF47kelkPru+uZnN3k9nZ5NKpSKiscnd7a/rr8XvRfL5wwP/9ucqqZab
+        P+6zq7v7L5d3t18+TjCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRbnhYzPaa5h/19Ra7niFrQF
+        L4w4m6h1JfRk3k4KlckKQg5gIIg0vb6evp/Nbt7tKb/5uvyw+T77reHf6jz9XKzi+79nd7fJ5u4+
+        +xdLOeRxHTW6AD23tjZzxvygubzIpM2buDFCJ6qyorIXiSpZw3phn1YfrwDJdIdxJsPAHq6WHckv
+        B86wwzvJbVnsKeN1cCsPr1moolBrMPd3caRYtgXQmTmYrLLXwQBombK5gGmx3UcyksSZn0p1i1tG
+        /+CXhDM4Ni3SU4HdcihJLvbYMi1q5bhNbBItaytVdbK6OxBAlc54JR/4q6CAGLBI0ZMVc4sBESs4
+        88kUv7plLlyTDZlNi0TIFc7jdeQ9DMB2U1N2+TqyIJ2StCLiaUlJweWKxzNE7wtj50ACSsX28Cfz
+        CvmLIkIvtwnpycB2xj0UpAcEEfUZ+x+NQwADBqssxSYYk1gtw98u3hIkBh4rzZHEgwnZgbZs/JWc
+        ygpeBpPlYIDmSoWzvIMBKo1pxFG+f/ypOqZhfbBVTRn7THpMiB0vxtOwB26MzCohgll8C2xZfwnE
+        mldJHk5Ez2uZ/+S8hmfBtkAsIONCxcGYuNCZA7bM5NxfjTYKqTVJIN6OAC0WQbdAvK0AqwP6jVOf
+        gFs8bmsLFwqmf89jbXcCBa+yhmfhJGyBdFmhVMn4w7MV2vExOxCBp9JUy7gJm5gHJu3AF0XIP+GO
+        YEAOAlzV9XRJ9wIjjSo5Z6aylM/VPMfTO9xOiAUWQXGwL4a+P1+6vWwbxGvZcL/4y6yTFOo0utus
+        138sr3tbBXOtnsfan2puc8qwEFtzLUJtpsOxNsZT9/Hi4qLNBXfPklLogFnE04DlOslRXofSv+15
+        qBxLbt3zZ0Hqp3gOFYqnwc5iCwTcu0CoPXja2I9q1OvBFHewMb2UBboWqgp3RwzEsZxKWbmQyTFv
+        xePDfAfafjKySsQZx/MGUWFlIhEneLKTB6DIF+Gs6GnYHnpE/plYCIRMsFPSwvNa5rsCqagLtQma
+        IUdISiRaoEGVRtziUTqbzqbn0+vz6eyvd1fz2c/zq8vvmNPU6IH9eM4Nzakbkz8zBem/ixV8Qlfq
+        6UbQ/huTOk6QY0w+QH4ZEPMDvaQfIJICTr8Xtafpstq/21+GwXZyVYoadVr/ODfyAZ+nOzVWopoK
+        p4PBNbd4bKBmGYb6uqwH5NxEPpNM5lY36DnSSK3VvUisGY8NmWw0cS2Xcmch1ZDbboF/5A/CS6m1
+        6pqNvrnQ5WG0DbuOZyoNjwsxDKhaVJ2G423IRFRmawbfAKAtj6bvmMB9ScWCN4WN/FuJ2qnoyaLB
+        CncUuoQZqOdF7daus+INQq7a75Gyov+MhosVZR1577BqKag/CxSyilpH5p+Gw/XcBdYv9r+4IWyF
+        qrHdX7Sg63R3TYoAR6vHaxyhOOyIfYN43BZ66xM38Vuf+K1P/NYn9p12uv4O9IkrYddomI6y6fh5
+        22frx/8ANl9iExUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:49 GMT
+      etag:
+      - W/"4cb7c2aa1602845e4706b1a3a9caaed4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4366:6DC8EBF:5ED6616D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2882'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:49 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4401:6DC8F80:5ED6616D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2881'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4Suk6WpgaJ7yFZ0QFZg2EPXF4GSaImxJGokZc8R8t33P1Ky
+        ZM9NHIePeUlsmvzd8Xh3PF47kelkPru+uZnN3k9nZ5NKpSKiscnd7a/rr8XvRfL5wwP/9ucqqZab
+        P+6zq7v7L5d3t18+TjCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRbnhYzPaa5h/19Ra7niFrQF
+        L4w4m6h1JfRk3k4KlckKQg5gIIg0vb6evp/Nbt7tKb/5uvyw+T77reHf6jz9XKzi+79nd7fJ5u4+
+        +xdLOeRxHTW6AD23tjZzxvygubzIpM2buDFCJ6qyorIXiSpZw3phn1YfrwDJdIdxJsPAHq6WHckv
+        B86wwzvJbVnsKeN1cCsPr1moolBrMPd3caRYtgXQmTmYrLLXwQBombK5gGmx3UcyksSZn0p1i1tG
+        /+CXhDM4Ni3SU4HdcihJLvbYMi1q5bhNbBItaytVdbK6OxBAlc54JR/4q6CAGLBI0ZMVc4sBESs4
+        88kUv7plLlyTDZlNi0TIFc7jdeQ9DMB2U1N2+TqyIJ2StCLiaUlJweWKxzNE7wtj50ACSsX28Cfz
+        CvmLIkIvtwnpycB2xj0UpAcEEfUZ+x+NQwADBqssxSYYk1gtw98u3hIkBh4rzZHEgwnZgbZs/JWc
+        ygpeBpPlYIDmSoWzvIMBKo1pxFG+f/ypOqZhfbBVTRn7THpMiB0vxtOwB26MzCohgll8C2xZfwnE
+        mldJHk5Ez2uZ/+S8hmfBtkAsIONCxcGYuNCZA7bM5NxfjTYKqTVJIN6OAC0WQbdAvK0AqwP6jVOf
+        gFs8bmsLFwqmf89jbXcCBa+yhmfhJGyBdFmhVMn4w7MV2vExOxCBp9JUy7gJm5gHJu3AF0XIP+GO
+        YEAOAlzV9XRJ9wIjjSo5Z6aylM/VPMfTO9xOiAUWQXGwL4a+P1+6vWwbxGvZcL/4y6yTFOo0utus
+        138sr3tbBXOtnsfan2puc8qwEFtzLUJtpsOxNsZT9/Hi4qLNBXfPklLogFnE04DlOslRXofSv+15
+        qBxLbt3zZ0Hqp3gOFYqnwc5iCwTcu0CoPXja2I9q1OvBFHewMb2UBboWqgp3RwzEsZxKWbmQyTFv
+        xePDfAfafjKySsQZx/MGUWFlIhEneLKTB6DIF+Gs6GnYHnpE/plYCIRMsFPSwvNa5rsCqagLtQma
+        IUdISiRaoEGVRtziUTqbzqbn0+vz6eyvd1fz2c/zq8vvmNPU6IH9eM4Nzakbkz8zBem/ixV8Qlfq
+        6UbQ/huTOk6QY0w+QH4ZEPMDvaQfIJICTr8Xtafpstq/21+GwXZyVYoadVr/ODfyAZ+nOzVWopoK
+        p4PBNbd4bKBmGYb6uqwH5NxEPpNM5lY36DnSSK3VvUisGY8NmWw0cS2Xcmch1ZDbboF/5A/CS6m1
+        6pqNvrnQ5WG0DbuOZyoNjwsxDKhaVJ2G423IRFRmawbfAKAtj6bvmMB9ScWCN4WN/FuJ2qnoyaLB
+        CncUuoQZqOdF7daus+INQq7a75Gyov+MhosVZR1577BqKag/CxSyilpH5p+Gw/XcBdYv9r+4IWyF
+        qrHdX7Sg63R3TYoAR6vHaxyhOOyIfYN43BZ66xM38Vuf+K1P/NYn9p12uv4O9IkrYddomI6y6fh5
+        22frx/8ANl9iExUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:50 GMT
+      etag:
+      - W/"4cb7c2aa1602845e4706b1a3a9caaed4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE445C:6DC8FDE:5ED6616D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2880'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5191a57d8d5bf20f92613aa0f70c01330104d7a5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU72vbMBD9V4I+J7Fsy1ZtGGyQNvSDE8JShjdGOFvnWK1/BEtpm4b87z2RbWzf
+        Usi+COlOp3fv3UNHZmpgKYv8xIdIqhsVFVXAqySI/RCAV5KX3A9D7nOhJERszLpe4UYrKspmebwK
+        Elt8a3j2mIvl7P6wePtyWD4+vC7Xd/VirZ6W85Wft/khm+cR3XnNgrua9mE2z16ydfaWzW5fFvNV
+        mK8fPtHj+6Ghh2trdyb1PNjp6Vbbel9My771Btz1xmvRgrH9gJNGFxOLxhrPrZtNe1BAObQeFXlU
+        0WrKfYBabdtm828Lf8FfAnwG/Qgm7G3dDyw9sg5aJPJfa6hhGN0+D31HimAL2mlCc6LwFF3489YF
+        nSZ0gTi7soAHfMLjCQ/WvkiDKBXyOzuN2bkji/8Rwg5IHRx/WUlKvIlDUYmw4GFZVXGihBRRyQuU
+        iFUYFFhCETsrXXHargfjXYxNwrRoDGyddPedthqakXPPDsonio7OslGPOxiws4alP/4QxIBjUZQq
+        kUoIVYUJlzIEUSQ8iQIBWMkIfaGuS/C3neXl6Fez88WYp59j9oyDrnQJVpN/yRXnM9KHUUFjcMwG
+        BONSbN8Zve0oM2ZuA3Y/0Di6fdM42Q9ND1TkjqfTO411YmWoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:50 GMT
+      etag:
+      - W/"a10ae19838b0e87be18a8909c350259e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE44A8:6DC903D:5ED6616E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2879'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5191a57d8d5bf20f92613aa0f70c01330104d7a5
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5Ec138UGKMxW3FgHetezAmFIFlnW6ksGUtpyEq/+85tYF22
+        F1k3xl5IHDrpnh/PnR4CwzsIZoHknve8uuMNTDbOmuAs6Llvf51xLcdEBmlWScZlyoBNp5GgWRKH
+        aRJLCQmkMWWUZSKhWMqpryjCkrNgO2h82nrfuxkhvFeTRvl2KyaV7cgAvXWkA8+dtwOcayXOPTjv
+        yLiv191+xHTgSWWNB4OJY+63A9Rv4pCFPE5lJmNRT2nNpkkYcU7rlFY0jCIa0guZ8hjJWt/p9Y9Q
+        L4BOQRHaCnKq4k+8iIB6RwSvtgVLkZHHkd9ojrQ7oy2XRxAD3x16s3UwHAx/atMprvyJIX7fjyNZ
+        Kw1oz0EZD2BnmyJfbJdfQl1sMO7CeHX1ni7Lay3zwhWXT/n9qry+l+Visyo/qI9qLnJ12dyaIp+n
+        Y1Tk41rsluWNfa5y08qrd/ei1N9ffo43VbRUz/fn7NaMUfmpxwiRwFRWKtMgk8BxTC7wbK2VuXPB
+        7CFwoOv/asZxKv4Gz6uGa/xfL8T/7d96fPwG6/K6pOAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:50 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE44FA:6DC9098:5ED6616E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2878'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "5191a57d8d5bf20f92613aa0f70c01330104d7a5"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyNzAyOjRjOTY0NDg2M2MwZDQzOWU0OTA2NTJkMGZjNDIwNjM3NDgzYWUyYTM=","sha":"4c9644863c0d439e490652d0fc420637483ae2a3","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/4c9644863c0d439e490652d0fc420637483ae2a3","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:50Z"},"object":{"sha":"5191a57d8d5bf20f92613aa0f70c01330104d7a5","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5191a57d8d5bf20f92613aa0f70c01330104d7a5"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '692'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:51 GMT
+      etag:
+      - '"8d5d10e4b14bfff3a164cc1eb779fad4"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/4c9644863c0d439e490652d0fc420637483ae2a3
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE454E:6DC9111:5ED6616E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2877'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "4c9644863c0d439e490652d0fc420637483ae2a3", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyNzAyOnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"4c9644863c0d439e490652d0fc420637483ae2a3","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/4c9644863c0d439e490652d0fc420637483ae2a3"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:51 GMT
+      etag:
+      - '"d15af1fa94f9ba0c5c1affc4dac20499"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE45E8:6DC91C0:5ED6616F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2876'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:52 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE46F4:6DC9301:5ED6616F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2875'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4746:6DC9364:5ED66170
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2874'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:52 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE47E7:6DC9420:5ED66170
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2873'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7bOBCG38XXTSJHSdPUQNEe0i26QDbAYg/dXgRKoiXGkqglKXsdIe/ef0jJ
+        kr1u4jg85pLYNPnNcDgzHE47EelkFl5dX4fh+2l4MqlkyiMam9zefFndFX8UydcPD+z7X8ukWqz/
+        vM8ub++/XdzefPs4wWRWcsw0XJsoKtcpM0xzgx/mTVFE3a8lx6iRip8WIj6luTr4/4paiSUzoM1Z
+        ofnJRK4qriazdlLITFQQsgcDQaTp1dX0fRhen+8ov75bfFj/CH9v2Pc6T78Wy/j+n/D2Jlnf3mf/
+        YSmDPKaiRhWg58bUehYEblBfnGXC5E3caK4SWRlembNElkET9MI+LT9eApKpDmNNhoEdXC06klsO
+        nA727yQ3ZbGjjNPBrty/Zi6LQq7A3N3FgWKDDYDOzMJElb0OBkAbSJNzmBbbfSQjCZz5sVS7uA3o
+        H/yScBrHpnh6LLBbDiXJxR7bQPFaWm4T60SJ2ghZHa3uFgRQqTJWiQf2KiggGixS9GjF7GJA+BLO
+        fDTFrW4DG67JmsymeMLFEufxOvIOBmCzrim73I0sSKckDI9YWlJSsLni8QTR+8LY2ZOAUr45/Mms
+        Qv6iiFCLTUJ6MrCtcfcF6R5BRH3G/gfjEMCAwSoLvvbGJFYb4G8XbwkSA4ulYkji3oRsQdtg/JWc
+        ynBWepNlYYDmUvqzvIUBKrRu+EG+f/ipWqYO+mCrmjJ2mfSQEDtcjKNhD0xrkVWce7P4BtgG/SUQ
+        K1YluT8RPa8N3CfrNSzztgViARkXMvbGxIUeWGAb6Jy5q9FEPrUmCcTbEqD43OsWiLcRYJRHv7Hq
+        E3CDx21t4ELe9O95QdudQMGqrGGZPwkbIF1WKFUy9vBshXZ4zA5E4Kk0VSJu/CbmgUk7cEUR8o+/
+        IxiQgwBbdT1d0r3ASKNKzpqpLMVzNc/h9A63FWKeRVAc7Iqh78+Xbi/bBvHaYLhf3GXWSfJ1Gt1t
+        1us/lte9rby5Vs8L2t9qZnLKsBBbM8V9babDBW2Mp+7j2dlZm3NmnyUlVx6ziKMBy1SSo7z2pX/b
+        81A5lszY58+c1E/xHCokS72dxQYIuHMBX3twtLEf1ajXvSluYWN6KQp0LWTl744YiGM5lTRiLpJD
+        3oqHh/kWtP2kRZXwE4bnDaLCiEQgTvBkJw9Akc/9WdHRsD30iNwzseAIGW+npLjjtYHrCqS8LuTa
+        a4YcISmRKI4GVRoxg0dpOA2np9Or02n49/nlLHw3u7z4gTlNjR7YL+e8O6c5daPzZ6Yg/Xexgk/o
+        Sj3dCNp9Y1LHCXK0zgfI5wEx29NL+gUiKeD0O1F7nC7L3bv9ZRhsJ5clr1Gn9Y9zLR7webpVYyWy
+        qXA6GFwxg8cGapZhqK/LekDOdOQyyWRmVIOeI43USt7zxOjx2JDJRhNXYiG2FlINuekWuEf+ILwU
+        Ssmu2eiaC10eRtuw63imQrO44MOArHnVaTjehkh4pTdmcA0A2vJo+pYJ7JeUz1lTmMi9laidip4s
+        GqxwR65KmIF6XtRu7TorziDkqv0eKSu6z2i4GF7WkfMOIxec+rNAIavIVaT/bRhcz15g/WL3ix3C
+        Vqga2/5FcbpOt9ekCHC0epzGEYrDjtg3iMdtobc+cRO/9Ynf+sRvfWLXaafrb0+fuOJmhYbpKJuO
+        n7d9tn78CYtJyHIVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:53 GMT
+      etag:
+      - W/"00a3fef00f658bdb78d0909f5a8eb348"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:51 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE483E:6DC9492:5ED66170
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2872'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:25:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C999:160FE:5CE4895:6DC94F6:5ED66171
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2871'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_delete_no_tag.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_delete_no_tag.yaml
@@ -1,0 +1,2039 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:32 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DD79D:C7CA700:5ED6615B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2917'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:32 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DD813:C7CA75E:5ED6615C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2916'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822655,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI2NTU=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:25:32Z","updated_at":"2020-06-02T14:25:32Z","pushed_at":"2020-06-02T14:25:33Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:33 GMT
+      etag:
+      - '"807e06586ba8f836cdc0d1edac85023c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DD8A5:C7CA809:5ED6615C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2915'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"e6e8989bcae7d372ef0638308eb0a882acfc7558","node_id":"MDY6Q29tbWl0MjY4ODIyNjU1OmU2ZTg5ODliY2FlN2QzNzJlZjA2MzgzMDhlYjBhODgyYWNmYzc1NTg=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e6e8989bcae7d372ef0638308eb0a882acfc7558","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/e6e8989bcae7d372ef0638308eb0a882acfc7558","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:34Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:34Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:34 GMT
+      etag:
+      - '"3e1b2852c222d736a001d7cf0590913e"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DDBA3:C7CABA1:5ED6615D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2914'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X227bOBD9lUDPTiTLF8kGil7gLtACcRBs0tYpCoOiRhK9FKmSlLu2kX/vjKw0
+        sR/aKEjf8mJIpM7wzO1wvPMUK8GbeiWzDozX87guS+G86c6zBcMNGEM8iScJZxClgyiELBgP4kEQ
+        QxKwOA4Zz3g0GsUIVTqFpUgRdD5bjC/DiUs+y+B8tRhezD5s5qvr/kV5Hd5c5aOLmRSL8B85Dy+3
+        8+1HebN6G55v8+35rJCL1bviYpZvFp/n5WLL+/Or/NUBL1a7Qhti2HL/t2AFMyfv10Yr/BJKJiSS
+        QP64fAa0/CanxTN0Dj9ImSOXwyAMToPxaRBe9YfTcDQdDG+827sIUDT+2hElWMtyIvFBCSeYFFs4
+        QVrsxEClrXDabJCoM4Df3GWinwWTNAsHURSHw6g/HMWQhuGERUkyjHmEO3EaDSBAYG0oAIVzlZ36
+        PqvEWS5cUScUAL85wi/BYcq1gVMpklMH1lmffpfLckNMLDgfQT5xsP6jz8b4PePh+2K0fociJAgo
+        t+S6VljGQc9bgxGZ4MwJLA+M5v4dsE4zJi30PAPM0pZXKytyhTs9jx6Yqw3GX9VS9ryKbaRmCKLX
+        2+dz8wkuFq6Uy8MoP0jvYxK7P/QJYbVH5z65tLq67bd5tZibewGQOheUOFs0XY57JD/j0Wg8OJSj
+        y/GnL3PJVwuUk8WWbKyxxs2xN82iDdtuqS0YrpXDcmoap/Yby6/Xr4ZoITetjUbx/tR0ZMv69zx/
+        n8P77zItpf6B2GOqhz19YN7/BUJW+2eh8u4GELTztSsA44T0b8lpgTrRxVID2KGSoLKIlExYDLGB
+        tIuRFoJkfijksWskrLFVJ5YbUVFrd6J1AERD2uRMiW2jEZ0MIZBKstHULi41AATCGqurE3KP2PmV
+        EWvGNxQGAxzEGmPa3doRFI25TUUX0zVmnCIsHCxZWlKbNXJ5fEG+tGB7rb60YLfOeWnB/aWFYnbQ
+        vY9qwYoZ0g1v+vUbNuRSCvUfvuCkCDJ7jskvMUzxAge/X/8L6MJ6YLnjwEFT5J0tJFwZ7YC7BzNY
+        u9KOaKBYIg8mtO+1oEsDbwJX2yVS43uHQWXacGhGPonyRxx1lmEQm5v7/zZG92fiCb/X6cePx0dB
+        QkVuvCIfbn8CtIWUFFkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:34 GMT
+      etag:
+      - W/"1f33dbc7e4fba576502b82bb5cb2a0ef"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DDD6C:C7CADC1:5ED6615E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2913'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:35 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DDDF8:C7CAE64:5ED6615E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2912'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e6e8989bcae7d372ef0638308eb0a882acfc7558
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTUYubQBD+K2Gfk2hWjatQaEtauEIMR3McppQw6qgbVg2760EM+e832/ShfbuD
+        9mVx53Pm++ab2SszLbCU4RpFIpKiBIyrIOZY++tABL7AwgchOJR1GUeRYHPWDxUeZUVJ202+fuSJ
+        LZ6Vvz3l4W7zcMlOT6td98QP+ybabZTM+VeV8ccpm76pw+kT307NtN20Kj99bneb5pI/Z10+lats
+        33yg4qNWVLi19mxSz4OzXDbStmOxLIfO03gejNehBWMHjQsli4VFY43nzuOxu1RAGFqPkjzK6CRh
+        72ittZ06/i3hD/q3EN9J38MJo20HzdIr66FDav57Cy3o2ZcXPfTkCHYgnSc0Jwov0YU/Ni7oPKEf
+        qGeXxn3uL/z1wuf7VZjyKA3CA7vN2V2Rxf9IYTWSguvvVVrVflLVPIhjwcN4FUYCK84TiIsiFGVM
+        iKjiAP1/O22nwXhv5iZjOjQGGmfdQy+tBCUnnLkFmv3aM0krdiGNZ9DYW8PSHz/n7AW1rGUJVtJs
+        qOP7Hekx1KAMzplGMA5iY29k0xMyZ+4D7KiJqh+VciUvagBKctfb7RX2k9DEhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:35 GMT
+      etag:
+      - W/"35616bb41beb2c8da4d644b29204ba36"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:34 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DDF2B:C7CAFDC:5ED6615F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2911'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["e6e8989bcae7d372ef0638308eb0a882acfc7558"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"46ad6e840a3dffede6ec7838ae832f72361213b0","node_id":"MDY6Q29tbWl0MjY4ODIyNjU1OjQ2YWQ2ZTg0MGEzZGZmZWRlNmVjNzgzOGFlODMyZjcyMzYxMjEzYjA=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/46ad6e840a3dffede6ec7838ae832f72361213b0","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/46ad6e840a3dffede6ec7838ae832f72361213b0","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:36Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:36Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"e6e8989bcae7d372ef0638308eb0a882acfc7558","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/e6e8989bcae7d372ef0638308eb0a882acfc7558","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/e6e8989bcae7d372ef0638308eb0a882acfc7558"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:36 GMT
+      etag:
+      - '"ffeb3932067eb9fccd35a83aa2ad7347"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/46ad6e840a3dffede6ec7838ae832f72361213b0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DDFA3:C7CB06A:5ED6615F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2910'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnglNSEpMZQVspZSJVWSJ/vNSO4jiyH0gp4r/3oY5dOnS5y33n
+        3XNlETpW3TNxC9Ik7mVCiOyBjcFA6wy19bYujr7xdf/xdNi+zG/98fEwvg6nsb7IfWNPz/VFve++
+        zL6ZCTzHgSCLOKWKczm55adDe1ZLHTyPMAUaAaSZEGExOLVASJj4PdvWz0ZSB8gJouvfXkH1oJFV
+        V5aspCEoQGzERmkJpcnLFXRZkYs8E6AyKcRK6k6X67UgM5wnIII8vMP/Nf35mfifbW63b4N11tV9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:36 GMT
+      etag:
+      - W/"86cb5ba04de0ab971565fc5d90b65069"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:34 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE0B1:C7CB186:5ED66160
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2909'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "46ad6e840a3dffede6ec7838ae832f72361213b0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngkkcmSgzgraSy0SqskROfKkdxXFkH0gp4r/3UMcuHbq85d13
+        77uxCD2rHpm4BW0S9zohRPbEpmCgcYZatVPy5Guvho/iuHtZ3oZTdpxex/OkrvpQ2/Ozurbv+y9z
+        qBcCL3EkyCLOqeJcz2796dBe2nUXPI8wBxoBpJkQYTW6doWQMPFHNo1fjKYOkBNE17+9QjtAh6y6
+        sWQ1DRVSGwllsdHC9D0YkNBtS1FqKEXeb3MhszwT7YbMcJmBCPLwDv/X9Odn4n+2ud+/AUV9pYp9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:37 GMT
+      etag:
+      - W/"ac6c6d081d3540370f6445c09c49269a"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE127:C7CB227:5ED66160
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2908'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:37 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE2F9:C7CB42B:5ED66161
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2907'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SumqSpgaJ76FZsQBpg6ICuLwIl0RJjSdRIyp4j+Lv3f6Jk
+        yZ6bOA4f85LYNPm74/HueLxmIpPJLLi+uQmC66urs0mpEhHS2OT202+ru/zPPP78/oF/+2sZl4v1
+        l/v08vb+j+DL178/TDCZFwIzrTA2DIt1wi03wuKHeZ3nYfdrITBqlRbnuYzOaa5h/19RabnkFrQ5
+        z404m6hVKfRk1kxylcoSQg5gIIg0vb6evguCmzd7yq/vFu/X34Pfa/6typLP+TK6/ye4/RSvb+/T
+        /7CUQx7XYa1z0DNrKzNjzA2atxeptFkd1UboWJVWlPYiVgWrWS/s4/LDJSCp7jCtyTCwh6tkR3LL
+        gTPs8E4yW+R7yjgd2pWH18xVnqsVmPu7OFIs2wLozFqYLNOXwQBomLKZgGmx3Q0ZSeLMT6W2ixtG
+        /+CXhDM4Ni2SU4HdcihJLrZpmBaVarl1ZGItKytVebK6OxBAlU55KR/4i6CAGLBI0ZMVaxcDIpZw
+        5pMpbnXD2nCN12Q2LWIhlziPl5H3MADbdUXZ5W5kQTolaUXIk4KSQpsrNmeI3mfGzoEElIjt4U9m
+        JfIXRYRebBPSo4HdGvdQkB4QRNQn7H80DgEMGKyyEGtvTGI1DH+7eIuRGHikNEcS9yZkB9qw8Vdy
+        Kit44U1WCwM0U8qf5VsYoNKYWhzl+8efass0rA+2si4il0mPCbHjxTga9sCNkWkphDeLb4EN6y+B
+        SPMyzvyJ6HkNc59ar+Gpty0QC8goV5E3Ji501gIbZjLurkYb+tSaJBBvR4AWc69bIN5WgNUe/aZV
+        n4BbPG5rCxfypn/PY013Ajkv05qn/iRsgXRZoVRJ+cOTFdrxMTsQgafSVMuo9puYBybtwBVFyD/+
+        jmBADgLaquvxku4ZRhpVcq2ZikI+VfMcT+9wOyHmWQTFwb4Y+v506fa8bRCvYcP94i6zTpKv0+hu
+        s17/sbzubeXNtXoea36puM0ow0JsxbXwtZkOx5oIT93NxcVFkwnePksKoT1mEUcDlus4Q3ntS/+m
+        56FyLLhtnz9zUj/BcyhXPPF2Flsg4M4FfO3B0cZ+VKFe96Z4CxvTC5mja6FKf3fEQBzLKZWVcxkf
+        81Y8Psx3oM1HI8tYnHE8bxAVVsYScYInO3kAinzhz4qOhu2hR+SeiblAyHg7JS0cr2GuK5CIKldr
+        rxlyhKREogUaVEnILR6lwTSYnk+vz6fB1zeXs+Bq9jb4jjl1hR7Yz+e8ozlVbbInpiD9d7GCT+hK
+        Pd4I2n9jUscJcozJBsivA2J2oJf0E0Scw+n3ovY0XZb7d/vzMNhOpgpRoU7rH+dGPuDzdKfGilVd
+        4nQwuOIWjw3ULMNQX5f1gIyb0GWSyczqGj1HGqm0uhexNeOxIZONJq7kQu4spBpy2y1wj/xBeCG1
+        Vl2z0TUXujyMtmHX8Uyk4VEuhgFVibLTcLwNGYvSbM3gGgC05dH0HRO0XxIx53VuQ/dWonYqerJo
+        sMIdhS5gBup5Ubu166w4g5Cr9nukrOg+o+FiRVGFzjusWgjqzwKFrKJWofm35nC99gLrF7tf2iFs
+        haqx3V+0oOt0d02CAEerx2kcojjsiH2DeNwWeu0T19Frn/i1T/zaJ3addrr+DvSJS2FXaJiOsun4
+        edtn680PzoeKmxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:38 GMT
+      etag:
+      - W/"6ed965af242748e367574dd3e86e3c2b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE3A1:C7CB507:5ED66161
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2906'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:38 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE412:C7CB5AF:5ED66162
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2905'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SumqSpgaJ76FZsQBpg6ICuLwIl0RJjSdRIyp4j+Lv3f6Jk
+        yZ6bOA4f85LYNPm74/HueLxmIpPJLLi+uQmC66urs0mpEhHS2OT202+ru/zPPP78/oF/+2sZl4v1
+        l/v08vb+j+DL178/TDCZFwIzrTA2DIt1wi03wuKHeZ3nYfdrITBqlRbnuYzOaa5h/19RabnkFrQ5
+        z404m6hVKfRk1kxylcoSQg5gIIg0vb6evguCmzd7yq/vFu/X34Pfa/6typLP+TK6/ye4/RSvb+/T
+        /7CUQx7XYa1z0DNrKzNjzA2atxeptFkd1UboWJVWlPYiVgWrWS/s4/LDJSCp7jCtyTCwh6tkR3LL
+        gTPs8E4yW+R7yjgd2pWH18xVnqsVmPu7OFIs2wLozFqYLNOXwQBomLKZgGmx3Q0ZSeLMT6W2ixtG
+        /+CXhDM4Ni2SU4HdcihJLrZpmBaVarl1ZGItKytVebK6OxBAlU55KR/4i6CAGLBI0ZMVaxcDIpZw
+        5pMpbnXD2nCN12Q2LWIhlziPl5H3MADbdUXZ5W5kQTolaUXIk4KSQpsrNmeI3mfGzoEElIjt4U9m
+        JfIXRYRebBPSo4HdGvdQkB4QRNQn7H80DgEMGKyyEGtvTGI1DH+7eIuRGHikNEcS9yZkB9qw8Vdy
+        Kit44U1WCwM0U8qf5VsYoNKYWhzl+8efass0rA+2si4il0mPCbHjxTga9sCNkWkphDeLb4EN6y+B
+        SPMyzvyJ6HkNc59ar+Gpty0QC8goV5E3Ji501gIbZjLurkYb+tSaJBBvR4AWc69bIN5WgNUe/aZV
+        n4BbPG5rCxfypn/PY013Ajkv05qn/iRsgXRZoVRJ+cOTFdrxMTsQgafSVMuo9puYBybtwBVFyD/+
+        jmBADgLaquvxku4ZRhpVcq2ZikI+VfMcT+9wOyHmWQTFwb4Y+v506fa8bRCvYcP94i6zTpKv0+hu
+        s17/sbzubeXNtXoea36puM0ow0JsxbXwtZkOx5oIT93NxcVFkwnePksKoT1mEUcDlus4Q3ntS/+m
+        56FyLLhtnz9zUj/BcyhXPPF2Flsg4M4FfO3B0cZ+VKFe96Z4CxvTC5mja6FKf3fEQBzLKZWVcxkf
+        81Y8Psx3oM1HI8tYnHE8bxAVVsYScYInO3kAinzhz4qOhu2hR+SeiblAyHg7JS0cr2GuK5CIKldr
+        rxlyhKREogUaVEnILR6lwTSYnk+vz6fB1zeXs+Bq9jb4jjl1hR7Yz+e8ozlVbbInpiD9d7GCT+hK
+        Pd4I2n9jUscJcozJBsivA2J2oJf0E0Scw+n3ovY0XZb7d/vzMNhOpgpRoU7rH+dGPuDzdKfGilVd
+        4nQwuOIWjw3ULMNQX5f1gIyb0GWSyczqGj1HGqm0uhexNeOxIZONJq7kQu4spBpy2y1wj/xBeCG1
+        Vl2z0TUXujyMtmHX8Uyk4VEuhgFVibLTcLwNGYvSbM3gGgC05dH0HRO0XxIx53VuQ/dWonYqerJo
+        sMIdhS5gBup5Ubu166w4g5Cr9nukrOg+o+FiRVGFzjusWgjqzwKFrKJWofm35nC99gLrF7tf2iFs
+        haqx3V+0oOt0d02CAEerx2kcojjsiH2DeNwWeu0T19Frn/i1T/zaJ3addrr+DvSJS2FXaJiOsun4
+        edtn680PzoeKmxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:38 GMT
+      etag:
+      - W/"6ed965af242748e367574dd3e86e3c2b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE4FE:C7CB6BE:5ED66162
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2904'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/46ad6e840a3dffede6ec7838ae832f72361213b0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXY/aMBD8K8jPQIIdEhOpUitB0T0Aor0WkapCm2STOM0Hip1TAfHfby16UvsG
+        0vUlsnc9nt3ZiS9MF8BC5vmQ+ig9F0SaZZiij0kghQSUgmcBF/6ET0TssiFr2hQPKiXQar73t3xm
+        4l3lrsq9t5k/ndblt8mm3PL9bsuj59xdLRfnaBnV0e5Lta6/l+tzft4sP1eb+eoUlclpdd7/XpWL
+        87789IEu77uKLi6MOerQceCoxrkyRR+Pk7Z2Ojy22qnRgDZth6NKxSOD2mjHfg+H+pQC5dA4BHII
+        USvKPdBaYerq8G8Jf9HfQ3wjfYQTelO0HQsvrIEaqfmvBRTQDRYvXduQIliDsprQnCg8Rhv+mNug
+        1YQOUM8Wxl3ujlx/5PLniRfyaSj8iF2H7FaRwf9IYTqkCi5/rBQEKH3hZR7ZRSRZ5s9SL/CmiRtj
+        gJgJHmMCsT9932nbGrRzNzcJU6PWkFvpnhplFFQD654jJL8oOrjJRjUeocPGaBb+eGuQ/g05k7M4
+        AQxSEXDMXF9I4UqMXZCSQ5IlwXQq37fBNzs/wP5udr6b8/pzyF6wU5lKwCjyL7nitkd6MDKoNA5Z
+        h6BtivWNVnlDmSGzCzB9R+No+qqysp+qFghkt9frKyC5LrqoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:39 GMT
+      etag:
+      - W/"ffeb3932067eb9fccd35a83aa2ad7347"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE57B:C7CB758:5ED66162
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2903'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=46ad6e840a3dffede6ec7838ae832f72361213b0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft/G/WLYDozRmKw6sY92LOaEQJOtsK5UlYykNWel336kNrEv3
+        IuvG2AuJQyfd8+O504OnaA/ezOPU0oHWd7SFycZo5Z15A7XdrzOmo5jIIM1qnlOe5pBHUcyCjCRh
+        ShLOgUCaBHmQZ4wEWMqIbyiSkzNvO0p82lk7mJnv00FMWmG7LZvUuvdHGLTxe7DUWD3CuRTs3IKx
+        xnf7et3vHaYB69daWVCYOOa+GKF5NyWUE8imAY1504DDqdMszihkcdSkUUzCKEReJOtsL9c/Q70A
+        OgWFSc38UxVf8SIC6h0RvNkWLOU7HuP/RnO43impKT+CGOnu0JutgfFg+FObTnHlTwyx+8GNZCMk
+        oD0HZTyAnW7LYrFdfg1lucG4D5PV1YdgWV1LXpSmvHzK71fV9T2vFptV9VF8EnNWiMv2VpXFPHVR
+        Wbi12C2rG/1c5abjV+/vWSV/vPySbOp4KZ7vz/Nb5aLq84ARIoGqNReqRSaG40imeLaWQt0Zb/bg
+        GZDNfzXjOBV/g+dNw+X+1wvxf/u3Hh+/AwrD1CjgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:39 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE5DB:C7CB7CD:5ED66163
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2902'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "46ad6e840a3dffede6ec7838ae832f72361213b0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyNjU1OjZkNzA3NzgyOTcwMDkzYjM5NTI3MGVkODdlNzNkODlmNDQyOTNhM2Q=","sha":"6d707782970093b395270ed87e73d89f44293a3d","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6d707782970093b395270ed87e73d89f44293a3d","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:25:39Z"},"object":{"sha":"46ad6e840a3dffede6ec7838ae832f72361213b0","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/46ad6e840a3dffede6ec7838ae832f72361213b0"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '692'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:39 GMT
+      etag:
+      - '"230bada27c2d488a25b4a2ad97f5c898"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6d707782970093b395270ed87e73d89f44293a3d
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE649:C7CB862:5ED66163
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2901'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "6d707782970093b395270ed87e73d89f44293a3d", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyNjU1OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"6d707782970093b395270ed87e73d89f44293a3d","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6d707782970093b395270ed87e73d89f44293a3d"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:40 GMT
+      etag:
+      - '"a83a3befefc4a6a9f86417d659b4b4a1"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE71A:C7CB95B:5ED66163
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2900'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:41 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE8AE:C7CBB1D:5ED66164
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2899'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SummSJgaJ9aFdsQBpg6ICuLwIl0RJjSdRIyp4j5Lvvf6Rk
+        yZ6TOA4f85LYNPm74/HueLx2ItLJLLy8ugrDy4uLk0klUx7R2OTm85fVbfFHkXy9vmc//lwm1WL9
+        7S47v7n7Pfz2/a8PE0xmJcdMw7WJonKdMsM0N/hh3hRF1P1acowaqfhpIeJTmquD/6+olVgyA9qc
+        FZqfTOSq4moyayeFzEQFIXswEESaXl5Ofw3Dq3c7yq9vF9frn+FvDftR5+nXYhnf/R3efE7WN3fZ
+        v1jKII+pqFEF6LkxtZ4FgRvU788yYfImbjRXiawMr8xZIsugCXphH5cfzgHJVIexJsPADq4WHckt
+        B04H+3eSm7LYUcbpYFfuXzOXRSFXYO7u4kCxwQZAZ2ZhospeBwOgDaTJOUyL7T6QkQTO/FiqXdwG
+        9A9+STiNY1M8PRbYLYeS5GIPbaB4LS23iXWiRG2ErI5WdwsCqFQZq8Q9exUUEA0WKXq0YnYxIHwJ
+        Zz6a4la3gQ3XZE1mUzzhYonzeB15BwOwWdeUXW5HFqRTEoZHLC0pKdhc8XCC6H1h7OxJQCnfHP5k
+        ViF/UUSoxSYhPRnY1rj7gnSPIKI+Y/+DcQhgwGCVBV97YxKrDfC3i7cEiYHFUjEkcW9CtqBtMP5K
+        TmU4K73JsjBAcyn9Wd7CABVaN/wg3z/8VC1TB32wVU0Zu0x6SIgdLsbRsAemtcgqzr1ZfANsg/4S
+        iBWrktyfiJ7XBu6T9RqWedsCsYCMCxl7Y+JCDyywDXTO3NVoIp9akwTibQlQfO51C8TbCDDKo99Y
+        9Qm4weO2NnAhb/r3vKDtTqBgVdawzJ+EDZAuK5QqGbt/tkI7PGYHIvBUmioRN34T88CkHbiiCPnH
+        3xEMyEGArbqeLuleYKRRJWfNVJbiuZrncHqH2woxzyIoDnbF0PfnS7eXbYN4bTDcL+4y6yT5Oo3u
+        Nuv1H8vr3lbeXKvnBe0vNTM5ZViIrZnivjbT4YI2xlP34ezsrM05s8+SkiuPWcTRgGUqyVFe+9K/
+        7XmoHEtm7PNnTuqneA4VkqXezmIDBNy5gK89ONrYj2rU694Ut7AxvRQFuhay8ndHDMSxnEoaMRfJ
+        IW/Fw8N8C9p+1KJK+AnD8wZRYUQiECd4spMHoMjn/qzoaNgeekTumVhwhIy3U1Lc8drAdQVSXhdy
+        7TVDjpCUSBRHgyqNmMGjNJyG09Pp5ek0/P7ufBZezN6HPzGnqdEDe3zONc2pG50/OuV8SlOQ/rtY
+        wSd0pZ5uBO2+ManjBIjW+QD5NCBme3pJjyCSAk6/E7XH6bLcvdtfhsF2clnyGnVa/zjX4h6fp1s1
+        ViKbCqeDwRUzeGygZhmG+rqsB+RMRy6TTGZGNeg50kit5B1PjB6PDZlsNHElFmJrIdWQm26Be+QP
+        wkuhlOyaja650OVhtA27jmcqNIsLPgzImledhuNtiIRXemMG1wCgLY+mb5nAfkn5nDWFidxbidqp
+        6MmiwQp35KqEGajnRe3WrrPiDEKu2u+RsqL7jIaL4WUdOe8wcsGpPwsUsopcRfqfhsH17AXWL3a/
+        2CFshaqx7V8Up+t0e02KAEerx2kcoTjsiH2DeNwWeusTN/Fbn/itT/zWJ3addrr+9vSJK25WaJiO
+        sun4edtn64f/ABljhFsVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:41 GMT
+      etag:
+      - W/"d7cf5b1dc9cfcc1eeb34345566e177e0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:39 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE93F:C7CBBEE:5ED66165
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2898'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIBAF0auYtVW3sPMAll7BIHzRRFgDi43x7tLNy7wUkLPxoIkW0WaWEh11
+        5MSWgKhGT4lrSVf9h+qdJ2aHB5fcSIM/9SjbYCXwM3IVJ+yZWw/tTV8bCdGCvh8u9SX+ZwAAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:41 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DE9B8:C7CBC8B:5ED66165
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2897'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:42 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DEA84:C7CBD4E:5ED66165
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2896'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SummSJgaJ9aFdsQBpg6ICuLwIl0RJjSdRIyp4j5Lvvf6Rk
+        yZ6TOA4f85LYNPm74/HueLx2ItLJLLy8ugrDy4uLk0klUx7R2OTm85fVbfFHkXy9vmc//lwm1WL9
+        7S47v7n7Pfz2/a8PE0xmJcdMw7WJonKdMsM0N/hh3hRF1P1acowaqfhpIeJTmquD/6+olVgyA9qc
+        FZqfTOSq4moyayeFzEQFIXswEESaXl5Ofw3Dq3c7yq9vF9frn+FvDftR5+nXYhnf/R3efE7WN3fZ
+        v1jKII+pqFEF6LkxtZ4FgRvU788yYfImbjRXiawMr8xZIsugCXphH5cfzgHJVIexJsPADq4WHckt
+        B04H+3eSm7LYUcbpYFfuXzOXRSFXYO7u4kCxwQZAZ2ZhospeBwOgDaTJOUyL7T6QkQTO/FiqXdwG
+        9A9+STiNY1M8PRbYLYeS5GIPbaB4LS23iXWiRG2ErI5WdwsCqFQZq8Q9exUUEA0WKXq0YnYxIHwJ
+        Zz6a4la3gQ3XZE1mUzzhYonzeB15BwOwWdeUXW5HFqRTEoZHLC0pKdhc8XCC6H1h7OxJQCnfHP5k
+        ViF/UUSoxSYhPRnY1rj7gnSPIKI+Y/+DcQhgwGCVBV97YxKrDfC3i7cEiYHFUjEkcW9CtqBtMP5K
+        TmU4K73JsjBAcyn9Wd7CABVaN/wg3z/8VC1TB32wVU0Zu0x6SIgdLsbRsAemtcgqzr1ZfANsg/4S
+        iBWrktyfiJ7XBu6T9RqWedsCsYCMCxl7Y+JCDyywDXTO3NVoIp9akwTibQlQfO51C8TbCDDKo99Y
+        9Qm4weO2NnAhb/r3vKDtTqBgVdawzJ+EDZAuK5QqGbt/tkI7PGYHIvBUmioRN34T88CkHbiiCPnH
+        3xEMyEGArbqeLuleYKRRJWfNVJbiuZrncHqH2woxzyIoDnbF0PfnS7eXbYN4bTDcL+4y6yT5Oo3u
+        Nuv1H8vr3lbeXKvnBe0vNTM5ZViIrZnivjbT4YI2xlP34ezsrM05s8+SkiuPWcTRgGUqyVFe+9K/
+        7XmoHEtm7PNnTuqneA4VkqXezmIDBNy5gK89ONrYj2rU694Ut7AxvRQFuhay8ndHDMSxnEoaMRfJ
+        IW/Fw8N8C9p+1KJK+AnD8wZRYUQiECd4spMHoMjn/qzoaNgeekTumVhwhIy3U1Lc8drAdQVSXhdy
+        7TVDjpCUSBRHgyqNmMGjNJyG09Pp5ek0/P7ufBZezN6HPzGnqdEDe3zONc2pG50/OuV8SlOQ/rtY
+        wSd0pZ5uBO2+ManjBIjW+QD5NCBme3pJjyCSAk6/E7XH6bLcvdtfhsF2clnyGnVa/zjX4h6fp1s1
+        ViKbCqeDwRUzeGygZhmG+rqsB+RMRy6TTGZGNeg50kit5B1PjB6PDZlsNHElFmJrIdWQm26Be+QP
+        wkuhlOyaja650OVhtA27jmcqNIsLPgzImledhuNtiIRXemMG1wCgLY+mb5nAfkn5nDWFidxbidqp
+        6MmiwQp35KqEGajnRe3WrrPiDEKu2u+RsqL7jIaL4WUdOe8wcsGpPwsUsopcRfqfhsH17AXWL3a/
+        2CFshaqx7V8Up+t0e02KAEerx2kcoTjsiH2DeNwWeusTN/Fbn/itT/zWJ3addrr+9vSJK25WaJiO
+        sun4edtn64f/ABljhFsVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:25:42 GMT
+      etag:
+      - W/"d7cf5b1dc9cfcc1eeb34345566e177e0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:25:39 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DEB00:C7CBE23:5ED66166
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2895'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:25:43 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C997:2668D:A7DEC01:C7CBF3E:5ED66166
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2894'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_fetch_no_package.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_fetch_no_package.yaml
@@ -1,0 +1,1938 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:50 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A602B15:C584C9D:5ED6607E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3437'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:51 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A602B83:C584CF8:5ED6607E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3436'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821765,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE3NjU=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:21:51Z","updated_at":"2020-06-02T14:21:51Z","pushed_at":"2020-06-02T14:21:52Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:52 GMT
+      etag:
+      - '"344ed3cbf0d09f146fdf67442894ffdd"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A602C12:C584D8C:5ED6607F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3435'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"650c8d4903638e386bbd6263b530fafca9a3360b","node_id":"MDY6Q29tbWl0MjY4ODIxNzY1OjY1MGM4ZDQ5MDM2MzhlMzg2YmJkNjI2M2I1MzBmYWZjYTlhMzM2MGI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/650c8d4903638e386bbd6263b530fafca9a3360b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/650c8d4903638e386bbd6263b530fafca9a3360b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:53Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:53Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:53 GMT
+      etag:
+      - '"1b408c309fe610e96420e4cfbe5f2133"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A602FCA:C5851F1:5ED66080
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3434'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bMBD9lUBnJ5IlW16AokWRonABpQiaLk5RGJQ0kphSpEpSTmzD/94ZWVns
+        QxoF6S2XwCL5hm/eLJxsHMlKcKZOyYwF7fScRJUlt85045iC4UY49JJxOph4QRiMIRiHcZyGfhjE
+        w8DLWJawCQuC0IsRKlUKC54iKDqdh+f+xMbfhRddzQefT2c3Z+t5//PVvB99jAaXp+fD6DTyo3Uh
+        onXuz8tPv8+uZn7kz/rR+n05/355Nb8QRbTGMx9nb/Z4sdoWShPDlvuXghVMH31YaiXxJJSMCySB
+        /HH5BGj5XU6LJ+gcHkiZJZd9z/eOvfDY8y/6g6nfnw6DS2d7qwCp8d+uKMEYlhOJmeSWM8HXcIS0
+        2JGGShlulV4hUasBz9xGop95kzTzg9Fo7A9G/cFwDKnvT9gojgfjZIQ743QUgIfAWpMAhbWVmbou
+        q/hJzm1RxySA21zhlmAx5ErDseDxsQVjjUt/F4tyRUwMWBdBLnEw7pPvRv1e8PJdMhq3QxISBKRd
+        JKqWmMZez1mC5hlPmOWYHqjm7hswTzMmDPQcDczQllNLw3OJOz2HfjBba9Rf1kL0nIqthGIIos/t
+        y7n5DBcLW4rFvsoPwvuUwO4ufYas5uDeZ6dWV7fdNq4GY3PfAITKOQXOFE2V4x61n3A4DIP9dnQe
+        fvtxJhJsP2cX8zXZWGKO60NvmkXjt9VSG9CJkhbTqSmcGgVDy2+XbwZoIdetjabj/avoyJZx73k+
+        HsP7c5kSQl0j9pDqfk3vmXfvQMhq95vLvLsBBG1cZQtAnZD+lpzm2Ce6WGoAG+wk2Fl4SiYMSqwh
+        7WKkhSCZa4k8Nk0La2zVsUk0r6i0O9HaA6IhpXMm+brpEZ0MIZBSsumpXVxqAAiEJWZXJ+QOsXEr
+        zZcsWZEMGhLgS9S0u7UDKBqzq4oepq8YcVKYW1iwtKQya9rl4QP5WoLts/pagt0q57UEd48WNrO9
+        6n1SCVZMU99wpj9/YUEuBJe/8QMnRRDZS0x+sWYyKXDwu/u/gB6sB5Y7Dhw0Rd7aQsKVVhYS+2AG
+        a1faEQ0ki8XehPan5vRo4Etga7NAasnOYZCZ0gk0I5/A9kccVZahiM3LfdNqdH8n3vB4n376eHwg
+        EnbkxivyYfsXtm52g1kNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:54 GMT
+      etag:
+      - W/"baa6d07bc0569782a4a8da17f0c15248"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603176:C585444:5ED66081
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3433'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:54 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6031E9:C5854D0:5ED66082
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3432'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/650c8d4903638e386bbd6263b530fafca9a3360b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTXYvbMBD8K0HPSSzLjr+gUErKkYLuOHpwOKWEdbyOlcp2kOSjcch/v1XTh/bt
+        DtoXI+1odnZn1xdmW2AFS1Z8n9VxzqMkyjDKkqqqE5FE1SriDTR7yCGKEl6xOeuHGneqJpJcl8mj
+        yF31rLk8lvHDevPzfirDh2MZyjsZb9ePK7mWQk6tltNBlN2XH/fHjZBiE8rpU1c+b4/lk27lRG/u
+        Nh8o+Wg0JW6dO9kiCOCklgfl2rFa7ocuMHgabNChA+sGgwutqoVD62zgv7tdd66BMHQBkQJidIqw
+        d7TWuk7v/i7hD/m3CN9E36MJo2sHw4oL66FDav5rCy2Y2ecXM/TkCHagvCc0Jwov0Yc/HnzQe0IP
+        qGdPE1zwBU8WXDyFcSHCYhVt2XXObhU5/I8SziBVcPm9SmHD87oRUZpmIk7DeJVhLUQOaVXF2T4l
+        JKvTCPm/nbavwQZv1iZjOrQWDt66Ta+cAq0mnPkFmv3aM0UrdqYaT2Cwd5YV377P2Qsa1ag9OEWz
+        oY5vd6SfoQFtcc4MgvUQG3urDj0hc+YP4EZDUv2otU951gMQyV+v11cvzv8dhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:54 GMT
+      etag:
+      - W/"912812f8b05c7305cd0213e32c0e2773"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6032AC:C5855BB:5ED66082
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3431'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["650c8d4903638e386bbd6263b530fafca9a3360b"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"d5bdc9969bdd99c8a4a8838f1a387b00803c5ead","node_id":"MDY6Q29tbWl0MjY4ODIxNzY1OmQ1YmRjOTk2OWJkZDk5YzhhNGE4ODM4ZjFhMzg3YjAwODAzYzVlYWQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d5bdc9969bdd99c8a4a8838f1a387b00803c5ead","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/d5bdc9969bdd99c8a4a8838f1a387b00803c5ead","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:55Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:55Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"650c8d4903638e386bbd6263b530fafca9a3360b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/650c8d4903638e386bbd6263b530fafca9a3360b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/650c8d4903638e386bbd6263b530fafca9a3360b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:55 GMT
+      etag:
+      - '"66d1d866084630701c237f6b9f30433f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d5bdc9969bdd99c8a4a8838f1a387b00803c5ead
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A60335A:C585679:5ED66082
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3430'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngtMarJAZQVvJZWoqWCI7vtRGcRzZB2pA/Pce6tilQ5e3vPvu
+        fVeWoGPVPTN3oG3mQWeExB7YEC003lKr1kq+hzqo436xW798vV32j7vhtT8M6qy3tTs8q7P52Fzs
+        tp4IPKWeIIc45opzPfr5p0d3MvM2Bp5gjDQCSDMxwaz3ZoaQMfN7Nk2YrKYOkBNE17+9ojlCi6y6
+        suw0Dcll0ZZ2sSqEFCWIUhpj5ZMUZimKTnetXmkhZGHIDKcRiCCP4PF/TX9+Zv5nm9vtG3Gkmvh9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:55 GMT
+      etag:
+      - W/"2d7fcee28301328328a1d2dd63256113"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603427:C585777:5ED66083
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3429'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "d5bdc9969bdd99c8a4a8838f1a387b00803c5ead"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62PPW/CMBCG/4vngoMC1MmMClRymZoKlsgfR20Ux5F9oAbEf++hjl06dLnlvefe
+        524swZHVj5m5A2UzDyojJPbE+mih9ZZSuZLL99AEedrPd6vt19t1P9v1r92hlxe1btxhIy/64+Vq
+        181I4Dl1BDnEIdecq8FPPz26s56aGHiCIVIJINXEBJPO6wlCxswfs23DaBVlgJwg2v7tFfUJDLL6
+        xrJTVGQX2pqqWlba2qoyQs2VEKU4zlQpnnVRiKI0C3qNzHAcgAjyCB7/1/TnZuZ/trnfvwFcpkVi
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:56 GMT
+      etag:
+      - W/"95612c590c4c8a7363cb6e9f32869c65"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6034AC:C58580C:5ED66083
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3428'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:56 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603639:C5859F4:5ED66084
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3427'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOm7qtgaJ7aFdgQBpg2ICuLwIl0RZtSdRIyp4j5Lvvf6Rk
+        yZ6bOA4f85LYNPm74/HueLxmJNPRbDJ9/35y/W769mJUqlRENDa6/fxlc5f/nidfP9zz73+sk3K1
+        /bZc3Nwuv7z5tvzr4wiTeSEw0wpjo6jYptxyIyx+mNd5HrW/FgKjVmlxmcv4kuYa9v8VlZZrbkGb
+        89yIi5HalEKPZs0oVwtZQsgRDASRptPp+N1k8v76QPnt3erD9sfkt5p/r7L0a76Ol39Pbj8n29vl
+        4l8s5ZDHdVTrHPTM2srMGPOD5s3VQtqsjmsjdKJKK0p7laiC1awT9mn98QaQhW4xzmQYOMBVsiX5
+        5cAZdnwnmS3yA2W8Dm7l8TVzledqA+bhLk4Uy3YAOjMHk+XiZTAAGqZsJmBabPeBjCRx5udS3eKG
+        0T/4JeEMjk2L9FxguxxKkos9NEyLSjluHZtEy8pKVZ6t7h4EUKUXvJT3/EVQQAxYpOjZirnFgIg1
+        nPlsil/dMBeuyZbMpkUi5Brn8TLyAQZgu60ou9wNLEinJK2IeFpQUnC54uEC0fvM2DmSgFKxO/zR
+        rET+oojQq11CejSwnXGPBekRQUR9wv4n4xDAgMEqK7ENxiRWw/C3jbcEiYHHSnMk8WBC9qANG34l
+        p7KCF8FkORigmVLhLO9ggEpjanGS759+qo5pWBdsZV3EPpOeEmKni/E07IEbIxelEMEsvgM2rLsE
+        Ys3LJAsnouM1zH9yXsMXwbZALCDjXMXBmLjQmQM2zGTcX402Cqk1SSDengAt5kG3QLydAKsD+o1T
+        n4A7PG5rCxcKpn/HY017AjkvFzVfhJOwA9JlhVJlwe+frNBOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq7HS7pnGGlQyTkzFYV8quY5nd7i9kIssAiKg0Mx9P3p0u152yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPV1dXTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj9zUj/FcyhXPA12Fjsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKuUxO
+        eSueHuZ70OaTkWUiLjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlatt
+        0Aw5QFIi0QINqjTiFo/SyXgyvhxPL8eTP69vZpPr2dvrH5hTV+iB/XzOlOZUtcmemIL038YKPqEr
+        9Xgj6PCNSR0nyDEm6yG/9ojZkV7STxBJDqc/iNrzdFkf3u3Pw2A7mSpEhTqte5wbeY/P470aK1F1
+        idPB4IZbPDZQs/RDXV3WATJuIp9JRjOra/QcaaTSaikSa4ZjfSYbTNzIldxbSDXkrlvgH/m98EJq
+        rdpmo28utHkYbcO245lKw+Nc9AOqEmWr4XAbMhGl2ZnBNwBoy4PpeyZwX1Ix53VuI/9WonYqerJo
+        sMIdhS5gBup5Ubu17ax4g5CrdnukrOg/o+FiRVFF3jusWgnqzwKFrKI2kfmn5nA9d4F1i/0vbghb
+        oWps/xct6DrdX5MiwNHq8RpHKA5bYtcgHraFXvvEdfzaJ37tE7/2iX2nna6/I33iUtgNGqaDbDp8
+        3nbZ+uE/vE0ZwRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:57 GMT
+      etag:
+      - W/"6b720c35b5f166692cbd97871ddaa0a1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6036BF:C585A9D:5ED66084
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3426'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:57 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603752:C585B4A:5ED66085
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3425'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOm7qtgaJ7aFdgQBpg2ICuLwIl0RZtSdRIyp4j5Lvvf6Rk
+        yZ6bOA4f85LYNPm74/HueLxmJNPRbDJ9/35y/W769mJUqlRENDa6/fxlc5f/nidfP9zz73+sk3K1
+        /bZc3Nwuv7z5tvzr4wiTeSEw0wpjo6jYptxyIyx+mNd5HrW/FgKjVmlxmcv4kuYa9v8VlZZrbkGb
+        89yIi5HalEKPZs0oVwtZQsgRDASRptPp+N1k8v76QPnt3erD9sfkt5p/r7L0a76Ol39Pbj8n29vl
+        4l8s5ZDHdVTrHPTM2srMGPOD5s3VQtqsjmsjdKJKK0p7laiC1awT9mn98QaQhW4xzmQYOMBVsiX5
+        5cAZdnwnmS3yA2W8Dm7l8TVzledqA+bhLk4Uy3YAOjMHk+XiZTAAGqZsJmBabPeBjCRx5udS3eKG
+        0T/4JeEMjk2L9FxguxxKkos9NEyLSjluHZtEy8pKVZ6t7h4EUKUXvJT3/EVQQAxYpOjZirnFgIg1
+        nPlsil/dMBeuyZbMpkUi5Brn8TLyAQZgu60ou9wNLEinJK2IeFpQUnC54uEC0fvM2DmSgFKxO/zR
+        rET+oojQq11CejSwnXGPBekRQUR9wv4n4xDAgMEqK7ENxiRWw/C3jbcEiYHHSnMk8WBC9qANG34l
+        p7KCF8FkORigmVLhLO9ggEpjanGS759+qo5pWBdsZV3EPpOeEmKni/E07IEbIxelEMEsvgM2rLsE
+        Ys3LJAsnouM1zH9yXsMXwbZALCDjXMXBmLjQmQM2zGTcX402Cqk1SSDengAt5kG3QLydAKsD+o1T
+        n4A7PG5rCxcKpn/HY017AjkvFzVfhJOwA9JlhVJlwe+frNBOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq7HS7pnGGlQyTkzFYV8quY5nd7i9kIssAiKg0Mx9P3p0u152yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPV1dXTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj9zUj/FcyhXPA12Fjsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKuUxO
+        eSueHuZ70OaTkWUiLjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlatt
+        0Aw5QFIi0QINqjTiFo/SyXgyvhxPL8eTP69vZpPr2dvrH5hTV+iB/XzOlOZUtcmemIL038YKPqEr
+        9Xgj6PCNSR0nyDEm6yG/9ojZkV7STxBJDqc/iNrzdFkf3u3Pw2A7mSpEhTqte5wbeY/P470aK1F1
+        idPB4IZbPDZQs/RDXV3WATJuIp9JRjOra/QcaaTSaikSa4ZjfSYbTNzIldxbSDXkrlvgH/m98EJq
+        rdpmo28utHkYbcO245lKw+Nc9AOqEmWr4XAbMhGl2ZnBNwBoy4PpeyZwX1Ix53VuI/9WonYqerJo
+        sMIdhS5gBup5Ubu17ax4g5CrdnukrOg/o+FiRVFF3jusWgnqzwKFrKI2kfmn5nA9d4F1i/0vbghb
+        oWps/xct6DrdX5MiwNHq8RpHKA5bYtcgHraFXvvEdfzaJ37tE7/2iX2nna6/I33iUtgNGqaDbDp8
+        3nbZ+uE/vE0ZwRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:57 GMT
+      etag:
+      - W/"6b720c35b5f166692cbd97871ddaa0a1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6037D3:C585BD6:5ED66085
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3424'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d5bdc9969bdd99c8a4a8838f1a387b00803c5ead
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K4eek1ixbMU2FHqQa7lCLqQ9GpxSwspex0r8ESz52kvIf++q6UH7
+        lkD6IqRdrWZ2dtCRmRJYwvJQ5Vkcy1jleRxnEQQQRSIqxiCiieI84iILEXI2YE2b41rnVDSbpnLh
+        x1YtKz7bpsF8+vjz6ZCO5/VinNaft/PnnT9fftqtprswPZTl08cHujMLVtsP5eywEen2/sd8en9I
+        D1+rdLl4R4/3XUUPl9buTeJ5sNejjbZlr0ZZW3sd7lvj1WjB2LbDYaXV0KKxxnPrel2/5kA5tB4V
+        eVRRa8pd0Vpp62r9L4W/4C8BPoNegwm9LduOJUfWQI3U/JcSSujuHl66tiFFsAbtNKE5UXiELvx+
+        44JOE7pAPbsyn/t8yOWQ+8/jIPHHSRiu2GnAzows/kcI2yExOP6x0mSCkRRBEQhFpikKGefBJAgz
+        rnCCWAhfYQZKhredtuNgvIuxSZgajYGNk+6x0VZDdefcs4dsR9G7s2zEcQ8dNtaw5NtbgzLkWZQH
+        MRdSRCgiqVQufSlUKHgBRQYxCCG5um2Db3a+Av1mdr4Y8/R9wF6w04XOwGryL7nifEb6MAqoDA5Y
+        h2BcivWN0ZuGMgPmNmD7jsbR9FXlZH+tWvpvfh9Pp1+rhGPzqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:57 GMT
+      etag:
+      - W/"66d1d866084630701c237f6b9f30433f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A60384A:C585C7B:5ED66085
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3423'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=d5bdc9969bdd99c8a4a8838f1a387b00803c5ead
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5FT17YUGKUxW3FgHetezAmFoD8XW6ksGUtpyEq/+85tYF26
+        F1k3xl5IHDrpnh/PnR4iy1uIJpHigXdc3vEaRmvvbHQSdTw0v874hmOCQk6lYlzlDNjZWSJimqXj
+        PEuVggzyNGYxoyKLsZTX31CEZSfRpjf4tAmh8xNCeKdHtQ7NRoyka0kPnfOkhcB9cD2cGi1OA/jg
+        ybAvl+1uwPQQiHQ2gMXEIfdFD6t3KhVKMpYxoRRjkvJzTmlCV2Oe0FzEMY0TmQJXSNaE1ix/hnoB
+        dAyKME6QYxVf8SIC6h0QvNkWLEUGHk9+oznKba1xXB1A9Hy7783GQ783/KlNx7jyJ4aEXTeM5Eob
+        QHv2yngAW1eXxWwz/zo25Rrjdpwurj7E8+raqKL05eVTfreoru9VNVsvqo/6k56KQl/Wt7YspvkQ
+        lcWwZtt5deOeq9w06ur9vajMj5df0rVM5vr5/pTd2iGqPncYIRJY6ZS2NTIJHMfsHM+WRts7H00e
+        Ig9m9V/NOE7F3+B503AN/+uF+L/9W4+P3wG2f3oA4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:58 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6038A3:C585CEF:5ED66085
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3422'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "d5bdc9969bdd99c8a4a8838f1a387b00803c5ead"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxNzY1OmQyMWQxZGY5YjExOWRmMDMzODIxNjc1ZWU2ZGFiZjYyN2UyYTM2NDM=","sha":"d21d1df9b119df033821675ee6dabf627e2a3643","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/d21d1df9b119df033821675ee6dabf627e2a3643","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:58Z"},"object":{"sha":"d5bdc9969bdd99c8a4a8838f1a387b00803c5ead","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d5bdc9969bdd99c8a4a8838f1a387b00803c5ead"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:58 GMT
+      etag:
+      - '"90f2fc8661279b26d2448e668a4ae9ae"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/d21d1df9b119df033821675ee6dabf627e2a3643
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A60391F:C585D7E:5ED66086
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3421'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "d21d1df9b119df033821675ee6dabf627e2a3643", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxNzY1OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"d21d1df9b119df033821675ee6dabf627e2a3643","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/d21d1df9b119df033821675ee6dabf627e2a3643"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:59 GMT
+      etag:
+      - '"228c06ec5c91b570b3908c50807759f9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A6039DF:C585E77:5ED66086
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3420'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603B4F:C58603A:5ED66087
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3419'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603BC1:C5860CB:5ED66087
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3418'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:59 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603C31:C58613B:5ED66087
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3417'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOm6aJgaJ7aFdgQFpg2ICuLwIl0RZtSdRIyp4j5Lvvf6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJNPRdHJ9czO5/HD9/mxUqlRENDa6+/xl/T3/PU++3t7zH3+sknK5
+        +baYX90tvrz7tvjr4wiTeSEw0wpjo6jYpNxyIyx+mNV5HrW/FgKjVmlxnsv4nOYa9v8VlZYrbkGb
+        8dyIs5Fal0KPps0oV3NZQsgBDASRptfX4w+Tyc3lnvKb78vbzc/JbzX/UWXp13wVL/6e3H1ONneL
+        +b9YyiGP66jWOeiZtZWZMuYHzbuLubRZHddG6ESVVpT2IlEFq1kn7NPq4xUgc91inMkwsIerZEvy
+        y4Ez7PBOMlvke8p4HdzKw2tmKs/VGsz9XRwplm0BdGYOJsv562AANEzZTMC02O4DGUnizE+lusUN
+        o3/wS8IZHJsW6anAdjmUJBd7aJgWlXLcOjaJlpWVqjxZ3R0IoErPeSnv+auggBiwSNGTFXOLAREr
+        OPPJFL+6YS5ckw2ZTYtEyBXO43XkPQzAdlNRdvk+sCCdkrQi4mlBScHlioczRO8LY+dAAkrF9vBH
+        0xL5iyJCL7cJ6cnAdsY9FKQHBBH1GfsfjUMAAwarLMUmGJNYDcPfNt4SJAYeK82RxIMJ2YE2bPiV
+        nMoKXgST5WCAZkqFs7yDASqNqcVRvn/8qTqmYV2wlXUR+0x6TIgdL8bTsAdujJyXQgSz+BbYsO4S
+        iDUvkyyciI7XMP/JeQ2fB9sCsYCMcxUHY+JCZw7YMJNxfzXaKKTWJIF4OwK0mAXdAvG2AqwO6DdO
+        fQJu8bitLVwomP4djzXtCeS8nNd8Hk7CFkiXFUqVOb9/tkI7PmZ7IvBUmmoZ12ETc8+kHfiiCPkn
+        3BH0yF6Aq7qeLuleYKRBJefMVBTyuZrneHqL2wmxwCIoDvbF0PfnS7eXbYN4DevvF3+ZtZJCnUZ7
+        m3X6D+W1b6tgrtXxWPNLxW1GGRZiK65FqM20ONbEeOo+XFxcNJng7llSCB0wi3gasFwnGcrrUPo3
+        HQ+VY8Gte/7MSP0Uz6Fc8TTYWWyBgHsXCLUHTxv6UYV6PZjiDjakFzJH10KV4e6InjiUUyorZzI5
+        5q14fJjvQJtPRpaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/E3OBkAl2Slp4XsN8VyAVVa42
+        QTPkAEmJRAs0qNKIWzxKJ+PJ+Hx8fT6e/Hl5NZ1cTt9f/sScukIP7PE5NzSnqk32+JRbmoL038YK
+        PqEr9XQjaP+NSR0nQIzJesivPWJ6oJf0CCLJ4fR7UXuaLqv9u/1lGGwnU4WoUKd1j3Mj7/F5vFNj
+        JaoucToYXHOLxwZqln6oq8s6QMZN5DPJaGp1jZ4jjVRaLURizXCsz2SDiWu5lDsLqYbcdgv8I78X
+        XkitVdts9M2FNg+jbdh2PFNpeJyLfkBVomw1HG5DJqI0WzP4BgBteTB9xwTuSypmvM5t5N9K1E5F
+        TxYNVrij0AXMQD0vare2nRVvEHLVbo+UFf1nNFysKKrIe4dVS0H9WaCQVdQ6Mv/UHK7nLrBusf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFL7BrEw7bQW5+4jt/6xG994rc+se+00/V3oE9cCrtGw3SQ
+        TYfP2y5bP/wH9Z3b8hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:00 GMT
+      etag:
+      - W/"648da94b967fde8c844f666b203c9790"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603CD8:C5861EA:5ED66088
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3416'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:22:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C937:204C5:A603DAE:C5862F0:5ED66088
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3415'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_fetch_no_tag.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_fetch_no_tag.yaml
@@ -1,0 +1,1340 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:42 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A61E:15800E0:5ED66076
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3453'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:42 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A630:15800F2:5ED66076
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3452'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821730,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE3MzA=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:21:43Z","updated_at":"2020-06-02T14:21:43Z","pushed_at":"2020-06-02T14:21:44Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:44 GMT
+      etag:
+      - '"fc3aa7af02ac5c09bb86daf7f5b08d24"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A662:1580123:5ED66076
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3451'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"5c30adc43beb00f0212c3eb3837f4e197e8524f4","node_id":"MDY6Q29tbWl0MjY4ODIxNzMwOjVjMzBhZGM0M2JlYjAwZjAyMTJjM2ViMzgzN2Y0ZTE5N2U4NTI0ZjQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5c30adc43beb00f0212c3eb3837f4e197e8524f4","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5c30adc43beb00f0212c3eb3837f4e197e8524f4","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:44Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:44Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:45 GMT
+      etag:
+      - '"593f8cfa66dbe48d9175df2a81ec4a03"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A6CF:15801B6:5ED66078
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3450'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X227bOBD9lUDPTiTT8iUGim6LFkUKyEWwbnbtYmFQ0kiilyK1JOXUNvLvOyMr
+        TeyHNgrSt7wYEqkzPHM7HO89xUvwpl7JrQPj9bxEl6Vw3nTv2YLjxjAZBDxNwkEMcRBkAeuzZADx
+        YDIYZyH0L8cwGbIwCxGqdAorkSIo+rAYXbNLF/8lg2i9CL98uPo+20W3X9Y362j3vlh+ioKIfZaL
+        9bvb5frdNpp/XkfsRkS7fDdji2A5/zicsa/hbH4VLNfXb4548doV2hDDlvufBS+4Ofu4MVrhl1By
+        IZEE8sflC6DlP3JavEDn8IOUO3KZBSw4D0bnAZv3wynrT8Nw6d3dR4Ci8duOKMFanhOJKyWc4FLs
+        4Axp8TMDlbbCabNFos4AfnOfiX4WXKYZG4zHExaO++FwAiljl3wcx+EkGePOJB0PIEBgbSgAhXOV
+        nfo+r8RFLlxRxxQAvznCL8FhyrWBcynicwfWWZ9+V6tyS0wsOB9BPnGw/pPPxvi94OGHYrR+hyIk
+        CCi3SnStsIyDnrcBIzKRcCewPDCah3fAOs24tNDzDHBLW16trMgV7vQ8euCuNhh/VUvZ8yq+lZoj
+        iF7vXs7NZ7hYuFKujqP8KL1PSezh0GeE1Z6c++zS6uq23+bVYm4eBEDqXFDibNF0Oe6R/IyGw9Hg
+        WI6uRzd/z2SyXvRn88WObGywxs2pN82iZW231BZMopXDcmoap/Yby283b0jtctPaaBTvV01Htqz/
+        wPPnOXz4LtNS6lvEnlI97ukj8/4PELI6PAuVdzeAoL2vXQEYJ6R/R04L1IkulhrAHpUElUWkZMJi
+        iA2kXYy0ECRzq5DHvpGwxlYd28SIilq7E60jIBrSJudK7BqN6GQIgVSSjaZ2cakBIBA2WF2dkAfE
+        3q+M2PBkS2EwkIDYYEy7WzuBojG3rehi+ooZpwgLByueltRmjVyeXpCvLdheq68t2K1zXlvwcGmh
+        mB1175NasOKGdMObfvsHG3IlhfoXX3BSBJm9xOQXG66SAge/H/8L6MJ6ZLnjwEFT5L0tJFwZ7SBx
+        j2awdqUd0UDxWB5NaP/Vgi4NvAlcbVdILTk4DCrTJoFm5JMof8RRZxkGsbm5v7cxejgTT/i5Tj99
+        PD4JEipy4xX5cPc/nqC5v1kNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:45 GMT
+      etag:
+      - W/"8f691e299f8ef66f828a3f040dd34d54"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A71A:1580215:5ED66079
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3449'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:46 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A740:158023C:5ED66079
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3448'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5c30adc43beb00f0212c3eb3837f4e197e8524f4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTUW+bMBD+K5GfSTDGKQRp0jq1mlKJVNWyTmGaIgMHGBmIbNMuRPnvPS97aN9a
+        aXux8H3cfd99dz4R0wiSkGURUlEWPMwhp7SiLGBFCHkYh1HFIVhFEC8ZrzjxSD+UsJclJqU3u6sH
+        trL5D0XTdsfvb9a/N1P6fN8+tun0pcm+pjRld2rXXj9n7fUx3d61KXuU6VRPG7aj2fZ2uWHf+Wa7
+        pln78AmLj1ph4cbag0l8Xxzkopa2GfNFMXS+hsNg/A6sMHbQMFcyn1sw1vju3O+7YykQA+tjko8Z
+        nUTsA601tlP7txJe0b+H+EL6EU4x2mbQJDmRXnSAzX9rRCP07PZJDz06Ap2QzhOcE4YX4MKfaxd0
+        nuAP2LNLY5TROb2aU7YNeMKChPOMnD1yUWThP1JYDajg9HeVgoquyoqFURQzHgV8GUPJ2EpEec7j
+        IkIkLqMQ6L+dttNg/HdzozEdGCNqZ926l1YKJSeYuQWa/dkziSt2RI0HoaG3hiQ/f3nkCbSsZCGs
+        xNlgx5c74GOohDLgEQ3COIiMvZF1j4hH3Iewo0aqflTKlTyqQWCSu57PL5+7ik2EAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:46 GMT
+      etag:
+      - W/"74bae98a84283a41b370536f9c52cc7b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A771:1580274:5ED6607A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3447'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["5c30adc43beb00f0212c3eb3837f4e197e8524f4"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"25b1590160c09fe579c7dee444e0d999917d2d86","node_id":"MDY6Q29tbWl0MjY4ODIxNzMwOjI1YjE1OTAxNjBjMDlmZTU3OWM3ZGVlNDQ0ZTBkOTk5OTE3ZDJkODY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/25b1590160c09fe579c7dee444e0d999917d2d86","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/25b1590160c09fe579c7dee444e0d999917d2d86","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:46Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:21:46Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"5c30adc43beb00f0212c3eb3837f4e197e8524f4","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5c30adc43beb00f0212c3eb3837f4e197e8524f4","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5c30adc43beb00f0212c3eb3837f4e197e8524f4"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:46 GMT
+      etag:
+      - '"ba67e102cbec1e548b0c6541e00079c4"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/25b1590160c09fe579c7dee444e0d999917d2d86
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A788:1580291:5ED6607A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3446'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngkNiCs2MClRymZqqLJE/XmqjOInsB21A/Pc+1LFLB5a73Hfe
+        PRcWoWHlLRN3oGziQSWEyB5Y11uovaVWruTjW6iCPHyI3Wr7/XqWX7vupd138qTWldtv5Em/P5/t
+        uhoJPMaWIIc4pJJzNfjpp0d31FPTBx5h6GkEkGb6CJPW6wlCwsRvWddhtIo6QE4QXf/16vUBDLLy
+        wpJTNDQ3RaasEYUGnWVNls9yU4AulsWiETB7WsBynotGkBmOAxBBHsHjfU1/fyb+b5vr9QfDTlMA
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:47 GMT
+      etag:
+      - W/"c2e9cb78f060981dc46c268338c861b6"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A7BA:15802D7:5ED6607A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3445'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "25b1590160c09fe579c7dee444e0d999917d2d86"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4tnwAnKR5MZlRbJMDVVWSI7PmqjOI7sAxoQ/72HOnbp0Bve5e65
+        97mxAAdWPzJyA1JH7mRECGzGBq+htZq2YiWKN9c4cfzIdqvXr+1VXHbDpt8P4izXjdm/iLN6f77q
+        dTMReAo9QQZxjDXncrSLT4vmpBaddzzA6KkEkGp8gHlv1RwhYuSPbFs3aUk7QE4QXf/28uoIHbL6
+        xqKRVLTMVZpXSVokXVIdIC+rrtQAWZZBoiuatNRL/VSQGU4jEEEezuL/mv78jPzPNvf7N/M2KLB9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:48 GMT
+      etag:
+      - W/"8389e8131810515a9f642ca3817d83ec"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A7D5:15802FA:5ED6607B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3444'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:48 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A855:1580388:5ED6607C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3443'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTcLECZKsgcW2wG4XKJAuUPSwuxeBkmiJsSSqJGXXEfLf+w4p
+        WbLrJI7DYy6JTZPPDD9mOHzbiUwns+n17e304uby/GRSqVRE1Da5+/xl9a34o0i+fnjg3/9aJtVi
+        /ed9dnV3/+Xy7uG3jxN05qVATyuMjaJynXLLjbD4Yd4URdT9Wgq0WqXFaSHjU+pr2P9H1FouuQVt
+        zgsjTiZqVQk9mbWTQmWygpE9GBgiT6+vz2+m09uLHefX3xYf1j+nvzf8e52nX4tlfP9jevc5Wd/d
+        Z/9iKIc9rqNGF6Dn1tZmxphvNJdnmbR5EzdG6ERVVlT2LFEla1hv7NPy4xUgme4wbsnQsIOrZUfy
+        w4EzbP9MclsWO854H9zI/WPmqijUCszdWRxolm0AtGcOJqvsbTAAWqZsLrC0mO4jLZLEnh9LdYNb
+        Rv9wLglnsG1apMcCu+Fwko7YY8u0qJXjNrFJtKytVNXR7m5BAFU645V84G+CAmLAIkePdswNBkQs
+        cZiPpvjRLXPhmqxp2bRIhFxiP95G3sEAbNc1ZZdvoxWkXZJWRDwtKSm4XPF4guh9ZezsSUCp2Gz+
+        ZFYhf1FE6MUmIT0b2G5x9wXpHkNEfWH9D8YhgAHDqizEOhiTWC3D3y7eEiQGHivNkcSDGdmCtmz8
+        lQ6VFbwMZsvBAM2VCrfyDgaoNKYRB539w3fVMQ3rg61qythn0kNC7HAznoY5cGNkVgkRbMU3wJb1
+        l0CseZXk4Uz0vJb5T+7U8CzYFIgFZFyoOBgTFzpzwJaZnPur0UYhvSYLxNsyoMU86BSItzFgdcBz
+        49wn4AaP29riCAXzv+exttuBgldZw7NwFjZAuqxQqmT84cUK7fCYHYjAU2mqZdyETcwDk2bgiyLk
+        n3BbMCAHA67qer6ke8UijSo5t0xlKV+qeQ6nd7itEAtsguJg1wx9f7l0e900iNey4X7xl1lnKdRu
+        dLdZ7//YXve2Cna0eh5rf6m5zSnDwmzNtQg1mQ7H2hhP3cezs7M2F9w9S0qhA2YRTwOW6yRHeR3K
+        /7bnoXIsuXXPnzm5n+I5VCieBtuLDRBwfwRCzcHTxueoRr0ezHEHG9NLWUC1UFW4O2Igju1Uysq5
+        TA55Kx4e5lvQ9pORVSJOOJ43iAorE4k4wZOdTgCKfBFuFT0N04NG5J+JhUDIBNslLTyvZV4VSEVd
+        qHXQDDlCUiLRAgJVGnGLR+n0fHp+en59ej79++JqNr2YXV3+RJ+mhgb2dJ8b6lM3Jn+6yy11Qfrv
+        YgWfoEo9LwTtvjFJcQLEmHyA/DogZnu0pCcQSYFDvxO1x/my3L3bX4fBdHJVihp1Wv84N/IBn6FY
+        jmqsRDUVdgeNK27x2EDNMjT1dVkPyLmJfCaZzKxuoDlSS63VvUisGbcNmWzUcSUXcmsg1ZAbtcA/
+        8gfjpdRadWKjFxe6PAzZsFM8U2l4XIihQdWi6jwcT0MmojKbZfACAE151H1rCdyXVMx5U9jIv5VI
+        ToUmC4EVx1HoEstAmhfJrZ2y4heEjmo/R8qK/jMEFyvKOvKnw6qFIH0WKGQVtYrMPw3H0XMXWD/Y
+        /+KaMBWqxrZ/0YKu0+0xKQIcUo/3OEJx2BF7gXgsC73rxE38rhO/68TvOrFX2un626MTV8KuIJiO
+        sun4edtn68f/APyWVCAVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:48 GMT
+      etag:
+      - W/"05906554a936dad4db73a987e523b30e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A889:15803C6:5ED6607C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3442'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIBAF0auYtVW3sPMAll7BIHzRRFgDi43x7tLNy7wUkLPxoIkW0WaWEh11
+        5MSWgKhGT4lrSVf9h+qdJ2aHB5fcSIM/9SjbYCXwM3IVJ+yZWw/tTV8bCdGCvh8u9SX+ZwAAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A8AD:15803EB:5ED6607C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3441'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:49 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A8C7:158040B:5ED6607C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3440'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTcLECZKsgcW2wG4XKJAuUPSwuxeBkmiJsSSqJGXXEfLf+w4p
+        WbLrJI7DYy6JTZPPDD9mOHzbiUwns+n17e304uby/GRSqVRE1Da5+/xl9a34o0i+fnjg3/9aJtVi
+        /ed9dnV3/+Xy7uG3jxN05qVATyuMjaJynXLLjbD4Yd4URdT9Wgq0WqXFaSHjU+pr2P9H1FouuQVt
+        zgsjTiZqVQk9mbWTQmWygpE9GBgiT6+vz2+m09uLHefX3xYf1j+nvzf8e52nX4tlfP9jevc5Wd/d
+        Z/9iKIc9rqNGF6Dn1tZmxphvNJdnmbR5EzdG6ERVVlT2LFEla1hv7NPy4xUgme4wbsnQsIOrZUfy
+        w4EzbP9MclsWO854H9zI/WPmqijUCszdWRxolm0AtGcOJqvsbTAAWqZsLrC0mO4jLZLEnh9LdYNb
+        Rv9wLglnsG1apMcCu+Fwko7YY8u0qJXjNrFJtKytVNXR7m5BAFU645V84G+CAmLAIkePdswNBkQs
+        cZiPpvjRLXPhmqxp2bRIhFxiP95G3sEAbNc1ZZdvoxWkXZJWRDwtKSm4XPF4guh9ZezsSUCp2Gz+
+        ZFYhf1FE6MUmIT0b2G5x9wXpHkNEfWH9D8YhgAHDqizEOhiTWC3D3y7eEiQGHivNkcSDGdmCtmz8
+        lQ6VFbwMZsvBAM2VCrfyDgaoNKYRB539w3fVMQ3rg61qythn0kNC7HAznoY5cGNkVgkRbMU3wJb1
+        l0CseZXk4Uz0vJb5T+7U8CzYFIgFZFyoOBgTFzpzwJaZnPur0UYhvSYLxNsyoMU86BSItzFgdcBz
+        49wn4AaP29riCAXzv+exttuBgldZw7NwFjZAuqxQqmT84cUK7fCYHYjAU2mqZdyETcwDk2bgiyLk
+        n3BbMCAHA67qer6ke8UijSo5t0xlKV+qeQ6nd7itEAtsguJg1wx9f7l0e900iNey4X7xl1lnKdRu
+        dLdZ7//YXve2Cna0eh5rf6m5zSnDwmzNtQg1mQ7H2hhP3cezs7M2F9w9S0qhA2YRTwOW6yRHeR3K
+        /7bnoXIsuXXPnzm5n+I5VCieBtuLDRBwfwRCzcHTxueoRr0ezHEHG9NLWUC1UFW4O2Igju1Uysq5
+        TA55Kx4e5lvQ9pORVSJOOJ43iAorE4k4wZOdTgCKfBFuFT0N04NG5J+JhUDIBNslLTyvZV4VSEVd
+        qHXQDDlCUiLRAgJVGnGLR+n0fHp+en59ej79++JqNr2YXV3+RJ+mhgb2dJ8b6lM3Jn+6yy11Qfrv
+        YgWfoEo9LwTtvjFJcQLEmHyA/DogZnu0pCcQSYFDvxO1x/my3L3bX4fBdHJVihp1Wv84N/IBn6FY
+        jmqsRDUVdgeNK27x2EDNMjT1dVkPyLmJfCaZzKxuoDlSS63VvUisGbcNmWzUcSUXcmsg1ZAbtcA/
+        8gfjpdRadWKjFxe6PAzZsFM8U2l4XIihQdWi6jwcT0MmojKbZfACAE151H1rCdyXVMx5U9jIv5VI
+        ToUmC4EVx1HoEstAmhfJrZ2y4heEjmo/R8qK/jMEFyvKOvKnw6qFIH0WKGQVtYrMPw3H0XMXWD/Y
+        /+KaMBWqxrZ/0YKu0+0xKQIcUo/3OEJx2BF7gXgsC73rxE38rhO/68TvOrFX2un626MTV8KuIJiO
+        sun4edtn68f/APyWVCAVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:21:49 GMT
+      etag:
+      - W/"05906554a936dad4db73a987e523b30e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:21:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A8DE:158042A:5ED6607D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3439'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:21:50 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C934:160FC:123A8FE:1580453:5ED6607D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3438'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_list.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_list.yaml
@@ -1,0 +1,6449 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:01 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546393D:641663D:5ED66089
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3414'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:01 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54639BD:64166AB:5ED66089
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3413'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821807,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE4MDc=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:22:01Z","updated_at":"2020-06-02T14:22:01Z","pushed_at":"2020-06-02T14:22:02Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:03 GMT
+      etag:
+      - '"371d3416ce379fa4841d0f2bc1ea6e75"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5463A48:6416749:5ED66089
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3412'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"332dd89982e4a9f259b5ab7d4126e5d228087683","node_id":"MDY6Q29tbWl0MjY4ODIxODA3OjMzMmRkODk5ODJlNGE5ZjI1OWI1YWI3ZDQxMjZlNWQyMjgwODc2ODM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/332dd89982e4a9f259b5ab7d4126e5d228087683","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/332dd89982e4a9f259b5ab7d4126e5d228087683","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:03Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:03Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:04 GMT
+      etag:
+      - '"083e0c7676b35c17bde8f4a5ee5384be"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5463D0F:6416A9B:5ED6608B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3411'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XXW+bMBT9KxXPaSGQDxJp2iZlmjIpjbp169JpigxcwKmxmW3SplH/++4ldG3y
+        sJWqe+tLBDbn+txzP3yzdSQrwBk7BTMWtNNxYlUU3DrjrWNyhhtB4CdJOBqFPvTYKPX7o6jPomHS
+        6/oD6Ce+H3rhcBAGCJUqgSVPEDSbLAZn/shGF8KbrRa9+WR6M5+8D+ar2e2s+Hw1n1z155NP4vTj
+        h/7latqdX0y7i4tpcDk5u5mtLsXpxdlmtsqu55PYn09mb/Z4scrmShPDhvuXnOVMH31YayXxSygY
+        F0gC+ePyCdDyu4wWT9A5/CBhllz2Pd879gbHnn/e7Y19f+wFl87dvQKkxn87ogBjWEYkppJbzgS/
+        hSOkxY40lMpwq/QGiVoN+M19JLqpN0pSPxgOQ7837Pb6IaD8IzaMol4YD3EnTIYBeAisNAmQW1ua
+        seuykp9k3OZVRAK49RFuARZDrjQcCx4dWzDWuPS7XBYbYmLAughyiYNxn3w26veCh++S0bgtkpAg
+        IO0yVpXENPY6zho0T3nMLMf0QDV374B5mjJhoONoYIa2nEoanknc6Tj0wGylUX9ZCdFxSrYRiiGI
+        Xu9ezs1nuJjbQiz3VX4U3qcEdnfoM2Q1B+c+O7Xauu02cTUYm4cGIFTGKXAmr6sc96j9DPr9QbDf
+        js4G376fini16J6eL27JxhpzXB96Uy8av6mWyoCOlbSYTnXhVG5t+e36TQ8tZLqxUXe8fxUd2TLu
+        A8+/x/Dhu1QJoa4Re0h1v6b3zLt/QMhq98xl1t4AgrausjmgTkj/jpzm2CfaWKoBW+wk2Fl4QiYM
+        SqwhaWOkgSCZa4k8tnULq21VkYk1L6m0W9HaA6IhpTMm+W3dI1oZQiClZN1T27hUAxAIa8yuVsgd
+        YuuWmq9ZvCEZNMTA16hpe2sHUDRmNyVdTF8x4qQwt7BkSUFlVrfLwwvytQSba/W1BNtVzmsJ7i4t
+        bGZ71fukEiyZpr7hjH/8xIJcCi6v8AUnRRDpS0x+kWYyznHw+/O/gC6sR5ZbDhw0Rd7bQsKlVhZi
+        +2gGa1aaEQ0ki8TehPar4nRp4E1gK7NEavHOYZCp0jHUI5/A9kccVZqiiPXNfdNo9HAmnvD3Pv30
+        8fhAJOzItVfkw91vnGj0YlkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:04 GMT
+      etag:
+      - W/"2088c8f739296ffa55bbdc1dd1f7d6a9"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5463E8B:6416C67:5ED6608C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3410'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:04 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5463EE7:6416CE3:5ED6608C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3409'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/332dd89982e4a9f259b5ab7d4126e5d228087683
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTXYvbMBD8K0HPTmzLdvwBhRZ8lBR8Jm0hJKWEdby2lZPtIMnXy4X8966aPty9
+        3UH7Iqwd787s7ujCdAcsY0HA6zpJ04RjCGnDo7SKoIrr0OdLjGrOEy+Jl0nAHDaMNe5FTUlFvl2u
+        eWqqjfSK4zYs89VTmX8KymPxXPRfH8r8ISrzL/L+8120O678crPyt5tVsMvXT8VxJ+8363NxbH+V
+        +YGXefGBik9KUuHOmJPOXBdOYtEK003V4jD2rsLTqN0eDWgzKpxLUc0NaqNde+73/bkGwtC4lORS
+        Ri8Ie0drnenl/rWEF/RvIb6RvocTJtONimUXNkCP1Py3DjpQs7tHNQ40EexB2JnQnii8QBv+2Nqg
+        nQn9QD3bNO5xb+4t5x7/7ocZ55kX7NjVYTdFBv8jhVFICi5/reQ3Xlo3PIjjhIexH0YJkn9SiKsq
+        TA4xIUkdB+j9221bDdp9MzcNpketobWjWw3CCJDiGWfWQLM/PhNksTNpPIHCwWiW/fjpsEdUohEH
+        MIJ2Qx3f7kiPoQGp0WEKQVuITYMW7UCIw+wHmEkR1TBJaUue5QiUZK/X62/p0G9xhAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      etag:
+      - W/"bb47bba4fad96c0dc7deaa4676d9bfda"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5463F79:6416D8E:5ED6608C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3408'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["332dd89982e4a9f259b5ab7d4126e5d228087683"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"abefe2a65bfc225fdf5d30bebf418517d3d6adca","node_id":"MDY6Q29tbWl0MjY4ODIxODA3OmFiZWZlMmE2NWJmYzIyNWZkZjVkMzBiZWJmNDE4NTE3ZDNkNmFkY2E=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/abefe2a65bfc225fdf5d30bebf418517d3d6adca","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:05Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:05Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"332dd89982e4a9f259b5ab7d4126e5d228087683","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/332dd89982e4a9f259b5ab7d4126e5d228087683","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/332dd89982e4a9f259b5ab7d4126e5d228087683"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      etag:
+      - '"c551704cd0f23aadc6137b37b98752c3"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5463FD9:6416DF5:5ED6608D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3407'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnglvnAycbUlSgkpWpqcoS2fjRBMVxZD9QU8R/70Mdu3Tocpf7
+        zrvnygIcWXnPyDvQNnKnI0JgD2z0FtreUqsqlb+6xqnTe1pXu8+6Wif1+DLsR3XRm6bbb9XFvD1/
+        2U0zE3gOA0Ed4hRLzvXULz967M5mefCOB5g8jQDSjA+wGHqzQIgY+T3b1s1WUwfICaLr317enOCA
+        rLyy2GkaShJhrSwKKSDVxVFkhcm0Wdn0SeSQWSHko1zlMiEznCcggjxcj/9r+vMz8j/b3G7fLTFA
+        TX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      etag:
+      - W/"358a84c06c723d6dcdb1a90bec5a6251"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546407A:6416ED3:5ED6608D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3406'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "abefe2a65bfc225fdf5d30bebf418517d3d6adca"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWtOkCSgbUkQBycpEEF2ic3zGruI4iq8Voep/5ypGFgaWt7z7
+        7n1nMaMV1TWTdAgmyQCJcBY3YowGO2+4VbUqX0Mb1OF929TPn039kDfjy7Af1Ql2rds/qZN+e/wy
+        u3Zh8DgPDDmiKVVSwuTXH57cUa/7GOSMU+QRJJ6JM64Gr1eEiZK8ZteFxQB3SJIhvv7tFfUBexLV
+        WSQHPAQaLWZQFtr2WVZYYwuT32rUdru5LzZ3JjclmB7YjJYJmWCP4Ol/TX9+Jvlnm8vlG89YjLV9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:06 GMT
+      etag:
+      - W/"1e19452c41b0c8ff16bce984e86bdba3"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54640E3:6416F44:5ED6608D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3405'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:06 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546421A:64170CA:5ED6608E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3404'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/bOBCG/4uvTULHG6SpgaJ76AewQDbAYg/dXgRKoiXGkqglKXsdIf993yEl
+        S3bdxHF4zCWxafKZ4XBmOJx2ItPJfHZ9czO7vJm+P5tUKhURjU1uP39Z3xV/FMm3Dw/8+1+rpFpu
+        /rzPrm7vv1zdfk4+TjCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRbnhYzPaa5hP6+otVxxC9qC
+        F0acTdS6EnoybyeFymQFIQcwEESaXl9P389mN5d7ym/ulh82P2ZfG/69ztNvxSq+/2cGxTe399l/
+        WMohj+uo0QXoubW1mTPmB81vF5m0eRM3RuhEVVZU9iJRJWtYL+zT6uMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9joYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38VFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyOvIcB2G5qyi53IwvSKUkrIp6WlBRcrng8Q/S+MHYOJKBUbA9/Mq+Q
+        vygi9HKbkJ4MbGfcQ0F6QBBRn7H/0TgEMGCwylJsgjGJ1TL87eItQWLgsdIcSTyYkB1oy8Zfyams
+        4GUwWQ4GaK5UOMs7GKDSmEYc5fvHn6pjGtYHW9WUsc+kx4TY8WI8DXvgxsisEiKYxbfAlvWXQKx5
+        leThRPS8lvlPzmt4FmwLxAIyLlQcjIkLnTlgy0zO/dVoo5BakwTi7QjQYhF0C8TbCrA6oN849Qm4
+        xeO2tnChYPr3PNZ2J1DwKmt4Fk7CFkiXFUqVjD88W6EdH7MDEXgqTbWMm7CJeWDSDnxRhPwT7ggG
+        5CDAVV1Pl3QvMNKoknNmKkv5XM1zPL3D7YRYYBEUB/ti6PvzpdvLtkG8lg33i7/MOkmhTqO7zXr9
+        x/K6t1Uw1+p5rH1Xc5tThoXYmmsRajMdjrUxnrqPFxcXbS64e5aUQgfMIp4GLNdJjvI6lP5tz0Pl
+        WHLrnj8LUj/Fc6hQPA12Flsg4N4FQu3B08Z+VKNeD6a4g43ppSzQtVBVuDtiII7lVMrKhUyOeSse
+        H+Y70PaTkVUizjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxEIgZIKdkhae1zLfFUhFXahN0Aw5
+        QlIi0QINqjTiFo/S2XQ2PZ9en09nf19ezWez+fTyB+Y0NXpgv55zTXPqxuTPTEH672IFn9CVeroR
+        tP/GpI4T5BiTD5DfB8T8QC/pF4ikgNPvRe1puqz27/aXYbCdXJWiRp3WP86NfMDn6U6Nlaimwulg
+        cM0tHhuoWYahvi7rATk3kc8kk7nVDXqONFJrdS8Sa8ZjQyYbTVzLpdxZSDXktlvgH/mD8FJqrbpm
+        o28udHkYbcOu45lKw+NCDAOqFlWn4XgbMhGV2ZrBNwBoy6PpOyZwX1Kx4E1hI/9WonYqerJosMId
+        hS5hBup5Ubu166x4g5Cr9nukrOg/o+FiRVlH3jusWgrqzwKFrKLWkfm34XA9d4H1i/0vbghboWps
+        9xct6DrdXZMiwNHq8RpHKA47Yt8gHreF3vrETfzWJ37rE7/1iX2nna6/A33iStg1GqajbDp+3vbZ
+        +vF/O7hf/BUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:07 GMT
+      etag:
+      - W/"66de4af73a3a568dfaac8092d9572160"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:06 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464288:6417149:5ED6608E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3403'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:07 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464314:64171C6:5ED6608F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3402'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/bOBCG/4uvTULHG6SpgaJ76AewQDbAYg/dXgRKoiXGkqglKXsdIf993yEl
+        S3bdxHF4zCWxafKZ4XBmOJx2ItPJfHZ9czO7vJm+P5tUKhURjU1uP39Z3xV/FMm3Dw/8+1+rpFpu
+        /rzPrm7vv1zdfk4+TjCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRbnhYzPaa5hP6+otVxxC9qC
+        F0acTdS6EnoybyeFymQFIQcwEESaXl9P389mN5d7ym/ulh82P2ZfG/69ztNvxSq+/2cGxTe399l/
+        WMohj+uo0QXoubW1mTPmB81vF5m0eRM3RuhEVVZU9iJRJWtYL+zT6uMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9joYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38VFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyOvIcB2G5qyi53IwvSKUkrIp6WlBRcrng8Q/S+MHYOJKBUbA9/Mq+Q
+        vygi9HKbkJ4MbGfcQ0F6QBBRn7H/0TgEMGCwylJsgjGJ1TL87eItQWLgsdIcSTyYkB1oy8Zfyams
+        4GUwWQ4GaK5UOMs7GKDSmEYc5fvHn6pjGtYHW9WUsc+kx4TY8WI8DXvgxsisEiKYxbfAlvWXQKx5
+        leThRPS8lvlPzmt4FmwLxAIyLlQcjIkLnTlgy0zO/dVoo5BakwTi7QjQYhF0C8TbCrA6oN849Qm4
+        xeO2tnChYPr3PNZ2J1DwKmt4Fk7CFkiXFUqVjD88W6EdH7MDEXgqTbWMm7CJeWDSDnxRhPwT7ggG
+        5CDAVV1Pl3QvMNKoknNmKkv5XM1zPL3D7YRYYBEUB/ti6PvzpdvLtkG8lg33i7/MOkmhTqO7zXr9
+        x/K6t1Uw1+p5rH1Xc5tThoXYmmsRajMdjrUxnrqPFxcXbS64e5aUQgfMIp4GLNdJjvI6lP5tz0Pl
+        WHLrnj8LUj/Fc6hQPA12Flsg4N4FQu3B08Z+VKNeD6a4g43ppSzQtVBVuDtiII7lVMrKhUyOeSse
+        H+Y70PaTkVUizjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxEIgZIKdkhae1zLfFUhFXahN0Aw5
+        QlIi0QINqjTiFo/S2XQ2PZ9en09nf19ezWez+fTyB+Y0NXpgv55zTXPqxuTPTEH672IFn9CVeroR
+        tP/GpI4T5BiTD5DfB8T8QC/pF4ikgNPvRe1puqz27/aXYbCdXJWiRp3WP86NfMDn6U6Nlaimwulg
+        cM0tHhuoWYahvi7rATk3kc8kk7nVDXqONFJrdS8Sa8ZjQyYbTVzLpdxZSDXktlvgH/mD8FJqrbpm
+        o28udHkYbcOu45lKw+NCDAOqFlWn4XgbMhGV2ZrBNwBoy6PpOyZwX1Kx4E1hI/9WonYqerJosMId
+        hS5hBup5Ubu166x4g5Cr9nukrOg/o+FiRVlH3jusWgrqzwKFrKLWkfm34XA9d4H1i/0vbghboWps
+        9xct6DrdXZMiwNHq8RpHKA47Yt8gHreF3vrETfzWJ37rE7/1iX2nna6/A33iStg1GqajbDp+3vbZ
+        +vF/O7hf/BUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      etag:
+      - W/"66de4af73a3a568dfaac8092d9572160"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:06 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464398:6417275:5ED6608F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3401'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K8d+VhM374FCW/TAAyOlR8WUIpPsxOyZTSS7OeqJ//1msQftNwX7
+        JWRnMvu8zENOTNfAUgYFVsghDIqq5DyoRBUIzy2wqPxpHEwj4YkQRAlsxNpO4FYKGlrONuE3nphi
+        3bjLl42/mi1+r2ZfvJV6lPk6b5ZqzrP1k9q8LY7ZOt/nLz/2y7ev1HtS2WzuZ89zL59l+0w97jd8
+        /okuH/qGLq6NOejUceAgJztp6qGYlJ1yejx02lFoQJuux3Eji7FBbbRjn9utOgqgHhqHhhyaUJJ6
+        N0irjWq2/1L4C/4a4AvoLZgwmLrrWXpiLSgk8d9rqKF/mL/2XUuOoAJpPaE9UXmCtvx5Z4vWE/qA
+        NNsx7nJ37IZjlz9P/ZTz1A1ydh6xCyOD/xHC9EgMTn+iFEUYh55f+V7hemVVhYnwIz8oKU0RYuXx
+        AksowuC+27YctHM1NhmjUGvYWesWrTQSmgebngOUe6o+XGwjjgfosTWapT8/BHoeFyJOkpijD0nF
+        g6QIoIiEP+UhBoLz2I2jMPbuK/Ajzjeg3y3OV2Oef43YK/aykiUYSfmlVFzOSD+MChqNI9YjaNti
+        Q6vlrqXOiNkXMENP62iHprG2H5sOaMgez+d3BcIxUqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      etag:
+      - W/"c551704cd0f23aadc6137b37b98752c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54643FC:641730F:5ED66090
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3400'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXUvDMBSG/0uvdek6+zUQcUWlAxX1wm4II2lO28w0KU3mmOJ/91QH6vRifiBe
+        JBxykvM+vOfkwVG0BmfocGppQ/NbWkJvbrRydpyG2urzjKkoJiIIo5zHlIcxxJ43YG4U+P0w8DmH
+        AELfjd04YoGLpYy4R5E42HEWrcSnlbWNGRJCG9Erha0WrJfrmrTQaENqsNRY3cKuFGzXgrGGdPts
+        Vq86TAOW5FpZUJjY5D5oodinDArwaOCzIvc8v+CFzwcuA1bs9SNE5AMeUJ5TJKtsLWfvod4AbYPC
+        pGZkW8UPvIiAehsE37YFS5GOx5AvNIfrpZKa8g2Ili7XvVkYaNeGP7dpG1d+YohdNd1IFkIC2rNW
+        xgNY6jJNxovJdV+mc4zrvj89OXYn2ZnkSWrSw+f8apqd3fFsPJ9mp+JcjFgiDssblSajsIvSpFvj
+        5SS71C9VLit+cnTHMvn68sqf54OJeLk/im9UF2UXDUaIBCrXXKgSmRiOY7CHZzMp1K1xhg+OAVn8
+        qxnHqfgNnm8NV/e/3oj/7d96fHwC6a1B3eAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54644B2:64173F1:5ED66090
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3399'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "abefe2a65bfc225fdf5d30bebf418517d3d6adca"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxODA3OmIzOWVkMWNiNTY3ZmFhYjA2NDQ3OGE2MmJkYmQxNjcxYjJhOGVhZTg=","sha":"b39ed1cb567faab064478a62bdbd1671b2a8eae8","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/b39ed1cb567faab064478a62bdbd1671b2a8eae8","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:09Z"},"object":{"sha":"abefe2a65bfc225fdf5d30bebf418517d3d6adca","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '692'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:09 GMT
+      etag:
+      - '"8976974e227cca4d1c548f4c29b7ad5b"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/b39ed1cb567faab064478a62bdbd1671b2a8eae8
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546450F:641745C:5ED66090
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3398'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "b39ed1cb567faab064478a62bdbd1671b2a8eae8", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxODA3OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"b39ed1cb567faab064478a62bdbd1671b2a8eae8","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/b39ed1cb567faab064478a62bdbd1671b2a8eae8"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:10 GMT
+      etag:
+      - '"d6efc36c819cc0680fd0631c1474fbd1"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54645AA:641751A:5ED66091
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3397'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:10 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54646BC:6417661:5ED66092
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3396'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBtmsgcX2sNsFCqQBih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+uZld3kw/nE0qlYqIxia3X76u74o/iuTbxwf+/a9VUi03
+        f95nV7f3X69uvySfJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nH2azm8s95Td3y4+bH7PfG/69ztNvxSq+/2cGxTe399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zz6tMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi53IwvSKUkrIp6WlBRcrng8Q/S+MnYOJKBUbA9/Mq+Q
+        vygi9HKbkJ4NbGfcQ0F6QBBRX7D/0TgEMGCwylJsgjGJ1TL87eItQWLgsdIcSTyYkB1oy8Zfyams
+        4GUwWQ4GaK5UOMs7GKDSmEYc5fvHn6pjGtYHW9WUsc+kx4TY8WI8DXvgxsisEiKYxbfAlvWXQKx5
+        leThRPS8lvlPzmt4FmwLxAIyLlQcjIkLnTlgy0zO/dVoo5BakwTi7QjQYhF0C8TbCrA6oN849Qm4
+        xeO2tnChYPr3PNZ2J1DwKmt4Fk7CFkiXFUqVjD+8WKEdH7MDEXgqTbWMm7CJeWDSDnxRhPwT7ggG
+        5CDAVV3Pl3SvMNKoknNmKkv5Us1zPL3D7YRYYBEUB/ti6PvLpdvrtkG8lg33i7/MOkmhTqO7zXr9
+        x/K6t1Uw1+p5rP2l5janDAuxNdci1GY6HGtjPHUfLy4u2lxw9ywphQ6YRTwNWK6THOV1KP3bnofK
+        seTWPX8WpH6K51CheBrsLLZAwL0LhNqDp439qEa9HkxxBxvTS1mga6GqcHfEQBzLqZSVC5kc81Y8
+        Psx3oO1nI6tEnHE8bxAVViYScYInO3kAinwRzoqehu2hR+SfiYVAyAQ7JS08r2W+K5CKulCboBly
+        hKREogUaVGnELR6ls+lsej69Pp/O/r68ms9m8+nlD8xpavTAnp5zQ3PqxuRPTrmc0hSk/y5W8Ald
+        qecbQftvTOo4AWJMPkB+GxDzA72kJxBJAaffi9rTdFnt3+2vw2A7uSpFjTqtf5wb+YDP050aK1FN
+        hdPB4JpbPDZQswxDfV3WA3JuIp9JJnOrG/QcaaTW6l4k1ozHhkw2mriWS7mzkGrIbbfAP/IH4aXU
+        WnXNRt9c6PIw2oZdxzOVhseFGAZULapOw/E2ZCIqszWDbwDQlkfTd0zgvqRiwZvCRv6tRO1U9GTR
+        YIU7Cl3CDNTzonZr11nxBiFX7fdIWdF/RsPFirKOvHdYtRTUnwUKWUWtI/Nvw+F67gLrF/tf3BC2
+        QtXY7i9a0HW6uyZFgKPV4zWOUBx2xL5BPG4LvfeJm/i9T/zeJ37vE/tOO11/B/rElbBrNExH2XT8
+        vO2z9eP/c880kxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:10 GMT
+      etag:
+      - W/"08869f46520ad919348c04c3cde290ce"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464711:64176C3:5ED66092
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3395'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWtOkCSgbUkQBycpEEF2ic3zGruI4iq8Voep/5ypGFgaWt7z7
+        7n1nMaMV1TWTdAgmyQCJcBY3YowGO2+4VbUqX0Mb1OF929TPn039kDfjy7Af1Ql2rds/qZN+e/wy
+        u3Zh8DgPDDmiKVVSwuTXH57cUa/7GOSMU+QRJJ6JM64Gr1eEiZK8ZteFxQB3SJIhvv7tFfUBexLV
+        WSQHPAQaLWZQFtr2WVZYYwuT32rUdru5LzZ3JjclmB7YjJYJmWCP4Ol/TX9+Jvlnm8vlG89YjLV9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:11 GMT
+      etag:
+      - W/"1e19452c41b0c8ff16bce984e86bdba3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54647A1:6417761:5ED66092
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3394'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K8d+VhM374FCW/TAAyOlR8WUIpPsxOyZTSS7OeqJ//1msQftNwX7
+        JWRnMvu8zENOTNfAUgYFVsghDIqq5DyoRBUIzy2wqPxpHEwj4YkQRAlsxNpO4FYKGlrONuE3nphi
+        3bjLl42/mi1+r2ZfvJV6lPk6b5ZqzrP1k9q8LY7ZOt/nLz/2y7ev1HtS2WzuZ89zL59l+0w97jd8
+        /okuH/qGLq6NOejUceAgJztp6qGYlJ1yejx02lFoQJuux3Eji7FBbbRjn9utOgqgHhqHhhyaUJJ6
+        N0irjWq2/1L4C/4a4AvoLZgwmLrrWXpiLSgk8d9rqKF/mL/2XUuOoAJpPaE9UXmCtvx5Z4vWE/qA
+        NNsx7nJ37IZjlz9P/ZTz1A1ydh6xCyOD/xHC9EgMTn+iFEUYh55f+V7hemVVhYnwIz8oKU0RYuXx
+        AksowuC+27YctHM1NhmjUGvYWesWrTQSmgebngOUe6o+XGwjjgfosTWapT8/BHoeFyJOkpijD0nF
+        g6QIoIiEP+UhBoLz2I2jMPbuK/Ajzjeg3y3OV2Oef43YK/aykiUYSfmlVFzOSD+MChqNI9YjaNti
+        Q6vlrqXOiNkXMENP62iHprG2H5sOaMgez+d3BcIxUqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:11 GMT
+      etag:
+      - W/"c551704cd0f23aadc6137b37b98752c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54647F3:64177D4:5ED66093
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3393'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXUvDMBSG/0uvdek6+zUQcUWlAxX1wm4II2lO28w0KU3mmOJ/91QH6vRifiBe
+        JBxykvM+vOfkwVG0BmfocGppQ/NbWkJvbrRydpyG2urzjKkoJiIIo5zHlIcxxJ43YG4U+P0w8DmH
+        AELfjd04YoGLpYy4R5E42HEWrcSnlbWNGRJCG9Erha0WrJfrmrTQaENqsNRY3cKuFGzXgrGGdPts
+        Vq86TAOW5FpZUJjY5D5oodinDArwaOCzIvc8v+CFzwcuA1bs9SNE5AMeUJ5TJKtsLWfvod4AbYPC
+        pGZkW8UPvIiAehsE37YFS5GOx5AvNIfrpZKa8g2Ili7XvVkYaNeGP7dpG1d+YohdNd1IFkIC2rNW
+        xgNY6jJNxovJdV+mc4zrvj89OXYn2ZnkSWrSw+f8apqd3fFsPJ9mp+JcjFgiDssblSajsIvSpFvj
+        5SS71C9VLit+cnTHMvn68sqf54OJeLk/im9UF2UXDUaIBCrXXKgSmRiOY7CHZzMp1K1xhg+OAVn8
+        qxnHqfgNnm8NV/e/3oj/7d96fHwC6a1B3eAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:11 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546484F:641783C:5ED66093
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3392'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:11 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464896:641789C:5ED66093
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3391'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBtmsgcX2sNsFCqQBih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+uZld3kw/nE0qlYqIxia3X76u74o/iuTbxwf+/a9VUi03
+        f95nV7f3X69uvySfJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nH2azm8s95Td3y4+bH7PfG/69ztNvxSq+/2cGxTe399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zz6tMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi53IwvSKUkrIp6WlBRcrng8Q/S+MnYOJKBUbA9/Mq+Q
+        vygi9HKbkJ4NbGfcQ0F6QBBRX7D/0TgEMGCwylJsgjGJ1TL87eItQWLgsdIcSTyYkB1oy8Zfyams
+        4GUwWQ4GaK5UOMs7GKDSmEYc5fvHn6pjGtYHW9WUsc+kx4TY8WI8DXvgxsisEiKYxbfAlvWXQKx5
+        leThRPS8lvlPzmt4FmwLxAIyLlQcjIkLnTlgy0zO/dVoo5BakwTi7QjQYhF0C8TbCrA6oN849Qm4
+        xeO2tnChYPr3PNZ2J1DwKmt4Fk7CFkiXFUqVjD+8WKEdH7MDEXgqTbWMm7CJeWDSDnxRhPwT7ggG
+        5CDAVV3Pl3SvMNKoknNmKkv5Us1zPL3D7YRYYBEUB/ti6PvLpdvrtkG8lg33i7/MOkmhTqO7zXr9
+        x/K6t1Uw1+p5rP2l5janDAuxNdci1GY6HGtjPHUfLy4u2lxw9ywphQ6YRTwNWK6THOV1KP3bnofK
+        seTWPX8WpH6K51CheBrsLLZAwL0LhNqDp439qEa9HkxxBxvTS1mga6GqcHfEQBzLqZSVC5kc81Y8
+        Psx3oO1nI6tEnHE8bxAVViYScYInO3kAinwRzoqehu2hR+SfiYVAyAQ7JS08r2W+K5CKulCboBly
+        hKREogUaVGnELR6ls+lsej69Pp/O/r68ms9m8+nlD8xpavTAnp5zQ3PqxuRPTrmc0hSk/y5W8Ald
+        qecbQftvTOo4AWJMPkB+GxDzA72kJxBJAaffi9rTdFnt3+2vw2A7uSpFjTqtf5wb+YDP050aK1FN
+        hdPB4JpbPDZQswxDfV3WA3JuIp9JJnOrG/QcaaTW6l4k1ozHhkw2mriWS7mzkGrIbbfAP/IH4aXU
+        WnXNRt9c6PIw2oZdxzOVhseFGAZULapOw/E2ZCIqszWDbwDQlkfTd0zgvqRiwZvCRv6tRO1U9GTR
+        YIU7Cl3CDNTzonZr11nxBiFX7fdIWdF/RsPFirKOvHdYtRTUnwUKWUWtI/Nvw+F67gLrF/tf3BC2
+        QtXY7i9a0HW6uyZFgKPV4zWOUBx2xL5BPG4LvfeJm/i9T/zeJ37vE/tOO11/B/rElbBrNExH2XT8
+        vO2z9eP/c880kxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:12 GMT
+      etag:
+      - W/"08869f46520ad919348c04c3cde290ce"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54648EB:64178FE:5ED66093
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3390'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aSBT+K5GfSWzGFy5S1e4KIqVSiKrNNoUqQuPxMZ4wHntnxrQE8d97xpgm
+        8JDiKPuWFwRjn2++850rG0fSHJyhk1NtQDkdhxV5zo0z3Dg6o/iAxpACoVEYp4yQME3SMPG9GOI0
+        6PbDbi/xk4gmjKKpLBKY8wSNrkfT6AsZmPhOeNcP0+BmdPXzZvSXf5Nf8tndTFznYzK5+5xPH6/W
+        k7vZcvbwdXn9+Dc++5xPRuNgcjv2Z6PJcpJfLqdk/OGAF61MVijLsOH+T0Yzqs7GK1VIfBNyygWS
+        QP54fAH2+NPCHl6gc/hCQo11mXjEO/eic4/cdoMhIUMvnDnbvQJWjf/tihy0pgtL4kpyw6k4Q060
+        pGyJp2dNCDqOUYDv7CPR60E/8oM08GPPZ2kaDZKgF4QMg9EDSH0SA6NxFKKHlbICZMaUeui6tOQX
+        C26yKrYCuArKQrs5GAx5oeBc8PjcgDbatZ/zeb62ZDQYF41cy0G7J9+N+r3h5TsltNsiCa0JSDNn
+        RSUxjb2OswLFU86o4ZgeqObuN2CeplRo6DgKqLaPnEpqvpD4pOPYL9RUCvWXlRAdp6RrUVA0sj+3
+        b+fmK1zMTC7mhyo/C+8pgd1d+gpZ9dG9r06ttm67TVw1xuapAYhiwW3gdFZXOT6z7ScKw8g/bEdf
+        oq/fJoI9TLuT2+mjxVhhjqtjb+pDTZpqqTQoVkiD6VQXTuXWyB9XHwJEWKgGo+54fyo6i6XdJ54v
+        x/DpvbQQoviBtsdUD2v6AN79bYSsdt+5XLQHQKONW5gMUCekv7VOc+wTbZBqgw12EuwsPLEQGiVW
+        kLQBaUyQzA+JPDZ1C6uxqlgzxUtb2q1oHRgiUKEWVPLHuke0AkJDm5J1T23jUm2AhrDC7GplubPY
+        uKXiK8rWVgYFDPgKNW2PdmSKYGZd2sH0L0bcKswNzGmS2zKr2+XxgHwvwWasvpdgu8p5L8Hd0MJm
+        dlC9J5VgSZXtG87w+3479H2SJP3BoE8goIOUhIM4pHEvCbokgjAhpO/1e1HfR/g3WtD2I7zFzS9P
+        vRaby8l3bu+xYc0Fl0sUC7UCkb7FZhwrKlmGi/Hv/03WtWfILRcyu2XvsZBwqQoDzDzbUZuTZoUF
+        SWNxsMH+V3E7VHFSmkrPkRrbOQwyLRSDeiUWOB4sxyJNMQvqzeZnnUP3dp99uuHlOXb634cjkXBi
+        1V5ZH7a/AD+kzlF5DgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:12 GMT
+      etag:
+      - W/"2e5b401f9fa09972f87e907fb1a89aa2"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464948:6417970:5ED66094
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3389'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:12 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546498F:64179D0:5ED66094
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3388'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K8d+VhM374FCW/TAAyOlR8WUIpPsxOyZTSS7OeqJ//1msQftNwX7
+        JWRnMvu8zENOTNfAUgYFVsghDIqq5DyoRBUIzy2wqPxpHEwj4YkQRAlsxNpO4FYKGlrONuE3nphi
+        3bjLl42/mi1+r2ZfvJV6lPk6b5ZqzrP1k9q8LY7ZOt/nLz/2y7ev1HtS2WzuZ89zL59l+0w97jd8
+        /okuH/qGLq6NOejUceAgJztp6qGYlJ1yejx02lFoQJuux3Eji7FBbbRjn9utOgqgHhqHhhyaUJJ6
+        N0irjWq2/1L4C/4a4AvoLZgwmLrrWXpiLSgk8d9rqKF/mL/2XUuOoAJpPaE9UXmCtvx5Z4vWE/qA
+        NNsx7nJ37IZjlz9P/ZTz1A1ydh6xCyOD/xHC9EgMTn+iFEUYh55f+V7hemVVhYnwIz8oKU0RYuXx
+        AksowuC+27YctHM1NhmjUGvYWesWrTQSmgebngOUe6o+XGwjjgfosTWapT8/BHoeFyJOkpijD0nF
+        g6QIoIiEP+UhBoLz2I2jMPbuK/Ajzjeg3y3OV2Oef43YK/aykiUYSfmlVFzOSD+MChqNI9YjaNti
+        Q6vlrqXOiNkXMENP62iHprG2H5sOaMgez+d3BcIxUqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      etag:
+      - W/"c551704cd0f23aadc6137b37b98752c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464A20:6417A65:5ED66094
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3387'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["abefe2a65bfc225fdf5d30bebf418517d3d6adca"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"5dbcb2b5da7f819025adf6fcee0c59cbdf48e021","node_id":"MDY6Q29tbWl0MjY4ODIxODA3OjVkYmNiMmI1ZGE3ZjgxOTAyNWFkZjZmY2VlMGM1OWNiZGY0OGUwMjE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5dbcb2b5da7f819025adf6fcee0c59cbdf48e021","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5dbcb2b5da7f819025adf6fcee0c59cbdf48e021","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:13Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:13Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"abefe2a65bfc225fdf5d30bebf418517d3d6adca","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/abefe2a65bfc225fdf5d30bebf418517d3d6adca"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      etag:
+      - '"e049ecc3ee17cae7a5270f1ed5ae04e2"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5dbcb2b5da7f819025adf6fcee0c59cbdf48e021
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464A6E:6417ACE:5ED66095
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3386'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWtOkCSgbUkQBycpEEF2ic3zGruI4iq8Voep/5ypGFgaWt7z7
+        7n1nMaMV1TWTdAgmyQCJcBY3YowGO2+4VbUqX0Mb1OF929TPn039kDfjy7Af1Ql2rds/qZN+e/wy
+        u3Zh8DgPDDmiKVVSwuTXH57cUa/7GOSMU+QRJJ6JM64Gr1eEiZK8ZteFxQB3SJIhvv7tFfUBexLV
+        WSQHPAQaLWZQFtr2WVZYYwuT32rUdru5LzZ3JjclmB7YjJYJmWCP4Ol/TX9+Jvlnm8vlG89YjLV9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      etag:
+      - W/"1e19452c41b0c8ff16bce984e86bdba3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464B13:6417B88:5ED66095
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3385'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "5dbcb2b5da7f819025adf6fcee0c59cbdf48e021"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vngkMgFLIhRYVWsjI1VVkif7zURnEc2Q/UFPHf+1DHLh263OW+
+        8+65sggdK++ZuAVpEvcyIUT2wIZgoHWGWlGJ9atvvDi9r+rq+bOudst6eOmPg7jIfWOPB3FRb09f
+        Zt9MBJ5jT5BFHFPJuRzd/MOhPau5Dp5HGAONANJMiDDrnZohJEz8nm3rJyOpA+QE0fVvr6BOoJGV
+        V5aspKHCKK1yVRj52G0W2ywvpOnWnQbIdLHVynSrDWT5gsxwGoEI8vAO/9f052fif7a53b4BhuhW
+        wn0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:14 GMT
+      etag:
+      - W/"22e97c56f82c1abb44858f55d512696d"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464B66:6417C08:5ED66095
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3384'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:14 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464C61:6417D31:5ED66096
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3383'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBtmsgcX2sNsFCqQBih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+uZld3kw/nE0qlYqIxia3X76u74o/iuTbxwf+/a9VUi03
+        f95nV7f3X69uvySfJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nH2azm8s95Td3y4+bH7PfG/69ztNvxSq+/2cGxTe399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zz6tMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi53IwvSKUkrIp6WlBRcrng8Q/S+MnYOJKBUbA9/Mq+Q
+        vygi9HKbkJ4NbGfcQ0F6QBBRX7D/0TgEMGCwylJsgjGJ1TL87eItQWLgsdIcSTyYkB1oy8Zfyams
+        4GUwWQ4GaK5UOMs7GKDSmEYc5fvHn6pjGtYHW9WUsc+kx4TY8WI8DXvgxsisEiKYxbfAlvWXQKx5
+        leThRPS8lvlPzmt4FmwLxAIyLlQcjIkLnTlgy0zO/dVoo5BakwTi7QjQYhF0C8TbCrA6oN849Qm4
+        xeO2tnChYPr3PNZ2J1DwKmt4Fk7CFkiXFUqVjD+8WKEdH7MDEXgqTbWMm7CJeWDSDnxRhPwT7ggG
+        5CDAVV3Pl3SvMNKoknNmKkv5Us1zPL3D7YRYYBEUB/ti6PvLpdvrtkG8lg33i7/MOkmhTqO7zXr9
+        x/K6t1Uw1+p5rP2l5janDAuxNdci1GY6HGtjPHUfLy4u2lxw9ywphQ6YRTwNWK6THOV1KP3bnofK
+        seTWPX8WpH6K51CheBrsLLZAwL0LhNqDp439qEa9HkxxBxvTS1mga6GqcHfEQBzLqZSVC5kc81Y8
+        Psx3oO1nI6tEnHE8bxAVViYScYInO3kAinwRzoqehu2hR+SfiYVAyAQ7JS08r2W+K5CKulCboBly
+        hKREogUaVGnELR6ls+lsej69Pp/O/r68ms9m8+nlD8xpavTAnp5zQ3PqxuRPTrm8oilI/12s4BO6
+        Us83gvbfmNRxAsSYfID8NiDmB3pJTyCSAk6/F7Wn6bLav9tfh8F2clWKGnVa/zg38gGfpzs1VqKa
+        CqeDwTW3eGygZhmG+rqsB+TcRD6TTOZWN+g50kit1b1IrBmPDZlsNHEtl3JnIdWQ226Bf+QPwkup
+        teqajb650OVhtA27jmcqDY8LMQyoWlSdhuNtyERUZmsG3wCgLY+m75jAfUnFgjeFjfxbidqp6Mmi
+        wQp3FLqEGajnRe3WrrPiDUKu2u+RsqL/jIaLFWUdee+waimoPwsUsopaR+bfhsP13AXWL/a/uCFs
+        haqx3V+0oOt0d02KAEerx2scoTjsiH2DeNwWeu8TN/F7n/i9T/zeJ/addrr+DvSJK2HXaJiOsun4
+        edtn68f/AScRG/EVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:15 GMT
+      etag:
+      - W/"85ed5667ef075a56e44c620161729c11"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464CA0:6417D8C:5ED66096
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3382'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:15 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464D1F:6417DFC:5ED66097
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3381'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBtmsgcX2sNsFCqQBih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+uZld3kw/nE0qlYqIxia3X76u74o/iuTbxwf+/a9VUi03
+        f95nV7f3X69uvySfJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nH2azm8s95Td3y4+bH7PfG/69ztNvxSq+/2cGxTe399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zz6tMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi53IwvSKUkrIp6WlBRcrng8Q/S+MnYOJKBUbA9/Mq+Q
+        vygi9HKbkJ4NbGfcQ0F6QBBRX7D/0TgEMGCwylJsgjGJ1TL87eItQWLgsdIcSTyYkB1oy8Zfyams
+        4GUwWQ4GaK5UOMs7GKDSmEYc5fvHn6pjGtYHW9WUsc+kx4TY8WI8DXvgxsisEiKYxbfAlvWXQKx5
+        leThRPS8lvlPzmt4FmwLxAIyLlQcjIkLnTlgy0zO/dVoo5BakwTi7QjQYhF0C8TbCrA6oN849Qm4
+        xeO2tnChYPr3PNZ2J1DwKmt4Fk7CFkiXFUqVjD+8WKEdH7MDEXgqTbWMm7CJeWDSDnxRhPwT7ggG
+        5CDAVV3Pl3SvMNKoknNmKkv5Us1zPL3D7YRYYBEUB/ti6PvLpdvrtkG8lg33i7/MOkmhTqO7zXr9
+        x/K6t1Uw1+p5rP2l5janDAuxNdci1GY6HGtjPHUfLy4u2lxw9ywphQ6YRTwNWK6THOV1KP3bnofK
+        seTWPX8WpH6K51CheBrsLLZAwL0LhNqDp439qEa9HkxxBxvTS1mga6GqcHfEQBzLqZSVC5kc81Y8
+        Psx3oO1nI6tEnHE8bxAVViYScYInO3kAinwRzoqehu2hR+SfiYVAyAQ7JS08r2W+K5CKulCboBly
+        hKREogUaVGnELR6ls+lsej69Pp/O/r68ms9m8+nlD8xpavTAnp5zQ3PqxuRPTrm8oilI/12s4BO6
+        Us83gvbfmNRxAsSYfID8NiDmB3pJTyCSAk6/F7Wn6bLav9tfh8F2clWKGnVa/zg38gGfpzs1VqKa
+        CqeDwTW3eGygZhmG+rqsB+TcRD6TTOZWN+g50kit1b1IrBmPDZlsNHEtl3JnIdWQ226Bf+QPwkup
+        teqajb650OVhtA27jmcqDY8LMQyoWlSdhuNtyERUZmsG3wCgLY+m75jAfUnFgjeFjfxbidqp6Mmi
+        wQp3FLqEGajnRe3WrrPiDUKu2u+RsqL/jIaLFWUdee+waimoPwsUsopaR+bfhsP13AXWL/a/uCFs
+        haqx3V+0oOt0d02KAEerx2scoTjsiH2DeNwWeu8TN/F7n/i9T/zeJ/addrr+DvSJK2HXaJiOsun4
+        edtn68f/AScRG/EVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:15 GMT
+      etag:
+      - W/"85ed5667ef075a56e44c620161729c11"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464D7D:6417E8A:5ED66097
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3380'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5dbcb2b5da7f819025adf6fcee0c59cbdf48e021
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VSXY/aMBD8Kyc/A7EdHCBSpZ4ERfcQoqp3h0hVoXW8IYF8KXauhxD/vXbpSe0b
+        SPTF8u56PTuzcyI6BxISoWQquRQKJtmUzSgXoLIgSxFpKmapVNl4ipQzMiB1o3BbKNsUzTfBVz4z
+        cl3SaL8Zx/On93j+6Mf718OmWhVR9cSS5cJP9rv3+PnxuFp/OST7pNrw1zJaRixer4pkuaHx8uVn
+        tF98sp/3XWk/zo1pdeh50BajXWHyXo7SpvI6bBvtVWhAm6bDYVnIoUFttOfO7bY6KrA1NJ5t8mxH
+        VdjaDdRyU5Xbf0f4C/4a4AvoLZjQm7zpSHgiNVRoyX/LIYfuYfHWNbVVBCsonCZ2TzY9Qpf+vHNJ
+        p4l9YDm7Nk45HdJgSPkzG4ech8xPyHlALhMZ/I8QpkM7wemPlRiwFFLrp5maCBFMJkz5nAoUiDMx
+        FRPuB5L6jN93224G7V2NbYWpUGvYOenm1jUtpAcbPfSt01PZ4VrosDaahN8/mIHEDDkEQmYp5yJT
+        mVA+lSizMZsKNlG+CkClcF9mHz6+Af1uPr4a8/xjQN6wK7IiBVNY41o7XGKrZZhBqXFAOgTtSqSv
+        dbGrf6vsLmD6zu6h7svSyX4sG7BNLjyffwFJEUHYoQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      etag:
+      - W/"e049ecc3ee17cae7a5270f1ed5ae04e2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464DE4:6417EF8:5ED66097
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3379'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5dbcb2b5da7f819025adf6fcee0c59cbdf48e021
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft7HsxE+BMZrQlgSase7FnBAIejjFSmXJWEpDWvrdKzVmtOle
+        ZN0YfSOJO93dj7v/PQYK1xAMA4YtbjC9w2vobYxWwVnQYFv93mMq7ByEpIgzlOdxgmJU9HGWoH6W
+        sixNWZ7iPsvyLKYcuVRGPLgiUTQ4C7atdLGVtY0ZhiFuRG8tbLUlParrsIVGm7AGi43VLZxLQc4t
+        GGtCf65W9d5zGrAh1cqCco5j8K8t8C8JI5TEJGE443lUoDjBjKecAiCaFJQwPsgBxZFDq2wtV2+h
+        XgGdgkKkJuGpFd/xOgRX74jgw21xqULPY8I/mA7TOyU1ZkcQLd51s9kaaLuGv4zplK78TUPsvvGa
+        5EKCa09X2Rlgp9eT8RRBOZKTjXvXswcmJmZy8WLfzn9GnT1KFtdXaF7OJBsf/EvlfuwX5eyeldPN
+        orwR38SIjMWFixxlh9u/p7t5easP2W8rdn15T0q5X6pfkT+SDe3PRRdZ+Lv83hRLvzKgqGZCrf12
+        OJmmA2dbSaHuTDB8DAxI/qm079TyL3g+JDq/d6+K/9+de3p6BnYOAAP5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464E55:6417F5D:5ED66098
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3378'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "Second version", "tag": "version-1.1", "type":
+      "commit", "object": "5dbcb2b5da7f819025adf6fcee0c59cbdf48e021"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxODA3OjYxMzEyMTliOGZkNDkxM2EzOTJjNWIxYWQ1NTdhMDQzMTAyMTNkODk=","sha":"6131219b8fd4913a392c5b1ad557a04310213d89","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6131219b8fd4913a392c5b1ad557a04310213d89","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:16Z"},"object":{"sha":"5dbcb2b5da7f819025adf6fcee0c59cbdf48e021","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5dbcb2b5da7f819025adf6fcee0c59cbdf48e021"},"tag":"version-1.1","message":"Second
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '693'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:17 GMT
+      etag:
+      - '"51949a90e0675f87e009fdfacbe9c174"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6131219b8fd4913a392c5b1ad557a04310213d89
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464EA8:6417FEA:5ED66098
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3377'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "6131219b8fd4913a392c5b1ad557a04310213d89", "ref":
+      "refs/tags/version-1.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.1","node_id":"MDM6UmVmMjY4ODIxODA3OnJlZnMvdGFncy92ZXJzaW9uLTEuMQ==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1","object":{"sha":"6131219b8fd4913a392c5b1ad557a04310213d89","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6131219b8fd4913a392c5b1ad557a04310213d89"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:17 GMT
+      etag:
+      - '"f9319485d54b180fd3d5fcacd595fec7"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5464F42:64180BB:5ED66099
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3376'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:18 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465025:64181E4:5ED66099
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3375'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__otherdataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821881,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE4ODE=","name":"test__otherdataset","full_name":"metastore-lib-tests/test__otherdataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__otherdataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/deployments","created_at":"2020-06-02T14:22:18Z","updated_at":"2020-06-02T14:22:18Z","pushed_at":"2020-06-02T14:22:19Z","git_url":"git://github.com/metastore-lib-tests/test__otherdataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__otherdataset.git","clone_url":"https://github.com/metastore-lib-tests/test__otherdataset.git","svn_url":"https://github.com/metastore-lib-tests/test__otherdataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '7043'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:19 GMT
+      etag:
+      - '"0a913a9fc5f3cf46bdbe1158ec9e0548"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546507C:6418248:5ED6609A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3374'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__otherdataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md"}},"commit":{"sha":"68fa7024cfa2864d5492d25db72b53fc8df05c44","node_id":"MDY6Q29tbWl0MjY4ODIxODgxOjY4ZmE3MDI0Y2ZhMjg2NGQ1NDkyZDI1ZGI3MmI1M2ZjOGRmMDVjNDQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/68fa7024cfa2864d5492d25db72b53fc8df05c44","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/68fa7024cfa2864d5492d25db72b53fc8df05c44","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:19Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:19Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1815'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:20 GMT
+      etag:
+      - '"03a53c8491f67b7cf2d7f7f90b1fefb4"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465205:6418434:5ED6609B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3373'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bMBD9lUBnJ5JpeQWK9uAi8MEO0iWtXRQCJVESXYpUScqNY+TfO0MrTexD
+        GqXpLRdDIvWGb7bH8c6TtGTexCupsUx7HS9RZcmtN9l5pqCwMRhldBiQMMkoGQ3CtB+OSUr6aTwk
+        cb+XJaM0C/pJGAJUqpRFPAXQfLocXJKxjb+IYL5ehhfT2fXFNL++gOdV+b43n86CJVkV83VOFueX
+        3cX0x3Y1nXVX57PevJx152S1vjj/UM6nV+vF9PLNAS9a20JpZNhw/1jQguqT9xutJHzJSsoFkAD+
+        sHzGcPldjotn4Bx8kFKLLpOABKfB4DQgn7rhhJBJd7zybu8igNH4b0eUzBiaI4mZ5JZTwW/YCdCi
+        J5pVynCr9BaIWs3gm7tMdLNgnGakNxyOSDjshv0RSwkZ02Ech6NkCDujdNhjAQBrjQEorK3MxPdp
+        xc9ybos6xgD47gi/ZBZSrjQ7FTw+tcxY4+NvFClbMI1kDLM+4HykYfwnHw8hfNnz9yVp/BaliBAm
+        bZSoWkIxBx1vwzTPeEIthyKBmO7fGVRrRoVhHU8zanDLq6XhuYSdjocP1NYasiBrITpeRbdCUQDh
+        6+2LevoMLwtbiugw1g/y/MQM7899RnDN0dH/UmZtnfebBBtI0r0eCJVzzKApXNPDHqrRoN8f9A7V
+        6XJw9XUhkvWyu/i0vEEbG6h3feyQWzSkaZ7aMJ0oaaGuXB/VvrP8dvMGxS/XjQ0ngH/rQbRl/Hue
+        j2fy/rtMCaF+AfaY6mGLH5j3/4CA1f6Zy7y9AQDtfCcOEdq/Rac5yEYbSw6wA1UBoeEpmjAQYs3S
+        NkYaCJD5JYHHzimas1XHJtG8wh5vResACIaUzqnkN04sWhkCIJakk9g2LjkAANkGqqsVco/Y+ZXm
+        G5psMQyaJYxvIKbtrR1BwZjdVnhPfYaMY4S5ZRFNS2wzp5vH9+VrCza37GsLtuuc1xbcX1ogZgfd
+        +6QWrKhG3fAm375DQ0aCyx/wAoMjE9kLDYKxpjIpYA78808B76wHxttPHjhX3pkD2pVWliX2wUjW
+        rDQTG5M0FgcD28+a49UB94GtTQTskr3bTGZKJ8xNgAJEEGmqLINQuvv7uonU/ZlwwuNq3WpmPgoV
+        SLNzDN24/Q14JDYjcQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:20 GMT
+      etag:
+      - W/"ebac6178876b00dcd33a356d25e42a79"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465315:6418592:5ED6609C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3372'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"otherdataset\",
+      \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"05b0607cc662220661603d446d71eef5c4719212","size":99,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/05b0607cc662220661603d446d71eef5c4719212"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '686'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:21 GMT
+      etag:
+      - '"af7fbe6e808b96cd8a71d201501f97eb"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546536A:64185F1:5ED6609C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3371'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/68fa7024cfa2864d5492d25db72b53fc8df05c44
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTYvbMBD9K0FnJ5ZlJf6AQg9egg9OSFta4lKCbI1tpf4IkrxsGvLfO2p6aG+7
+        0F6MNE8z782b8Y2YTpCUbOJGRJTxuhEs3nC55gmTbC2riFXrsKlj2dB1zTnxyDhJOCmJSUV23BxY
+        YqsvPS3OR77P8pd91r7s8VwOT2GR5fTIyq44t2y3PQS77Pu1zPKg3OZhMeRBwcrzfvthKLLP5112
+        eIfFZ91j4c7ai0l9X1zUqlW2m6tVPQ2+hstk/AGsMHbSsOxVtbRgrPHd93SabAdaCoTB+pjnY9Kg
+        EH5Dd50d+tPfKv5Q8EruB+9baMVsu0mT9EZGMQBa8LETndCLp2c9jegLDEI5Z3BaGF6BC79vXdA5
+        gw+wbZfGKKNLullS9ingKWNpkJTk7pGHIgv/kcJqQAW33wsVNDSRDQujKGY8Cvg6BslYIqKq4nEd
+        IRLLKAT6z2fuZBj/1fTozQDGiNa5l4/KKtGrH7Bwa7T4tXAKd+2KMi9Cw2gNSb9+88gzaNWoWliF
+        48GmH3fAv6IRvQGPaBDGQWQejWpHRDziDsLOGqnGue9dyWs/CUxy1/v9J0Ex+keNAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:21 GMT
+      etag:
+      - W/"09c4fde4720cc815029b1742395de8e7"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54653E7:6418679:5ED6609D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3370'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["68fa7024cfa2864d5492d25db72b53fc8df05c44"],
+      "message": "Initial datapackage commit", "tree": "fa0f09c21c1c7f2607347dd929f58fc34575b5fc"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"9706ad396acdb1bf9f8533896ad52e553bcd56ac","node_id":"MDY6Q29tbWl0MjY4ODIxODgxOjk3MDZhZDM5NmFjZGIxYmY5Zjg1MzM4OTZhZDUyZTU1M2JjZDU2YWM=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/9706ad396acdb1bf9f8533896ad52e553bcd56ac","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/9706ad396acdb1bf9f8533896ad52e553bcd56ac","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:22Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:22Z"},"tree":{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc"},"message":"Initial
+        datapackage commit","parents":[{"sha":"68fa7024cfa2864d5492d25db72b53fc8df05c44","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/68fa7024cfa2864d5492d25db72b53fc8df05c44","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/68fa7024cfa2864d5492d25db72b53fc8df05c44"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1207'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:22 GMT
+      etag:
+      - '"43b098d8232d1d59bf5607180c76a64f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/9706ad396acdb1bf9f8533896ad52e553bcd56ac
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54654E7:64186DE:5ED6609D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3369'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4tnwCh1Qpo5Ki1SlKmpyhL54wUbxXFkPxAU8d/7UMcuHbrc5erc
+        e24swsCqRyZuQZrEvUwIkS3YFAz0zlDb1E3x7jvfHD9FW79d2vpwaafduJ+as9x2dv/anNXHy5fZ
+        dlcCT3EkyCLOqeJczm51cGhPaqWD5xHmQCeAdBMiLEenlggJE39k3we0EI2kGpATR8BvtaCOoJFV
+        N5aspK+iHORmnQk9yKwshMnFc2ay3KhNpvKnQZdmWOdaCJLD6wxEkIp3+O+yP7OJ/1nofv8GAx9N
+        AoMBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:23 GMT
+      etag:
+      - W/"d1ee89fa20adb944b3883fd3d396c926"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:19 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54655A5:641886C:5ED6609E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3368'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "9706ad396acdb1bf9f8533896ad52e553bcd56ac"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy27CMBBF/8VrwC2pU5J1VFokKytSlU1kxxNsFMeRPSAe4t87qMtuuujmSqOr
+        M/fcWISelY9M3IIyiXuVECKbsTEYaJ2hVlYy3/rGy8PXS119nOtqf67HzbAb5UmtG7t7lyf9+XY1
+        6+ZC4DEOBFnEKZWcq8kt9g7tUS+64HmEKdAIIM2ECPPB6TlCwsQf2bYBLUSjqAbkxBHwWy3oA3TI
+        yhtLVtFW8fqUK5MVueqMftZ90a9Elq3oNmIJQmS6M4JKksPLBESQinf477I/bxP/s9D9/g2v0gBw
+        gwEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:24 GMT
+      etag:
+      - W/"e85fc2586ceed0d627e9b47636c4c0c2"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465623:6418920:5ED6609F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3367'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:24 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54656E9:6418A4E:5ED660A0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3366'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTSJHG6RZA4vtIekCBdIARQ/bvQiUREu0JVElKbuOkP/ed0jJ
+        kr3Ohx0ec0lsmnyGQ3KGw7ediHQyC69vbsLLm5vLs0klUx5R2+T+9m79UPxRJN8+P7Lvf62Sarn5
+        c5Fd3S/urh5u775M0JmVHD0N1yaKpMm5Splhmhv8Nm+KIuo6lBytRip+Xoj4nLrr4OCgWokVM2DO
+        WaH52USuK64ms3ZSyExUMHWABFs03+vr6a9h+JMLm4fl582P8PeGfa/z9Fuxihf/hPe3yeZ+kf2H
+        oQz2mIoaVYCeG1PrWRC4Rv3pIhMmb+JGc5XIyvDKXCSyDJqgN/Z19eUKkEx1GLtwaNjD1aIjueHA
+        6eCwJ7kpi73JuDnYkYfHzGVRyDWY+1680WywBdC2WZiosvfBAGgDeyIiWr0nWiSBbT+Vage3Af3D
+        6SScxrYpnp4K7IZjknTEntpA8VpabhPrRInaCFmdPN0dCKBSZawSj+xdUEA0WDTRkydmBwPCVzjM
+        J1Pc6Daw4ZpsaNkUT7hYYT/eR97DAGw2NeWYh9EK0i4JwyOWlpQUbK54OkP0Hhk7h3NQyrf7P5lV
+        yGIUFGq5zUkvxrZd30NxetgWgV/ZhWOIiGTwsDxLvvGJJVwb4G8XewmSBIulYsjpPu3scNtg/JXO
+        mOGs9GnO8sDNpfS6C5YHrtC64W8KiKM22WJ10Adh1ZSxy7BvCb2jLDkgPGFai6zi3Ofqb5lt0F8R
+        sWJVknu10iPbwH2y54hlPh0hHKhxIWOfWNz7gWW2gc6Zu0FN5HnuZISQOzYUn/t2hJBbG0b5PUnW
+        CWJuLeB2NzhUPr3okUHb7UbBqqxhmVcjWyZdcShwMvb4al13VEQPUFigmlaJuPGexQcs+eEKKuQo
+        r9sxUAcbtmh7uSI8brVGtaBdr7IUr1VNRxnoiDvR598Kxce+Jfr+egl4tDOEbIPhSnJXYGfM4850
+        d2Dvxdhk91Lzedh6ZND+UjOTUy6G5Zop7tGljhi0MV7QTxcXF23OmX3qlFz5TTMOCDJTSY6q3aMX
+        bY9EKVoyYx9Wc3IixUOrkCz1uS9bJvjuRHj0xAHHJ6vGY8Dn9C1vbKAUBbQRWXm9Uwbo2FQljZiL
+        5C0v0qOSwA63/apFlfAzhkcUosWIRCB+oA3QgcALgntdTgeEk1Cl3JO04AglnzumuEO2gRMhUl4X
+        cuM7kY6olGkUhySWRszgGRxOw+n59Pp8Gv59eTULw9nlzQ/0aWoIb8/2CT9Rn7rR+fNdrqgLLoou
+        gPAJOtjL0tOBJy3JXOBonQ+c3wbK7ICA9TwlKRAJewF98oxW+3XB0ST4lcuS1yj5el1Ai0d8nu7U
+        aolsKuwUGtfM4DGDqmdo6uu7HpAzHbk8M5kZ1UDxpJZayQVPjB63Dalu1HEtlmJnIJWjW6HCiQuD
+        8VIoJTup0+kaXa6GaNnpranQLC740CBrXnUzHLshEl7p7TI41YFcHnXfWQL7JeVz1hQmcg8xEnMh
+        CkPexdHkqsQykOJGYm+n67gFoWPb+0gJ032G3GN4WUfujBi55KQOA4VUI9eR/rdhOIP2nusHu19s
+        E1yhSm73F8Xp4t0dkyLeITS5GUeoLTtiL0+PRakPlbqJP1TqD5X6Q6V2Oj/dgwdU6oqbNVTaUTYd
+        P5D7bP30P4MA7AmZGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:25 GMT
+      etag:
+      - W/"d71bcab930d9a99269430424ecb37333"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546572D:6418AA8:5ED660A0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3365'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:25 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465794:6418B12:5ED660A1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3364'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTSJHG6RZA4vtIekCBdIARQ/bvQiUREu0JVElKbuOkP/ed0jJ
+        kr3Ohx0ec0lsmnyGQ3KGw7ediHQyC69vbsLLm5vLs0klUx5R2+T+9m79UPxRJN8+P7Lvf62Sarn5
+        c5Fd3S/urh5u775M0JmVHD0N1yaKpMm5Splhmhv8Nm+KIuo6lBytRip+Xoj4nLrr4OCgWokVM2DO
+        WaH52USuK64ms3ZSyExUMHWABFs03+vr6a9h+JMLm4fl582P8PeGfa/z9Fuxihf/hPe3yeZ+kf2H
+        oQz2mIoaVYCeG1PrWRC4Rv3pIhMmb+JGc5XIyvDKXCSyDJqgN/Z19eUKkEx1GLtwaNjD1aIjueHA
+        6eCwJ7kpi73JuDnYkYfHzGVRyDWY+1680WywBdC2WZiosvfBAGgDeyIiWr0nWiSBbT+Vage3Af3D
+        6SScxrYpnp4K7IZjknTEntpA8VpabhPrRInaCFmdPN0dCKBSZawSj+xdUEA0WDTRkydmBwPCVzjM
+        J1Pc6Daw4ZpsaNkUT7hYYT/eR97DAGw2NeWYh9EK0i4JwyOWlpQUbK54OkP0Hhk7h3NQyrf7P5lV
+        yGIUFGq5zUkvxrZd30NxetgWgV/ZhWOIiGTwsDxLvvGJJVwb4G8XewmSBIulYsjpPu3scNtg/JXO
+        mOGs9GnO8sDNpfS6C5YHrtC64W8KiKM22WJ10Adh1ZSxy7BvCb2jLDkgPGFai6zi3Ofqb5lt0F8R
+        sWJVknu10iPbwH2y54hlPh0hHKhxIWOfWNz7gWW2gc6Zu0FN5HnuZISQOzYUn/t2hJBbG0b5PUnW
+        CWJuLeB2NzhUPr3okUHb7UbBqqxhmVcjWyZdcShwMvb4al13VEQPUFigmlaJuPGexQcs+eEKKuQo
+        r9sxUAcbtmh7uSI8brVGtaBdr7IUr1VNRxnoiDvR598Kxce+Jfr+egl4tDOEbIPhSnJXYGfM4850
+        d2Dvxdhk91Lzedh6ZND+UjOTUy6G5Zop7tGljhi0MV7QTxcXF23OmX3qlFz5TTMOCDJTSY6q3aMX
+        bY9EKVoyYx9Wc3IixUOrkCz1uS9bJvjuRHj0xAHHJ6vGY8Dn9C1vbKAUBbQRWXm9Uwbo2FQljZiL
+        5C0v0qOSwA63/apFlfAzhkcUosWIRCB+oA3QgcALgntdTgeEk1Cl3JO04AglnzumuEO2gRMhUl4X
+        cuM7kY6olGkUhySWRszgGRxOw+n59Pp8Gv59eTULw9nlzQ/0aWoIb8/2CT9Rn7rR+fNdrqgLLoou
+        gPAJOtjL0tOBJy3JXOBonQ+c3wbK7ICA9TwlKRAJewF98oxW+3XB0ST4lcuS1yj5el1Ai0d8nu7U
+        aolsKuwUGtfM4DGDqmdo6uu7HpAzHbk8M5kZ1UDxpJZayQVPjB63Dalu1HEtlmJnIJWjW6HCiQuD
+        8VIoJTup0+kaXa6GaNnpranQLC740CBrXnUzHLshEl7p7TI41YFcHnXfWQL7JeVz1hQmcg8xEnMh
+        CkPexdHkqsQykOJGYm+n67gFoWPb+0gJ032G3GN4WUfujBi55KQOA4VUI9eR/rdhOIP2nusHu19s
+        E1yhSm73F8Xp4t0dkyLeITS5GUeoLTtiL0+PRakPlbqJP1TqD5X6Q6V2Oj/dgwdU6oqbNVTaUTYd
+        P5D7bP30P4MA7AmZGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:25 GMT
+      etag:
+      - W/"d71bcab930d9a99269430424ecb37333"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54657ED:6418B81:5ED660A1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3363'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/9706ad396acdb1bf9f8533896ad52e553bcd56ac
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJLZly44DhT6kLSm4oTTLEpcSxrrYyvoSJHnJdsm/74h0oX1L
+        IAVjNHM8mjNnDn4ltgGyJHkWpiDiPAUuqqhSuVqwOF5gLBiVjMUVFwxBMiX9IOReCywqVrv0O81d
+        9diGxWGXbFbr02ZVnzaHp7hYlU25Kti37vOh/LI+7bodKw91VPwuks3WYw8v5fYhKujXA57p7rH4
+        gJePpsWLG+eOdhkEcNTzWrtmrOZ86AIjj4MNOunAusHIWaurmZPW2cC/9/vBNdIIQFi6AOsCLOo0
+        wjdM17iu3f/L4i8GV/a+9L2lLYyuGQxZvpIeOokS/GigATP59GyGHnWRHWivDG4L03Pp0x9rn/TK
+        4Ac4ti+jIQ1nYToL6TZKlpTiU5LzlFwYOfkfWzgjkcHrH0MpCFWYcxrxiGeKpmEWJ5kQOc0VWyge
+        JyxjFVPeUPfduadhg6vbozadtBZqr966105DO/EeOgJ/wuzkohzSPIKRvbNk+fN9xnShIAtpwhXQ
+        RZoIluRUUCaqjFYsVnwhVMh4ktx9xndf30Dgnr6+uu3515Q8S6OV5uA0GhntcYkl/j8UtFZOiZFg
+        PUTG3uq6R2RK/AHcaHAp/di2XvyXdgAs8uH5/AZ+mVxDtwQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:25 GMT
+      etag:
+      - W/"43b098d8232d1d59bf5607180c76a64f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:22 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465849:6418BF2:5ED660A1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3362'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/datapackage.json?ref=9706ad396acdb1bf9f8533896ad52e553bcd56ac
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft/FTLFeBMdqwhQTWsRY2JwSCHs6xUlkyltKQlX73ndrAumwv
+        snWMvbFP+uvuftzDQ2RYC9Eoksyzjok7tobBxlkTnUUd882vFdcwFJKCJyQphSAky7KEkJQkuRwO
+        iSxTgLoQwzKlWZphKKe+YhJKz6Jtr9G18b5zozhmnRqslW+2fCBsG/fQWRe34Jnztodzrfi5B+dd
+        HL6rlfUN9IHUgY+FNR4Masfob3uo39AyIUzmlDAhecprWl8UeX6BZ1lkUBQ5F7JAEeEa3+rVj1wv
+        mE6k4dry+NSkPyEjBaY8gnhNcTBaHJBc/BtdknZntGXyiKNnu0OTtg76Q9mf+nVibV5TFr/vwnjW
+        SgMW6ZAcL2Bn19PxbDv/kurpBu2WJmzyeb+YvE/m1bWW46mbXj692S+q63tZzTaL6oP6qK740ozV
+        JSpX5fM/2LPdvLqxz5FuGjl5d88r/d3zttiIfK7C+6VBTxqs6lNHl2FTwAgrlVkjF8fZJEO8W2ll
+        7lw0eogc6Pp/m3mcj7+E9EeTFlbuRf5/vm6Pj98A9Wz6CPkEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:26 GMT
+      etag:
+      - W/"05b0607cc662220661603d446d71eef5c4719212"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:22 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54658B4:6418C48:5ED660A1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3361'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "9706ad396acdb1bf9f8533896ad52e553bcd56ac"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxODgxOmQ1MjQ0ZGFhNTdhMjgxYmY3MWM0MjJiZDJmY2UyNWE2MjZhZTRhZjk=","sha":"d5244daa57a281bf71c422bd2fce25a626ae4af9","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/d5244daa57a281bf71c422bd2fce25a626ae4af9","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:26Z"},"object":{"sha":"9706ad396acdb1bf9f8533896ad52e553bcd56ac","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/9706ad396acdb1bf9f8533896ad52e553bcd56ac"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '698'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:26 GMT
+      etag:
+      - '"afb150680e1820c8c4f9c47c7a2c7f76"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/d5244daa57a281bf71c422bd2fce25a626ae4af9
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546590C:6418CE2:5ED660A2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3360'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "d5244daa57a281bf71c422bd2fce25a626ae4af9", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxODgxOnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/tags/version-1.0","object":{"sha":"d5244daa57a281bf71c422bd2fce25a626ae4af9","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags/d5244daa57a281bf71c422bd2fce25a626ae4af9"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '397'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:27 GMT
+      etag:
+      - '"4a22c7fa3c475027f179dc0ca3c64645"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54659C8:6418DBA:5ED660A2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3359'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:28 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465B04:6418EDD:5ED660A3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3358'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBknWwGJ72O0CBdIFih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+vZ1d3k5vziaVSkVEY5O7z1/W34o/iuTrhwf+/a9VUi03
+        f95nV3f3X67uPicfJ5jMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nN7PZ7eWe8ptvyw+bH7PfG/69ztOvxSq+/2cGxTd399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zT6uMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi7fRhakU5JWRDwtKSm4XPF4huh9ZewcSECp2B7+ZF4h
+        f1FE6OU2IT0b2M64h4L0gCCivmD/o3EIYMBglaXYBGMSq2X428VbgsTAY6U5kngwITvQlo2/klNZ
+        wctgshwM0FypcJZ3MEClMY04yvePP1XHNKwPtqopY59Jjwmx48V4GvbAjZFZJUQwi2+BLesvgVjz
+        KsnDieh5LfOfnNfwLNgWiAVkXKg4GBMXOnPAlpmc+6vRRiG1JgnE2xGgxSLoFoi3FWB1QL9x6hNw
+        i8dtbeFCwfTveaztTqDgVdbwLJyELZAuK5QqGX94sUI7PmYHIvBUmmoZN2ET88CkHfiiCPkn3BEM
+        yEGAq7qeL+leYaRRJefMVJbypZrneHqH2wmxwCIoDvbF0PeXS7fXbYN4LRvuF3+ZdZJCnUZ3m/X6
+        j+V1b6tgrtXzWPtLzW1OGRZia65FqM10ONbGeOo+XlxctLng7llSCh0wi3gasFwnOcrrUPq3PQ+V
+        Y8mte/4sSP0Uz6FC8TTYWWyBgHsXCLUHTxv7UY16PZjiDjaml7JA10JV4e6IgTiWUykrFzI55q14
+        fJjvQNtPRlaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/EwuBkAl2Slp4Xst8VyAVdaE2QTPk
+        CEmJRAs0qNKIWzxKZ9PZ9Hx6fT6d/X15NZ/N5tPLH5jT1OiBPTnn8prm1I3Jn55yQ1OQ/rtYwSd0
+        pZ5vBO2/ManjBIgx+QD5bUDMD/SSnkAkBZx+L2pP02W1f7e/DoPt5KoUNeq0/nFu5AM+T3dqrEQ1
+        FU4Hg2tu8dhAzTIM9XVZD8i5iXwmmcytbtBzpJFaq3uRWDMeGzLZaOJaLuXOQqoht90C/8gfhJdS
+        a9U1G31zocvDaBt2Hc9UGh4XYhhQtag6DcfbkImozNYMvgFAWx5N3zGB+5KKBW8KG/m3ErVT0ZNF
+        gxXuKHQJM1DPi9qtXWfFG4Rctd8jZUX/GQ0XK8o68t5h1VJQfxYoZBW1jsy/DYfruQusX+x/cUPY
+        ClVju79oQdfp7poUAY5Wj9c4QnHYEfsG8bgt9N4nbuL3PvF7n/i9T+w77XT9HegTV8Ku0TAdZdPx
+        87bP1o//AyHtk7sVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:28 GMT
+      etag:
+      - W/"b0d309cbe0b08d5f7553d76fe06e6c86"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465B59:6418FC4:5ED660A4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3357'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72RyWrDMBCG38Xn2LIsbzLkEEhbGmpMoWtKMSNrkjjEC5Yc6ga/e5QeSymBLpe5
+        zPyab/S9HKwOV1ZyqopoWCuyx06VTW1Tx7UmVt1IzEtpJtJ5Gt5XD1W6ffaz+fVbNp+xrF7slnW6
+        l1eXdTFwb/m0eIdH3t/cXfTpbDo1D/TdzoQ3WrcqIQTa0lmXetMLp2gq0mHbKFKhBqWbDu1dKWyN
+        ShsUU/O8GiSYHmpiQmb6a8ZGbLHQVnKw1AbMMsE4SlqIIIxWAMINfT+KIfSEFJKGERUexAgYGzo9
+        tGgS5vDfRf34ybM5xnHynQf6Mw+3/+HhxPjZQ0gZ9SgX8Ur6nDJg3CsCQUEGQQSuz6jrUSZj/tce
+        zuYYx9cj2yT0HxEDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:29 GMT
+      etag:
+      - W/"67079877d041056b667c271a11880624"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465BB8:641903A:5ED660A4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3356'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/b39ed1cb567faab064478a62bdbd1671b2a8eae8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S22rjMBD9laLnJLblS9LAwhbShBYSUzakOC9hZI1tuZZtJKUkW/LvHZH9gF3Y
+        FzGaM+fMmWG+WD9IPCnJlmy72maHzbrftkWSr14u+eopzvXL7/z98LF936ndvoiPet0U7RPfrd7i
+        fPPMt/r1o9Bvl11bXor2tck3h+a4r3+wCbMNkKiIH1FGpUizeQUgwixJ5gvIuJBCRtk8EhwWCLgg
+        wtl0RGicG+0yCGBUs1q55ixm5aADg+NgA40OrBsMTjslpg6ts4F/Tyd9lUAYuoBIgYPaBv/Qmupr
+        NGz5xXrQSC5+NdCAeXj+NENP1lCD8uZoJkrP0Kd/1j7pzVEBNfc0HvJwGmbTkO+jZMn5Mnw8stuE
+        DaLF0nn9+1ZAYIUcslRUJedpJatUxqFAUSXRIo3mMpYZyBJI2V1Hr0xttHL/d0t3TRv8tRuahDZF
+        bj7RWDX002gWkiWN1kLtXa6Vse7hD0oIRapSJTgq9tPf/0jXVkFnccIMgvUQO/dW1T0hdDgUgDsb
+        EuzPXTdhI1y7AYjkv7fbN1zRPBC0AgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:29 GMT
+      etag:
+      - W/"8976974e227cca4d1c548f4c29b7ad5b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465BF7:6419092:5ED660A5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3355'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:29 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465C3C:64190E2:5ED660A5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3354'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBknWwGJ72O0CBdIFih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+vZ1d3k5vziaVSkVEY5O7z1/W34o/iuTrhwf+/a9VUi03
+        f95nV3f3X67uPicfJ5jMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nN7PZ7eWe8ptvyw+bH7PfG/69ztOvxSq+/2cGxTd399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zT6uMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi7fRhakU5JWRDwtKSm4XPF4huh9ZewcSECp2B7+ZF4h
+        f1FE6OU2IT0b2M64h4L0gCCivmD/o3EIYMBglaXYBGMSq2X428VbgsTAY6U5kngwITvQlo2/klNZ
+        wctgshwM0FypcJZ3MEClMY04yvePP1XHNKwPtqopY59Jjwmx48V4GvbAjZFZJUQwi2+BLesvgVjz
+        KsnDieh5LfOfnNfwLNgWiAVkXKg4GBMXOnPAlpmc+6vRRiG1JgnE2xGgxSLoFoi3FWB1QL9x6hNw
+        i8dtbeFCwfTveaztTqDgVdbwLJyELZAuK5QqGX94sUI7PmYHIvBUmmoZN2ET88CkHfiiCPkn3BEM
+        yEGAq7qeL+leYaRRJefMVJbypZrneHqH2wmxwCIoDvbF0PeXS7fXbYN4LRvuF3+ZdZJCnUZ3m/X6
+        j+V1b6tgrtXzWPtLzW1OGRZia65FqM10ONbGeOo+XlxctLng7llSCh0wi3gasFwnOcrrUPq3PQ+V
+        Y8mte/4sSP0Uz6FC8TTYWWyBgHsXCLUHTxv7UY16PZjiDjaml7JA10JV4e6IgTiWUykrFzI55q14
+        fJjvQNtPRlaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/EwuBkAl2Slp4Xst8VyAVdaE2QTPk
+        CEmJRAs0qNKIWzxKZ9PZ9Hx6fT6d/X15NZ/N5tPLH5jT1OiBPTnn8prm1I3Jn55yQ1OQ/rtYwSd0
+        pZ5vBO2/ManjBIgx+QD5bUDMD/SSnkAkBZx+L2pP02W1f7e/DoPt5KoUNeq0/nFu5AM+T3dqrEQ1
+        FU4Hg2tu8dhAzTIM9XVZD8i5iXwmmcytbtBzpJFaq3uRWDMeGzLZaOJaLuXOQqoht90C/8gfhJdS
+        a9U1G31zocvDaBt2Hc9UGh4XYhhQtag6DcfbkImozNYMvgFAWx5N3zGB+5KKBW8KG/m3ErVT0ZNF
+        gxXuKHQJM1DPi9qtXWfFG4Rctd8jZUX/GQ0XK8o68t5h1VJQfxYoZBW1jsy/DYfruQusX+x/cUPY
+        ClVju79oQdfp7poUAY5Wj9c4QnHYEfsG8bgt9N4nbuL3PvF7n/i9T+w77XT9HegTV8Ku0TAdZdPx
+        87bP1o//AyHtk7sVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:30 GMT
+      etag:
+      - W/"b0d309cbe0b08d5f7553d76fe06e6c86"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465CB3:6419179:5ED660A5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3353'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUbYvaQBD+K8d+VhM374FCW/TAAyOlR8WUIpPsxOyZTSS7OeqJ//1msQftNwX7
+        JWRnMvu8zENOTNfAUgYFVsghDIqq5DyoRBUIzy2wqPxpHEwj4YkQRAlsxNpO4FYKGlrONuE3nphi
+        3bjLl42/mi1+r2ZfvJV6lPk6b5ZqzrP1k9q8LY7ZOt/nLz/2y7ev1HtS2WzuZ89zL59l+0w97jd8
+        /okuH/qGLq6NOejUceAgJztp6qGYlJ1yejx02lFoQJuux3Eji7FBbbRjn9utOgqgHhqHhhyaUJJ6
+        N0irjWq2/1L4C/4a4AvoLZgwmLrrWXpiLSgk8d9rqKF/mL/2XUuOoAJpPaE9UXmCtvx5Z4vWE/qA
+        NNsx7nJ37IZjlz9P/ZTz1A1ydh6xCyOD/xHC9EgMTn+iFEUYh55f+V7hemVVhYnwIz8oKU0RYuXx
+        AksowuC+27YctHM1NhmjUGvYWesWrTQSmgebngOUe6o+XGwjjgfosTWapT8/BHoeFyJOkpijD0nF
+        g6QIoIiEP+UhBoLz2I2jMPbuK/Ajzjeg3y3OV2Oef43YK/aykiUYSfmlVFzOSD+MChqNI9YjaNti
+        Q6vlrqXOiNkXMENP62iHprG2H5sOaMgez+d3BcIxUqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:30 GMT
+      etag:
+      - W/"c551704cd0f23aadc6137b37b98752c3"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465CFC:64191C9:5ED660A6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3352'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=abefe2a65bfc225fdf5d30bebf418517d3d6adca
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TXUvDMBSG/0uvdek6+zUQcUWlAxX1wm4II2lO28w0KU3mmOJ/91QH6vRifiBe
+        JBxykvM+vOfkwVG0BmfocGppQ/NbWkJvbrRydpyG2urzjKkoJiIIo5zHlIcxxJ43YG4U+P0w8DmH
+        AELfjd04YoGLpYy4R5E42HEWrcSnlbWNGRJCG9Erha0WrJfrmrTQaENqsNRY3cKuFGzXgrGGdPts
+        Vq86TAOW5FpZUJjY5D5oodinDArwaOCzIvc8v+CFzwcuA1bs9SNE5AMeUJ5TJKtsLWfvod4AbYPC
+        pGZkW8UPvIiAehsE37YFS5GOx5AvNIfrpZKa8g2Ili7XvVkYaNeGP7dpG1d+YohdNd1IFkIC2rNW
+        xgNY6jJNxovJdV+mc4zrvj89OXYn2ZnkSWrSw+f8apqd3fFsPJ9mp+JcjFgiDssblSajsIvSpFvj
+        5SS71C9VLit+cnTHMvn68sqf54OJeLk/im9UF2UXDUaIBCrXXKgSmRiOY7CHZzMp1K1xhg+OAVn8
+        qxnHqfgNnm8NV/e/3oj/7d96fHwC6a1B3eAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:30 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465D46:641922B:5ED660A6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3351'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6131219b8fd4913a392c5b1ad557a04310213d89
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9lUXPcWzJl40NhS44XbbgmKWmS/YljK2xrcQ3LHlJsuTfO2r6AS30
+        RUhz5pw5c9AnG0aJByVZwrI0i34+fxuy4z7I05dznj75+XF/zq7bS1Z0Kn9+P+3S0zkT22tefD/u
+        3l7O+7dXvitkm6Wv16x4or7dKU9PX9iK6RZINOI+FzwuN7UMYu6DH4sqLDnIMHwEL/C5J7gvNzER
+        lrkjQmvMpBPXhUmtG2XapVxXY+/OOI3a7dGANuOMTqdKx6A22rXn4dBfJBCGxiWSa6DR7j+Mpv4G
+        Z5Z8sgF6JBc/Wmhhfth+zONA1rAHZc3RTlReoy1/bWzRmqMGGm5pwhOe40WOJwoeJEIkPHpntxUb
+        yyNWxurfUwllWZWiDCU81hseeyIEWUd1hehVYVyVsg42SMmQsrlMVpnG9Mr835Tumtr9aze0CSVF
+        bj5w1mocHL62FnvUGprfsWE1DvLhD0wQ3VStKjDUbde/v5G+Ww2dxhWbEbSF2DJo1QyE0M+hC5hl
+        JsVh6boVm+DSjUAk+7zdfgF+yhcgtQIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:31 GMT
+      etag:
+      - W/"51949a90e0675f87e009fdfacbe9c174"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465DB3:641928F:5ED660A6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3350'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:31 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465DFE:6419310:5ED660A7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3349'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBknWwGJ72O0CBdIFih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+vZ1d3k5vziaVSkVEY5O7z1/W34o/iuTrhwf+/a9VUi03
+        f95nV3f3X67uPicfJ5jMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nN7PZ7eWe8ptvyw+bH7PfG/69ztOvxSq+/2cGxTd399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zT6uMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi7fRhakU5JWRDwtKSm4XPF4huh9ZewcSECp2B7+ZF4h
+        f1FE6OU2IT0b2M64h4L0gCCivmD/o3EIYMBglaXYBGMSq2X428VbgsTAY6U5kngwITvQlo2/klNZ
+        wctgshwM0FypcJZ3MEClMY04yvePP1XHNKwPtqopY59Jjwmx48V4GvbAjZFZJUQwi2+BLesvgVjz
+        KsnDieh5LfOfnNfwLNgWiAVkXKg4GBMXOnPAlpmc+6vRRiG1JgnE2xGgxSLoFoi3FWB1QL9x6hNw
+        i8dtbeFCwfTveaztTqDgVdbwLJyELZAuK5QqGX94sUI7PmYHIvBUmmoZN2ET88CkHfiiCPkn3BEM
+        yEGAq7qeL+leYaRRJefMVJbypZrneHqH2wmxwCIoDvbF0PeXS7fXbYN4LRvuF3+ZdZJCnUZ3m/X6
+        j+V1b6tgrtXzWPtLzW1OGRZia65FqM10ONbGeOo+XlxctLng7llSCh0wi3gasFwnOcrrUPq3PQ+V
+        Y8mte/4sSP0Uz6FC8TTYWWyBgHsXCLUHTxv7UY16PZjiDjaml7JA10JV4e6IgTiWUykrFzI55q14
+        fJjvQNtPRlaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/EwuBkAl2Slp4Xst8VyAVdaE2QTPk
+        CEmJRAs0qNKIWzxKZ9PZ9Hx6fT6d/X15NZ/N5tPLH5jT1OiBPTnn8prm1I3Jn55yQ1OQ/rtYwSd0
+        pZ5vBO2/ManjBIgx+QD5bUDMD/SSnkAkBZx+L2pP02W1f7e/DoPt5KoUNeq0/nFu5AM+T3dqrEQ1
+        FU4Hg2tu8dhAzTIM9XVZD8i5iXwmmcytbtBzpJFaq3uRWDMeGzLZaOJaLuXOQqoht90C/8gfhJdS
+        a9U1G31zocvDaBt2Hc9UGh4XYhhQtag6DcfbkImozNYMvgFAWx5N3zGB+5KKBW8KG/m3ErVT0ZNF
+        gxXuKHQJM1DPi9qtXWfFG4Rctd8jZUX/GQ0XK8o68t5h1VJQfxYoZBW1jsy/DYfruQusX+x/cUPY
+        ClVju79oQdfp7poUAY5Wj9c4QnHYEfsG8bgt9N4nbuL3PvF7n/i9T+w77XT9HegTV8Ku0TAdZdPx
+        87bP1o//AyHtk7sVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:31 GMT
+      etag:
+      - W/"b0d309cbe0b08d5f7553d76fe06e6c86"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465E44:641935F:5ED660A7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3348'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5dbcb2b5da7f819025adf6fcee0c59cbdf48e021
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VSXY/aMBD8Kyc/A7EdHCBSpZ4ERfcQoqp3h0hVoXW8IYF8KXauhxD/vXbpSe0b
+        SPTF8u56PTuzcyI6BxISoWQquRQKJtmUzSgXoLIgSxFpKmapVNl4ipQzMiB1o3BbKNsUzTfBVz4z
+        cl3SaL8Zx/On93j+6Mf718OmWhVR9cSS5cJP9rv3+PnxuFp/OST7pNrw1zJaRixer4pkuaHx8uVn
+        tF98sp/3XWk/zo1pdeh50BajXWHyXo7SpvI6bBvtVWhAm6bDYVnIoUFttOfO7bY6KrA1NJ5t8mxH
+        VdjaDdRyU5Xbf0f4C/4a4AvoLZjQm7zpSHgiNVRoyX/LIYfuYfHWNbVVBCsonCZ2TzY9Qpf+vHNJ
+        p4l9YDm7Nk45HdJgSPkzG4ech8xPyHlALhMZ/I8QpkM7wemPlRiwFFLrp5maCBFMJkz5nAoUiDMx
+        FRPuB5L6jN93224G7V2NbYWpUGvYOenm1jUtpAcbPfSt01PZ4VrosDaahN8/mIHEDDkEQmYp5yJT
+        mVA+lSizMZsKNlG+CkClcF9mHz6+Af1uPr4a8/xjQN6wK7IiBVNY41o7XGKrZZhBqXFAOgTtSqSv
+        dbGrf6vsLmD6zu6h7svSyX4sG7BNLjyffwFJEUHYoQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:31 GMT
+      etag:
+      - W/"e049ecc3ee17cae7a5270f1ed5ae04e2"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465E8B:64193BB:5ED660A7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3347'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5dbcb2b5da7f819025adf6fcee0c59cbdf48e021
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft7HsxE+BMZrQlgSase7FnBAIejjFSmXJWEpDWvrdKzVmtOle
+        ZN0YfSOJO93dj7v/PQYK1xAMA4YtbjC9w2vobYxWwVnQYFv93mMq7ByEpIgzlOdxgmJU9HGWoH6W
+        sixNWZ7iPsvyLKYcuVRGPLgiUTQ4C7atdLGVtY0ZhiFuRG8tbLUlParrsIVGm7AGi43VLZxLQc4t
+        GGtCf65W9d5zGrAh1cqCco5j8K8t8C8JI5TEJGE443lUoDjBjKecAiCaFJQwPsgBxZFDq2wtV2+h
+        XgGdgkKkJuGpFd/xOgRX74jgw21xqULPY8I/mA7TOyU1ZkcQLd51s9kaaLuGv4zplK78TUPsvvGa
+        5EKCa09X2Rlgp9eT8RRBOZKTjXvXswcmJmZy8WLfzn9GnT1KFtdXaF7OJBsf/EvlfuwX5eyeldPN
+        orwR38SIjMWFixxlh9u/p7t5easP2W8rdn15T0q5X6pfkT+SDe3PRRdZ+Lv83hRLvzKgqGZCrf12
+        OJmmA2dbSaHuTDB8DAxI/qm079TyL3g+JDq/d6+K/9+de3p6BnYOAAP5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:32 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465EE3:641941D:5ED660A7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3346'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:32 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465F31:6419479:5ED660A8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3345'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uvTSJHDbJZA4vtIekCBdIARQ/bvQiUREu0JVElKbuOkP/ed0jJ
+        kr3Ohx0ec0lsmnyGQ3KGw7ediHQyC69vbsLLm5vLs0klUx5R2+T+9m79UPxRJN8+P7Lvf62Sarn5
+        c5Fd3S/urh5u775M0JmVHD0N1yaKpMm5Splhmhv8Nm+KIuo6lBytRip+Xoj4nLrr4OCgWokVM2DO
+        WaH52USuK64ms3ZSyExUMHWABFs03+vr6acw/MmFzcPy8+ZH+HvDvtd5+q1YxYt/wvvbZHO/yP7D
+        UAZ7TEWNKkDPjan1LAhco/71IhMmb+JGc5XIyvDKXCSyDJqgN/Z19eUKkEx1GLtwaNjD1aIjueHA
+        6eCwJ7kpi73JuDnYkYfHzGVRyDWY+1680WywBdC2WZiosvfBAGgDeyIiWr0nWiSBbT+Vage3Af3D
+        6SScxrYpnp4K7IZjknTEntpA8VpabhPrRInaCFmdPN0dCKBSZawSj+xdUEA0WDTRkydmBwPCVzjM
+        J1Pc6Daw4ZpsaNkUT7hYYT/eR97DAGw2NeWYh9EK0i4JwyOWlpQUbK54OkP0Hhk7h3NQyrf7P5lV
+        yGIUFGq5zUkvxrZd30NxetgWgV/ZhWOIiGTwsDxLvvGJJVwb4G8XewmSBIulYsjpPu3scNtg/JXO
+        mOGs9GnO8sDNpfS6C5YHrtC64W8KiKM22WJ10Adh1ZSxy7BvCb2jLDkgPGFai6zi3Ofqb5lt0F8R
+        sWJVknu10iPbwH2y54hlPh0hHKhxIWOfWNz7gWW2gc6Zu0FN5HnuZISQOzYUn/t2hJBbG0b5PUnW
+        CWJuLeB2NzhUPr3okUHb7UbBqqxhmVcjWyZdcShwMvb4al13VEQPUFigmlaJuPGexQcs+eEKKuQo
+        r9sxUAcbtmh7uSI8brVGtaBdr7IUr1VNRxnoiDvR598Kxce+Jfr+egl4tDOEbIPhSnJXYGfM4850
+        d2Dvxdhk91Lzedh6ZND+UjOTUy6G5Zop7tGljhi0MV7QTxcXF23OmX3qlFz5TTMOCDJTSY6q3aMX
+        bY9EKVoyYx9Wc3IixUOrkCz1uS9bJvjuRHj0xAHHJ6vGY8Dn9C1vbKAUBbQRWXm9Uwbo2FQljZiL
+        5C0v0qOSwA63/apFlfAzhkcUosWIRCB+oA3QgcALgntdTgeEk1Cl3JO04AglnzumuEO2gRMhUl4X
+        cuM7kY6olGkUhySWRszgGRxOw+n59Pp8Gv59eTULw9nlzQ/0aWoIb8/2Ca+pT93o/Pkun6gLLoou
+        gPAJOtjL0tOBJy3JXOBonQ+c3wbK7ICA9TwlKRAJewF98oxW+3XB0ST4lcuS1yj5el1Ai0d8nu7U
+        aolsKuwUGtfM4DGDqmdo6uu7HpAzHbk8M5kZ1UDxpJZayQVPjB63Dalu1HEtlmJnIJWjW6HCiQuD
+        8VIoJTup0+kaXa6GaNnpranQLC740CBrXnUzHLshEl7p7TI41YFcHnXfWQL7JeVz1hQmcg8xEnMh
+        CkPexdHkqsQykOJGYm+n67gFoWPb+0gJ032G3GN4WUfujBi55KQOA4VUI9eR/rdhOIP2nusHu19s
+        E1yhSm73F8Xp4t0dkyLeITS5GUeoLTtiL0+PRakPlbqJP1TqD5X6Q6V2Oj/dgwdU6oqbNVTaUTYd
+        P5D7bP30P967vkSZGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:32 GMT
+      etag:
+      - W/"2f75c2dfe1c278ce81054162cc6f7522"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:26 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5465F81:64194D2:5ED660A8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3344'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:22:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:546600B:641954A:5ED660A8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3343'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:33 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:5466088:6419622:5ED660A9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3342'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjBknWwGJ72O0CBdIFih62exEoiZYYS6JKUnYdIe/ef0jJ
+        kr1O4jg85pLYNPnNcDgzHE47kelkPru+vZ1d3k5vziaVSkVEY5O7z1/W34o/iuTrhwf+/a9VUi03
+        f95nV3f3X67uPicfJ5jMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNewn1fUWq64BW3B
+        CyPOJmpdCT2Zt5NCZbKCkAMYCCJNr6+nN7PZ7eWe8ptvyw+bH7PfG/69ztOvxSq+/2cGxTd399l/
+        WMohj+uo0QXoubW1mTPmB82vF5m0eRM3RuhEVVZU9iJRJWtYL+zT6uMVIJnuMM5kGNjD1bIj+eXA
+        GXZ4J7ktiz1lvA5u5eE1C1UUag3m/i6OFMu2ADozB5NV9jYYAC1TNhcwLbb7SEaSOPNTqW5xy+gf
+        /JJwBsemRXoqsFsOJcnFHlumRa0ct4lNomVtpapOVncHAqjSGa/kA38TFBADFil6smJuMSBiBWc+
+        meJXt8yFa7Ihs2mRCLnCebyNvIcB2G5qyi7fRhakU5JWRDwtKSm4XPF4huh9ZewcSECp2B7+ZF4h
+        f1FE6OU2IT0b2M64h4L0gCCivmD/o3EIYMBglaXYBGMSq2X428VbgsTAY6U5kngwITvQlo2/klNZ
+        wctgshwM0FypcJZ3MEClMY04yvePP1XHNKwPtqopY59Jjwmx48V4GvbAjZFZJUQwi2+BLesvgVjz
+        KsnDieh5LfOfnNfwLNgWiAVkXKg4GBMXOnPAlpmc+6vRRiG1JgnE2xGgxSLoFoi3FWB1QL9x6hNw
+        i8dtbeFCwfTveaztTqDgVdbwLJyELZAuK5QqGX94sUI7PmYHIvBUmmoZN2ET88CkHfiiCPkn3BEM
+        yEGAq7qeL+leYaRRJefMVJbypZrneHqH2wmxwCIoDvbF0PeXS7fXbYN4LRvuF3+ZdZJCnUZ3m/X6
+        j+V1b6tgrtXzWPtLzW1OGRZia65FqM10ONbGeOo+XlxctLng7llSCh0wi3gasFwnOcrrUPq3PQ+V
+        Y8mte/4sSP0Uz6FC8TTYWWyBgHsXCLUHTxv7UY16PZjiDjaml7JA10JV4e6IgTiWUykrFzI55q14
+        fJjvQNtPRlaJOON43iAqrEwk4gRPdvIAFPkinBU9DdtDj8g/EwuBkAl2Slp4Xst8VyAVdaE2QTPk
+        CEmJRAs0qNKIWzxKZ9PZ9Hx6fT6d/X15NZ/N5tPLH5jT1OiBPTnn8prm1I3Jn55yQ1OQ/rtYwSd0
+        pZ5vBO2/ManjBIgx+QD5bUDMD/SSnkAkBZx+L2pP02W1f7e/DoPt5KoUNeq0/nFu5AM+T3dqrEQ1
+        FU4Hg2tu8dhAzTIM9XVZD8i5iXwmmcytbtBzpJFaq3uRWDMeGzLZaOJaLuXOQqoht90C/8gfhJdS
+        a9U1G31zocvDaBt2Hc9UGh4XYhhQtag6DcfbkImozNYMvgFAWx5N3zGB+5KKBW8KG/m3ErVT0ZNF
+        gxXuKHQJM1DPi9qtXWfFG4Rctd8jZUX/GQ0XK8o68t5h1VJQfxYoZBW1jsy/DYfruQusX+x/cUPY
+        ClVju79oQdfp7poUAY5Wj9c4QnHYEfsG8bgt9N4nbuL3PvF7n/i9T+w77XT9HegTV8Ku0TAdZdPx
+        87bP1o//AyHtk7sVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:37 GMT
+      etag:
+      - W/"b0d309cbe0b08d5f7553d76fe06e6c86"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54660C3:6419666:5ED660A9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3341'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:22:37 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C93C:2668B:54664CD:6419B74:5ED660AD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3340'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_list_authors.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_list_authors.yaml
@@ -1,0 +1,4757 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:11 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481965:6537F0D:5EDF6A8E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4957'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:11 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54819A0:6537F3D:5EDF6A8F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4956'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":270977359,"node_id":"MDEwOlJlcG9zaXRvcnkyNzA5NzczNTk=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-09T10:55:11Z","updated_at":"2020-06-09T10:55:11Z","pushed_at":"2020-06-09T10:55:12Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:12 GMT
+      etag:
+      - '"4cb1379ad1331335418f1c58b726131f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54819F1:6537F9F:5EDF6A8F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4955'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"fd601897e8bb21c218c9c5472d70eac332c592a6","node_id":"MDY6Q29tbWl0MjcwOTc3MzU5OmZkNjAxODk3ZThiYjIxYzIxOGM5YzU0NzJkNzBlYWMzMzJjNTkyYTY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fd601897e8bb21c218c9c5472d70eac332c592a6","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fd601897e8bb21c218c9c5472d70eac332c592a6","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-09T10:55:13Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-09T10:55:13Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:13 GMT
+      etag:
+      - '"d08c1828a02f1af6722311fe509f999a"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481BBE:65381CE:5EDF6A90
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4954'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XXW/aMBT9K1WeaRMCIYBU7UObpk6Cahpdl04TcpwbYnDszHYoBPW/7zqka+Fh
+        a6rurS8osXOOz/30ZecIkoMzdnKiDSin41CZ58w4452jM4IbaTLwusNRCMM49rvU7w7piAb90E9C
+        Dwjt9XwajHwyQKiQCcxZgqDJh2jwxR+Z+Jp7kyW9vZzR3qS6Ci7zm9V0+W5z+WHVu5llLFpebKLq
+        YnP5aRJE1ZU3rT6vptV7Hl1Pqkn1eTmdrbbRLDo/0EVKk0llFTbav2YkI+rk41pJgV9CThhHEagf
+        l8/ALr9d2MUzNA4/SIixJvue7516g1NvNOt64yAYd3s3zt29B6w3/tsROWhNFlbEhWCGEc4qOEFZ
+        5ERBITUzUm1RqFGA39xHopt6oyT1e2E49Pthtx8MIfH9EQnjuD+kIe4Mk7AHHgJLZR2QGVPoseuS
+        gp0tmMnK2DrArY9wczAYcqnglLP41IA22rW/83m+tUo0GBdBrtWg3Sefjf57wcP3yajdFkloISDM
+        nMpSYBp7HWcNiqWMEsMwPdCb+3fAPE0J19BxFBBtt5xSaLYQuNNx7AMxpUL/i5LzjlOQLZcEQfb1
+        7uXMfIaJmcn5/NDLj8L7lMDuD32GW/XRuc9OrbZmu01cNcbmoQFwuWA2cDqrqxz3bPsZBMGgd9iO
+        vgy+fZ9yuoy601lUWY415rg6tqZe1H5TLaUGRaUwmE514ZRuzfxmfd5HhoVqOOqO96+is1zafdD5
+        9xg+fJdKzuUtYo+lHtb0Ab37B4Sq9s9MLNoTIGjnSpMB+gnl31mjGfaJNkw1YIedBDsLSyyFRhcr
+        SNqQNBAUcytQx65uYTVXGWuqWGFLu5WsAyASSbUgglV1j2hFhECbknVPbWNSDUAgrDG7WiH3iJ1b
+        KLYmdGvdoIACW6NP27MdQZHMbAt7MV1hxK2HmYE5SXJbZnW7PL4gX0uwuVZfS7Bd5byW4P7SwmZ2
+        UL1PKsGCKNs3nPGPn1iQc87ECl9wUgSevsTkFysiaIaD35//BfbCesTccuCwU+Q9FwoulDRAzaMZ
+        rFlpRjQQJOYHE9qvktlLA28CU+o5SqN7g0GkUlGoRz6O7c9qlGmKTqxv7k3jo4cz8YS/9+mnj8dH
+        TsKOXFtlbbj7DYngN7lZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:14 GMT
+      etag:
+      - W/"6b7e1e0ff9b4946681d52fd86a1f05ff"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481D1A:653837A:5EDF6A91
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4953'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:14 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481D70:65383E8:5EDF6A92
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4952'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fd601897e8bb21c218c9c5472d70eac332c592a6
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTXYvbMBD8K0HPTizLcfwBhbZcKTlwQqmPwyklyPImViLbQZKviUP+e1dNH9q3
+        O2hfhLXj3ZmdXV2JaTjJyK5e0CBJY0iqigWCBYlIRTSPWR1T4CIMmYhSxhfEI11fw1bWmJQ/lIsv
+        LLXVs6L5QfxYFyLMx6do3W6Oq8OH8/rhGG6KRpaH5bkcl+f15zwqxye6Gh+Pq/GjKp/zMR8fD6vi
+        eCmL8h0WH7TCwo21J5P5Pj/J2V7aZqhmom99Dafe+C1YbmyvYapkNbVgrPHdud22l5ojBtbHJB8z
+        WonYG1prbKu2f0v4g/41xHfSt3DywTa9JtmVdLwFbP5rwxuuJ59edN+hI9By6TzBOWF4Bi78fu+C
+        zhP8AXt2aYwyOqWLKU2LgGZRlAXhhtw8cldk4T9SWA2o4Pp7lYIdTesdC+M4YfM4mEcJ1IylPK6q
+        eSJiRJI6DoH+22k7DcZ/NTca04IxfO+sW3bSSq7kCBO3QJNfeyZxxS6o8cQ1dNaQ7Nt3j7yAljsp
+        uJU4G+z4fgd8DDuuDHhEAzcOIkNn5L5DxCPug9tBI1U3KOVKXlTPMcldb7efvkEIwYQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:14 GMT
+      etag:
+      - W/"2e8327fd6749c8730764ac2ddb8c581b"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481DF6:653848D:5EDF6A92
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4951'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["fd601897e8bb21c218c9c5472d70eac332c592a6"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65",
+      "author": {"name": "Bob Example", "email": "bob@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"3372a0fd73a9e58807af898287fb462b04d2b053","node_id":"MDY6Q29tbWl0MjcwOTc3MzU5OjMzNzJhMGZkNzNhOWU1ODgwN2FmODk4Mjg3ZmI0NjJiMDRkMmIwNTM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/3372a0fd73a9e58807af898287fb462b04d2b053","author":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:55:15Z"},"committer":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:55:15Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"fd601897e8bb21c218c9c5472d70eac332c592a6","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/fd601897e8bb21c218c9c5472d70eac332c592a6","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/fd601897e8bb21c218c9c5472d70eac332c592a6"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1176'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      etag:
+      - '"946eb2be4d043c9d7d9f620de512de33"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481E43:65384ED:5EDF6A92
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4950'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62Oy27CMBBF/8XrgonTPNeoICSLTUklNpEfQxMUx5E9UAXEv3dQl9100c3d3Dlz
+        z50FOLH6mZF3oGzkTkWEwF7Y6C20vaVWrmV+cI2TZ/O1fzepvB2y/bgbjqO8qk3THbfyqj/ebnbT
+        zARewkBQhzjFmnM19cvPHruLXhrveIDJ0wggzfgAi6HXC4SIkT+zbd1sFXWAnCC6/u3l9RkMsvrO
+        Yqdo6GTzVVJWBZRai8SIpDSVyV4LYYsVKJOmwmSVUDmZ4TwBEeThevxf05+fkf/Z5vH4BmCm6T19
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      etag:
+      - W/"8bbea297e0eed62fdbe33f9ed659843a"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:13 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481EC9:653858F:5EDF6A93
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4949'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "3372a0fd73a9e58807af898287fb462b04d2b053"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngqOYEJO5KhWSxQKpxBLZ8aU2ipPIPqgC4r/3UMcuHbq85d13
+        77uzCB2rnpm4A20TDzohRPbChtFC4y216lWtj6EO6tx+7Q+tULdjsR92/WlQV72t3eldXc3H281u
+        65nAS+wJcohTqjjXk19+enQXs2zHwCNMI40A0swYYdF7s0BImPgzmybMVlMHyAmi699eozlDi6y6
+        s+Q0DQlR5jrrbCn0Bgops1J3ciNzWXZmtc5NtrIUhSAznCcggjyCx/81/fmZ+J9tHo9vuhUxjX0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:16 GMT
+      etag:
+      - W/"d1ffa6b64603b8adf95f6a3b2e985e0b"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5481F23:6538600:5EDF6A93
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4948'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:16 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548202F:6538745:5EDF6A94
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4947'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjbZLGwGJbYNsFCiQBij1s9yJQEm0xlkSVpOzaQt69/5CS
+        JbvexHF4zCWxafKb4XBmOJxmJNPRdHIzvr25+XB1ezYqVSoiGhvdff599ZD/mSdfbjf821/LpFys
+        7ze/Xd1vks3918XHESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI8l/E5zTXs/ysqLZfcgjbj
+        uRFnI7UqhR5Nm1Gu5rKEkAMYCCJNr6/HN5PJL5d7yq8fFrfr75M/av6tytIv+TJ+/Hty9zlZ3z3O
+        /8VSDnlcR7XOQc+srcyUMT9oPlzMpc3quDZCJ6q0orQXiSpYzTphn5YffwZkrluMMxkG9nCVbEl+
+        OXCGHd5JZot8Txmvg1t5eM1M5blagbm/iyPFsi2AzszBZDl/GwyAhimbCZgW230iI0mc+alUt7hh
+        9A9+STiDY9MiPRXYLoeS5GJPDdOiUo5bxybRsrJSlSeruwMBVOk5L+WGvwkKiAGLFD1ZMbcYELGE
+        M59M8asb5sI1WZPZtEiEXOI83kbewwBs1xVll4eBBemUpBURTwtKCi5XPJ0hel8ZOwcSUCq2hz+a
+        lshfFBF6sU1Izwa2M+6hID0giKgv2P9oHAIYMFhlIdbBmMRqGP628ZYgMfBYaY4kHkzIDrRhw6/k
+        VFbwIpgsBwM0Uyqc5R0MUGlMLY7y/eNP1TEN64KtrIvYZ9JjQux4MZ6GPXBj5LwUIpjFt8CGdZdA
+        rHmZZOFEdLyG+U/Oa/g82BaIBWScqzgYExc6c8CGmYz7q9FGIbUmCcTbEaDFLOgWiLcVYHVAv3Hq
+        E3CLx21t4ULB9O94rGlPIOflvObzcBK2QLqsUKrM+ebFCu34mO2JwFNpqmVch03MPZN24Isi5J9w
+        R9AjewGu6nq+pHuFkQaVnDNTUciXap7j6S1uJ8QCi6A42BdD318u3V63DeI1rL9f/GXWSgp1Gu1t
+        1uk/lNe+rYK5VsdjzU8VtxllWIituBahNtPiWBPjqft0cXHRZIK7Z0khdMAs4mnAcp1kKK9D6d90
+        PFSOBbfu+TMj9VM8h3LF02BnsQUC7l0g1B48behHFer1YIo72JBeyBxdC1WGuyN64lBOqaycyeSY
+        t+LxYb4DbT4ZWSbijON5g6iwMpGIEzzZyQNQ5ItwVvQ0bA89Iv9MzAVCJtgpaeF5DfNdgVRUuVoH
+        zZADJCUSLdCgSiNu8SidjCfj8/H1+fj26+V4enU1vbz8jjl1hR7Yj+dc05yqNtkLU5D+21jBJ3Sl
+        nm8E7b8xqeMEOcZkPeTXHjE90Ev6ASLJ4fR7UXuaLsv9u/11GGwnU4WoUKd1j3MjN/g83qmxElWX
+        OB0MrrjFYwM1Sz/U1WUdIOMm8plkNLW6Rs+RRiqtHkVizXCsz2SDiSu5kDsLqYbcdgv8I78XXkit
+        Vdts9M2FNg+jbdh2PFNpeJyLfkBVomw1HG5DJqI0WzP4BgBteTB9xwTuSypmvM5t5N9K1E5FTxYN
+        Vrij0AXMQD0vare2nRVvEHLVbo+UFf1nNFysKKrIe4dVC0H9WaCQVdQqMv/UHK7nLrBusf/FDWEr
+        VI3t/qIFXae7a1IEOFo9XuMIxWFL7BrEw7bQe5+4jt/7xO994vc+se+00/V3oE9cCrtCw3SQTYfP
+        2y5bP/0H/JHmPBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:17 GMT
+      etag:
+      - W/"794fce23fafb4f80398bcb09578a4c7c"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548208A:65387A2:5EDF6A94
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4946'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:17 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54820DA:6538809:5EDF6A95
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4945'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjbZLGwGJbYNsFCiQBij1s9yJQEm0xlkSVpOzaQt69/5CS
+        JbvexHF4zCWxafKb4XBmOJxmJNPRdHIzvr25+XB1ezYqVSoiGhvdff599ZD/mSdfbjf821/LpFys
+        7ze/Xd1vks3918XHESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI8l/E5zTXs/ysqLZfcgjbj
+        uRFnI7UqhR5Nm1Gu5rKEkAMYCCJNr6/HN5PJL5d7yq8fFrfr75M/av6tytIv+TJ+/Hty9zlZ3z3O
+        /8VSDnlcR7XOQc+srcyUMT9oPlzMpc3quDZCJ6q0orQXiSpYzTphn5YffwZkrluMMxkG9nCVbEl+
+        OXCGHd5JZot8Txmvg1t5eM1M5blagbm/iyPFsi2AzszBZDl/GwyAhimbCZgW230iI0mc+alUt7hh
+        9A9+STiDY9MiPRXYLoeS5GJPDdOiUo5bxybRsrJSlSeruwMBVOk5L+WGvwkKiAGLFD1ZMbcYELGE
+        M59M8asb5sI1WZPZtEiEXOI83kbewwBs1xVll4eBBemUpBURTwtKCi5XPJ0hel8ZOwcSUCq2hz+a
+        lshfFBF6sU1Izwa2M+6hID0giKgv2P9oHAIYMFhlIdbBmMRqGP628ZYgMfBYaY4kHkzIDrRhw6/k
+        VFbwIpgsBwM0Uyqc5R0MUGlMLY7y/eNP1TEN64KtrIvYZ9JjQux4MZ6GPXBj5LwUIpjFt8CGdZdA
+        rHmZZOFEdLyG+U/Oa/g82BaIBWScqzgYExc6c8CGmYz7q9FGIbUmCcTbEaDFLOgWiLcVYHVAv3Hq
+        E3CLx21t4ULB9O94rGlPIOflvObzcBK2QLqsUKrM+ebFCu34mO2JwFNpqmVch03MPZN24Isi5J9w
+        R9AjewGu6nq+pHuFkQaVnDNTUciXap7j6S1uJ8QCi6A42BdD318u3V63DeI1rL9f/GXWSgp1Gu1t
+        1uk/lNe+rYK5VsdjzU8VtxllWIituBahNtPiWBPjqft0cXHRZIK7Z0khdMAs4mnAcp1kKK9D6d90
+        PFSOBbfu+TMj9VM8h3LF02BnsQUC7l0g1B48behHFer1YIo72JBeyBxdC1WGuyN64lBOqaycyeSY
+        t+LxYb4DbT4ZWSbijON5g6iwMpGIEzzZyQNQ5ItwVvQ0bA89Iv9MzAVCJtgpaeF5DfNdgVRUuVoH
+        zZADJCUSLdCgSiNu8SidjCfj8/H1+fj26+V4enU1vbz8jjl1hR7Yj+dc05yqNtkLU5D+21jBJ3Sl
+        nm8E7b8xqeMEOcZkPeTXHjE90Ev6ASLJ4fR7UXuaLsv9u/11GGwnU4WoUKd1j3MjN/g83qmxElWX
+        OB0MrrjFYwM1Sz/U1WUdIOMm8plkNLW6Rs+RRiqtHkVizXCsz2SDiSu5kDsLqYbcdgv8I78XXkit
+        Vdts9M2FNg+jbdh2PFNpeJyLfkBVomw1HG5DJqI0WzP4BgBteTB9xwTuSypmvM5t5N9K1E5FTxYN
+        Vrij0AXMQD0vare2nRVvEHLVbo+UFf1nNFysKKrIe4dVC0H9WaCQVdQqMv/UHK7nLrBusf/FDWEr
+        VI3t/qIFXae7a1IEOFo9XuMIxWFL7BrEw7bQe5+4jt/7xO994vc+se+00/V3oE9cCrtCw3SQTYfP
+        2y5bP/0H/JHmPBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:17 GMT
+      etag:
+      - W/"794fce23fafb4f80398bcb09578a4c7c"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:16 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482123:6538863:5EDF6A95
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4944'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPyVmW/A2FUtKWHNihJcfRHCVI8jpWYtnGkpteQv57JdKD3lsC
+        6YuQNN6dndHgE9I1QxmiNCYMV2VMWQphkuCYVUmakCSueBARjoPSLiFFU9R2JWxkaYvy+Y/oG0kN
+        f25wvhOH5UrQ/PgULnf5sTg+1vnX9b44FvXy+clfzreHgnxRy/k+yHdbulYLXOweZT7/vs/V4lCs
+        8g+2+Tg0tnFtTK8zz2O9fNhKU4/8QXTKG6DvtKfAMG26AWaN5DMD2mjPrZuNei2ZxcB4tsizFUpa
+        7AZptVHN5v0I/9BfQ3whvYWTjabuBpSdUMsUWPGfOj75/JupvgFrCCgmnSW84x/hcuu8sIjV6j4n
+        mOAZjmY4Xfk4C8PMD9foPEWXSQz8h9ZmAMt8+hudOIYkokEVUI6pqKooLYM4CAXmEANUlHAQjEfh
+        fV/XzaC9q7mtIQq0Zltn2aKVRrJm4tLSM7G3t5OLXXbGng3QGo2ylzeBVRlhP0mtTM6JL4ifiFSE
+        QUzKGAMTlBIRpoRF9xX4Ft8b2O8W36s5zz+n6BcMspKCGdm1LhWXM9gfRMUaDVM0ANMOQmOr5ba1
+        yBS5DTPjYJ+jHZvG2f7adMwWueP5/AeigD3gmAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      etag:
+      - W/"946eb2be4d043c9d7d9f620de512de33"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482170:65388C1:5EDF6A95
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4943'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28ixY1sOjNKYrTjQlnUPdUIhSNbZVipLxlIastLvvnMbaJfu
+        IevG2IPEoZPu/+N/p0dPsxa8qSeYYx0r71kNo7U12jvxOuaaX2dswzBBIaGlSJlIUkiDIOQ+jaNx
+        EkdCQAxJ5Kd+SnnsYykrv6NIGp94m17h08a5zk4JYZ0c1dI1Gz4qTUt66IwlLThmnenhVEl+6sA6
+        S4Z9tWp3A6YFR0qjHWhMHHKf9VB9CsMkYH4lkpClEFHqJ6yiKQ1oUvFJHHB/InCLQiRrXKtWP0O9
+        AToGhSvDybGK73gRAfUOCD5sC5YiA48lv9EcYbZaGSYOIHq23fdmY6HfG/7cpmNc+RND3K4bRrKS
+        CtCevTIewNbUeTbfLG7HKl9j3I6j5cUXf1FcKZHlNj9/zu+WxdWDKObrZXEpr+WMZ/K8vtN5NkuG
+        KM+GNd8uihvzUuWmERefH3ihXl9+i9ZluJAv92fpnR6i4muHESKBLo2QukYmjuMYT/BspaS+t970
+        0bOgqv9qxnEq/gbPh4Zr+F9vxP/t33p6+gFf1uEw4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482226:653898C:5EDF6A96
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4942'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tagger": {"name": "Bilbo Baggins", "email": "bilbo@shire.net"},
+      "message": "First version", "tag": "version-1.0", "type": "commit", "object":
+      "3372a0fd73a9e58807af898287fb462b04d2b053"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '187'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjcwOTc3MzU5OjFjMjk1MzI2MmE3NTZiMWZlZDIyOWNiNDE3MmM0NjZlMmZkMTdjZDk=","sha":"1c2953262a756b1fed229cb4172c466e2fd17cd9","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/1c2953262a756b1fed229cb4172c466e2fd17cd9","tagger":{"name":"Bilbo
+        Baggins","email":"bilbo@shire.net","date":"2020-06-09T10:55:18Z"},"object":{"sha":"3372a0fd73a9e58807af898287fb462b04d2b053","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '686'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      etag:
+      - '"1c544e0113f352e8ad1875ba909e7b16"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/1c2953262a756b1fed229cb4172c466e2fd17cd9
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482282:6538A08:5EDF6A96
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4941'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "1c2953262a756b1fed229cb4172c466e2fd17cd9", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjcwOTc3MzU5OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"1c2953262a756b1fed229cb4172c466e2fd17cd9","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/1c2953262a756b1fed229cb4172c466e2fd17cd9"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:19 GMT
+      etag:
+      - '"b3738964c0142987f8c69005ec21a7f4"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548231F:6538AB8:5EDF6A96
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4940'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:19 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482467:6538C4E:5EDF6A97
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4939'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuyS1gaIb0K3AgCTA0IeuLwIl0RJjSdRIyp4t5Lv3f6Jk
+        yZ6TOA4f85LYNPm74/HueLx6JOPRbHIznt7cfLiano0KFYuAxka3X/5Y3Wd/ZdHX6YZ//3sZFYv1
+        3eb3q7tNtLn7tvg0wmSeC8y0wtggyNcxt9wIix/mVZYF7a+5wKhVWpxnMjynuYb9f0Wp5ZJb0OY8
+        M+JspFaF0KNZPcpUIgsIOYCBINL0+np8M5l8vNxTfn2/mK5/TP6s+Pcyjb9my/Dhn8ntl2h9+5D8
+        h6Uc8rgOKp2BnlpbmhljbtB8uEikTauwMkJHqrCisBeRylnFOmGfl59+BSTRLaYxGQb2cKVsSW45
+        cIYd3klq82xPGadDs/LwmrnKMrUCc38XR4plWwCdWQOTRfI2GAA1UzYVMC22+0hGkjjzU6nN4prR
+        P/gl4QyOTYv4VGC7HEqSiz3WTItSNdwqNJGWpZWqOFndHQigSie8kBv+JiggBixS9GTFmsWAiCWc
+        +WSKW12zJlyjNZlNi0jIJc7jbeQ9DMB2XVJ2uR9YkE5JWhHwOKek0OSKxzNE7ytj50ACisX28Eez
+        AvmLIkIvtgnp2cBujHsoSA8IIuoL9j8ahwAGDFZZiLU3JrFqhr9tvEVIDDxUmiOJexOyA63Z8Cs5
+        lRU89yargQGaKuXP8g0MUGlMJY7y/eNPtWEa1gVbUeWhy6THhNjxYhwNe+DGyKQQwpvFt8CadZdA
+        qHkRpf5EdLyauU+N1/DE2xaIBWSYqdAbExc6a4A1Myl3V6MNfGpNEoi3I0CLudctEG8rwGqPftOo
+        T8AtHre1hQt507/jsbo9gYwXScUTfxK2QLqsUKokfPNihXZ8zPZE4Kk01TKs/Cbmnkk7cEUR8o+/
+        I+iRvYCm6nq+pHuFkQaVXGOmPJcv1TzH01vcToh5FkFxsC+Gvr9cur1uG8SrWX+/uMusleTrNNrb
+        rNN/KK99W3lzrY7H6l9KblPKsBBbci18babFsTrEU/fx4uKiTgVvniW50B6ziKMBy3WUorz2pX/d
+        8VA55tw2z585qR/jOZQpHns7iy0QcOcCvvbgaEM/KlGve1O8gQ3puczQtVCFvzuiJw7lFMrKuYyO
+        eSseH+Y70PqzkUUkzjieN4gKKyOJOMGTnTwARb7wZ0VHw/bQI3LPxEwgZLydkhaOVzPXFYhFmam1
+        1ww5QFIi0QINqjjgFo/SyXgyPh9fn4+n3y7Hs6ur2eXlD8ypSvTAnp7zkeaUlUmfnjKlKUj/bazg
+        E7pSzzeC9t+Y1HECxJi0h/zWI2YHeklPIKIMTr8Xtafpsty/21+HwXZSlYsSdVr3ODdyg8/jnRor
+        UlWB08Hgils8NlCz9ENdXdYBUm4Cl0lGM6sr9BxppNTqQUTWDMf6TDaYuJILubOQashtt8A98nvh
+        udRatc1G11xo8zDahm3HM5aGh5noB1QpilbD4TZkJAqzNYNrANCWB9N3TNB8icWcV5kN3FuJ2qno
+        yaLBCncUOocZqOdF7da2s+IMQq7a7ZGyovuMhosVeRk477BqIag/CxSyiloF5t+Kw/WaC6xb7H5p
+        hrAVqsZ2f9GCrtPdNTECHK0ep3GA4rAldg3iYVvovU9che994vc+8Xuf2HXa6fo70CcuhF2hYTrI
+        psPnbZetH38CtUEkDxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:20 GMT
+      etag:
+      - W/"b116b9c9968fb5764371ef8ebfd5e67e"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54824C5:6538CB6:5EDF6A97
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4938'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngqOYEJO5KhWSxQKpxBLZ8aU2ipPIPqgC4r/3UMcuHbq85d13
+        77uzCB2rnpm4A20TDzohRPbChtFC4y216lWtj6EO6tx+7Q+tULdjsR92/WlQV72t3eldXc3H281u
+        65nAS+wJcohTqjjXk19+enQXs2zHwCNMI40A0swYYdF7s0BImPgzmybMVlMHyAmi699eozlDi6y6
+        s+Q0DQlR5jrrbCn0Bgops1J3ciNzWXZmtc5NtrIUhSAznCcggjyCx/81/fmZ+J9tHo9vuhUxjX0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:20 GMT
+      etag:
+      - W/"d1ffa6b64603b8adf95f6a3b2e985e0b"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548252E:6538D2C:5EDF6A98
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4937'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPyVmW/A2FUtKWHNihJcfRHCVI8jpWYtnGkpteQv57JdKD3lsC
+        6YuQNN6dndHgE9I1QxmiNCYMV2VMWQphkuCYVUmakCSueBARjoPSLiFFU9R2JWxkaYvy+Y/oG0kN
+        f25wvhOH5UrQ/PgULnf5sTg+1vnX9b44FvXy+clfzreHgnxRy/k+yHdbulYLXOweZT7/vs/V4lCs
+        8g+2+Tg0tnFtTK8zz2O9fNhKU4/8QXTKG6DvtKfAMG26AWaN5DMD2mjPrZuNei2ZxcB4tsizFUpa
+        7AZptVHN5v0I/9BfQ3whvYWTjabuBpSdUMsUWPGfOj75/JupvgFrCCgmnSW84x/hcuu8sIjV6j4n
+        mOAZjmY4Xfk4C8PMD9foPEWXSQz8h9ZmAMt8+hudOIYkokEVUI6pqKooLYM4CAXmEANUlHAQjEfh
+        fV/XzaC9q7mtIQq0Zltn2aKVRrJm4tLSM7G3t5OLXXbGng3QGo2ylzeBVRlhP0mtTM6JL4ifiFSE
+        QUzKGAMTlBIRpoRF9xX4Ft8b2O8W36s5zz+n6BcMspKCGdm1LhWXM9gfRMUaDVM0ANMOQmOr5ba1
+        yBS5DTPjYJ+jHZvG2f7adMwWueP5/AeigD3gmAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:20 GMT
+      etag:
+      - W/"946eb2be4d043c9d7d9f620de512de33"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482585:6538DA5:5EDF6A98
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4936'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28ixY1sOjNKYrTjQlnUPdUIhSNbZVipLxlIastLvvnMbaJfu
+        IevG2IPEoZPu/+N/p0dPsxa8qSeYYx0r71kNo7U12jvxOuaaX2dswzBBIaGlSJlIUkiDIOQ+jaNx
+        EkdCQAxJ5Kd+SnnsYykrv6NIGp94m17h08a5zk4JYZ0c1dI1Gz4qTUt66IwlLThmnenhVEl+6sA6
+        S4Z9tWp3A6YFR0qjHWhMHHKf9VB9CsMkYH4lkpClEFHqJ6yiKQ1oUvFJHHB/InCLQiRrXKtWP0O9
+        AToGhSvDybGK73gRAfUOCD5sC5YiA48lv9EcYbZaGSYOIHq23fdmY6HfG/7cpmNc+RND3K4bRrKS
+        CtCevTIewNbUeTbfLG7HKl9j3I6j5cUXf1FcKZHlNj9/zu+WxdWDKObrZXEpr+WMZ/K8vtN5NkuG
+        KM+GNd8uihvzUuWmERefH3ihXl9+i9ZluJAv92fpnR6i4muHESKBLo2QukYmjuMYT/BspaS+t970
+        0bOgqv9qxnEq/gbPh4Zr+F9vxP/t33p6+gFf1uEw4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:21 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54825C4:6538DFF:5EDF6A98
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4935'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:21 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482617:6538E52:5EDF6A99
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4934'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuyS1gaIb0K3AgCTA0IeuLwIl0RJjSdRIyp4t5Lv3f6Jk
+        yZ6TOA4f85LYNPm74/HueLx6JOPRbHIznt7cfLiano0KFYuAxka3X/5Y3Wd/ZdHX6YZ//3sZFYv1
+        3eb3q7tNtLn7tvg0wmSeC8y0wtggyNcxt9wIix/mVZYF7a+5wKhVWpxnMjynuYb9f0Wp5ZJb0OY8
+        M+JspFaF0KNZPcpUIgsIOYCBINL0+np8M5l8vNxTfn2/mK5/TP6s+Pcyjb9my/Dhn8ntl2h9+5D8
+        h6Uc8rgOKp2BnlpbmhljbtB8uEikTauwMkJHqrCisBeRylnFOmGfl59+BSTRLaYxGQb2cKVsSW45
+        cIYd3klq82xPGadDs/LwmrnKMrUCc38XR4plWwCdWQOTRfI2GAA1UzYVMC22+0hGkjjzU6nN4prR
+        P/gl4QyOTYv4VGC7HEqSiz3WTItSNdwqNJGWpZWqOFndHQigSie8kBv+JiggBixS9GTFmsWAiCWc
+        +WSKW12zJlyjNZlNi0jIJc7jbeQ9DMB2XVJ2uR9YkE5JWhHwOKek0OSKxzNE7ytj50ACisX28Eez
+        AvmLIkIvtgnp2cBujHsoSA8IIuoL9j8ahwAGDFZZiLU3JrFqhr9tvEVIDDxUmiOJexOyA63Z8Cs5
+        lRU89yargQGaKuXP8g0MUGlMJY7y/eNPtWEa1gVbUeWhy6THhNjxYhwNe+DGyKQQwpvFt8CadZdA
+        qHkRpf5EdLyauU+N1/DE2xaIBWSYqdAbExc6a4A1Myl3V6MNfGpNEoi3I0CLudctEG8rwGqPftOo
+        T8AtHre1hQt507/jsbo9gYwXScUTfxK2QLqsUKokfPNihXZ8zPZE4Kk01TKs/Cbmnkk7cEUR8o+/
+        I+iRvYCm6nq+pHuFkQaVXGOmPJcv1TzH01vcToh5FkFxsC+Gvr9cur1uG8SrWX+/uMusleTrNNrb
+        rNN/KK99W3lzrY7H6l9KblPKsBBbci18babFsTrEU/fx4uKiTgVvniW50B6ziKMBy3WUorz2pX/d
+        8VA55tw2z585qR/jOZQpHns7iy0QcOcCvvbgaEM/KlGve1O8gQ3puczQtVCFvzuiJw7lFMrKuYyO
+        eSseH+Y70PqzkUUkzjieN4gKKyOJOMGTnTwARb7wZ0VHw/bQI3LPxEwgZLydkhaOVzPXFYhFmam1
+        1ww5QFIi0QINqjjgFo/SyXgyPh9fn4+n3y7Hs6ur2eXlD8ypSvTAnp7zkeaUlUmfnjKlKUj/bazg
+        E7pSzzeC9t+Y1HECxJi0h/zWI2YHeklPIKIMTr8Xtafpsty/21+HwXZSlYsSdVr3ODdyg8/jnRor
+        UlWB08Hgils8NlCz9ENdXdYBUm4Cl0lGM6sr9BxppNTqQUTWDMf6TDaYuJILubOQashtt8A98nvh
+        udRatc1G11xo8zDahm3HM5aGh5noB1QpilbD4TZkJAqzNYNrANCWB9N3TNB8icWcV5kN3FuJ2qno
+        yaLBCncUOocZqOdF7da2s+IMQq7a7ZGyovuMhosVeRk477BqIag/CxSyiloF5t+Kw/WaC6xb7H5p
+        hrAVqsZ2f9GCrtPdNTECHK0ep3GA4rAldg3iYVvovU9che994vc+8Xuf2HXa6fo70CcuhF2hYTrI
+        psPnbZetH38CtUEkDxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:21 GMT
+      etag:
+      - W/"b116b9c9968fb5764371ef8ebfd5e67e"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54826BD:6538F30:5EDF6A99
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4933'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XbY+jNhD+Kys+Zw/CO5FOraq9VnsSie606bVbnSJjBnACmNomuU2U/94xIXeb
+        tNouUT7uFwS255mZx/PGzqhJBcbEqIhUIIyRQXlVMWVMdoYsCG44TmATK0sDh0TghaEVkCyMQjsM
+        ssT17cRyU3x4DorWPIUFS1EovvvT/2RHKvlSWvGSbmYP1Im3c2+2jLfT7cci/u1xNd1Oi9mX+Xh2
+        l2+m9q/V7G7lxsvceazurenyI4vvPq/i6n4zfYjfn9hFWlVwoS3sbf+FJzcfvpGqKQEPQkVYiTYk
+        PPkZDqvv0CncSYnSrtqWbd1a/q0VPYytiedNxt6jsT96rlm4OnQFUpJcK7+vmWKkvEFbSEPoCldv
+        espHhhKAZ47MBwGEvuNmrpNYDs0yP0rdwPWolUAAkDl2ApQkvoeetUJ7XCjVyIlpkoa9y5kq2kQ7
+        bgpouDQrUHjFXMBtyZJbBVJJUz8Xi+pJGyNBmShkahuk+WrdyNsVlR+YkOaAoNMiUKsF5W2NYWuN
+        jDUIljFKFOO1ZvPwDRiXGSkljAwBROoto60ly2vcGRn6hahWIP91W5YjoyFPJScopD/313PzAhcL
+        VZWLU5afXe9rLvag9AJa5Znei0NrqNtmf68S7+ZHwpc8Z/riMLdXNU9sJwoDPKBrjhcG49D3TqvQ
+        J//3P6YlXc7d6faDO13OdSUhawx3ce5YtyitPnFaCYLyWmFkdTnUmj3+T+v3LmLkokfpyt3/ZaBG
+        k+aZ0S/f6tnhjJcl3yDKudmnqf5vReZ3STTy8M7q/EIUlNyZXBWA7KFLe00Ew0IyGK6T2mG9wfrD
+        Uo0jkX0B6WCkXg7N2tRo0a6rdh1gm0gqWKOrwHADT6QRjYuc1Gzb1ZThaCit47grxIM97KRQGtYY
+        jMPFD2I7sxFsTeiTpkYABbZGsi+EPJNHRPXU6OY2x6DQ1DMFC5JWOlW7knveXN/SeHAUvKXxJYn3
+        lsbHIfA/OsMladwQoauQMfnrOKVmqW+Nwwhn1SSxx9QehzSinhvYaWABoY5jUy+yiY914UqD4nGU
+        GKD55V47YIJ6tc79Vyx6i5LVKyQLuYIyu8aEnghS0wIH9O//a9q1Z8gDB0M97R+x0OBGcAVUPZuV
+        +5V+lIaaJOXJJP13y3TbxjasWrlA0+jBYagzLih0o3mJfUbbyLMMo6Abq751MfRVz9U/NLxcFF//
+        G3NGEra+zivtw/4ffhipx/EOAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:22 GMT
+      etag:
+      - W/"f2cfa3083286e1bae7a971cb947a2dc9"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482708:6538F91:5EDF6A99
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4932'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:22 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482757:6538FF4:5EDF6A9A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4931'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPyVmW/A2FUtKWHNihJcfRHCVI8jpWYtnGkpteQv57JdKD3lsC
+        6YuQNN6dndHgE9I1QxmiNCYMV2VMWQphkuCYVUmakCSueBARjoPSLiFFU9R2JWxkaYvy+Y/oG0kN
+        f25wvhOH5UrQ/PgULnf5sTg+1vnX9b44FvXy+clfzreHgnxRy/k+yHdbulYLXOweZT7/vs/V4lCs
+        8g+2+Tg0tnFtTK8zz2O9fNhKU4/8QXTKG6DvtKfAMG26AWaN5DMD2mjPrZuNei2ZxcB4tsizFUpa
+        7AZptVHN5v0I/9BfQ3whvYWTjabuBpSdUMsUWPGfOj75/JupvgFrCCgmnSW84x/hcuu8sIjV6j4n
+        mOAZjmY4Xfk4C8PMD9foPEWXSQz8h9ZmAMt8+hudOIYkokEVUI6pqKooLYM4CAXmEANUlHAQjEfh
+        fV/XzaC9q7mtIQq0Zltn2aKVRrJm4tLSM7G3t5OLXXbGng3QGo2ylzeBVRlhP0mtTM6JL4ifiFSE
+        QUzKGAMTlBIRpoRF9xX4Ft8b2O8W36s5zz+n6BcMspKCGdm1LhWXM9gfRMUaDVM0ANMOQmOr5ba1
+        yBS5DTPjYJ+jHZvG2f7adMwWueP5/AeigD3gmAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:22 GMT
+      etag:
+      - W/"946eb2be4d043c9d7d9f620de512de33"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54827C0:653907E:5EDF6A9A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4930'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["3372a0fd73a9e58807af898287fb462b04d2b053"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312",
+      "author": {"name": "Bob Example", "email": "bob@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277","node_id":"MDY6Q29tbWl0MjcwOTc3MzU5OmI1OTU0NmYxZDVlMDNiNjhhNTVhYTJjNTJiN2YxYzRmYzQxYTkyNzc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277","author":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:55:23Z"},"committer":{"name":"Bob
+        Example","email":"bob@example.com","date":"2020-06-09T10:55:23Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"3372a0fd73a9e58807af898287fb462b04d2b053","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/3372a0fd73a9e58807af898287fb462b04d2b053"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1169'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:23 GMT
+      etag:
+      - '"8b3b772b7e63e5a6817fbcfc87053808"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482800:65390C7:5EDF6A9A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4929'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngqOYEJO5KhWSxQKpxBLZ8aU2ipPIPqgC4r/3UMcuHbq85d13
+        77uzCB2rnpm4A20TDzohRPbChtFC4y216lWtj6EO6tx+7Q+tULdjsR92/WlQV72t3eldXc3H281u
+        65nAS+wJcohTqjjXk19+enQXs2zHwCNMI40A0swYYdF7s0BImPgzmybMVlMHyAmi699eozlDi6y6
+        s+Q0DQlR5jrrbCn0Bgops1J3ciNzWXZmtc5NtrIUhSAznCcggjyCx/81/fmZ+J9tHo9vuhUxjX0B
+        AAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:23 GMT
+      etag:
+      - W/"d1ffa6b64603b8adf95f6a3b2e985e0b"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54828BD:65391B1:5EDF6A9B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4928'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4tnwE2Ik5K5KhWSxVJSiSXyx0ttFMdR/KAKiP/ehzp26dDlLved
+        d8+NTdCx+pGJO1A28aASwsQWbIgWWm+plS+yPIQmyJP52r+btbwexH7Y9cdBXtS2ccc3edEfr1e7
+        bWYCz1NPkEMcU825Gv3q06M765WJgU8wRhoBpJk4wbL3eomQMPFHtm2YraIOkBNE17+9oj6BQVbf
+        WHKKhrTYiKLsMivgaa3LZyWEUrkRua66zBSdKTK1yauKzHAegQjyCB7/1/TnZ+J/trnfvwG154PJ
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:24 GMT
+      etag:
+      - W/"0220e1d0c8fd12ba069566d4a6a4a882"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548290A:653920E:5EDF6A9B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4927'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:24 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482A13:6539356:5EDF6A9C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4926'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuyS1gaIb0K3AgCTA0IeuLwIl0RJjSdRIyp4t5Lv3f6Jk
+        yZ6TOA4f85LYNPm74/HueLx6JOPRbHIznt7cfLiano0KFYuAxka3X/5Y3Wd/ZdHX6YZ//3sZFYv1
+        3eb3q7tNtLn7tvg0wmSeC8y0wtggyNcxt9wIix/mVZYF7a+5wKhVWpxnMjynuYb9f0Wp5ZJb0OY8
+        M+JspFaF0KNZPcpUIgsIOYCBINL0+np8M5l8vNxTfn2/mK5/TP6s+Pcyjb9my/Dhn8ntl2h9+5D8
+        h6Uc8rgOKp2BnlpbmhljbtB8uEikTauwMkJHqrCisBeRylnFOmGfl59+BSTRLaYxGQb2cKVsSW45
+        cIYd3klq82xPGadDs/LwmrnKMrUCc38XR4plWwCdWQOTRfI2GAA1UzYVMC22+0hGkjjzU6nN4prR
+        P/gl4QyOTYv4VGC7HEqSiz3WTItSNdwqNJGWpZWqOFndHQigSie8kBv+JiggBixS9GTFmsWAiCWc
+        +WSKW12zJlyjNZlNi0jIJc7jbeQ9DMB2XVJ2uR9YkE5JWhHwOKek0OSKxzNE7ytj50ACisX28Eez
+        AvmLIkIvtgnp2cBujHsoSA8IIuoL9j8ahwAGDFZZiLU3JrFqhr9tvEVIDDxUmiOJexOyA63Z8Cs5
+        lRU89yargQGaKuXP8g0MUGlMJY7y/eNPtWEa1gVbUeWhy6THhNjxYhwNe+DGyKQQwpvFt8CadZdA
+        qHkRpf5EdLyauU+N1/DE2xaIBWSYqdAbExc6a4A1Myl3V6MNfGpNEoi3I0CLudctEG8rwGqPftOo
+        T8AtHre1hQt507/jsbo9gYwXScUTfxK2QLqsUKokfPNihXZ8zPZE4Kk01TKs/Cbmnkk7cEUR8o+/
+        I+iRvYCm6nq+pHuFkQaVXGOmPJcv1TzH01vcToh5FkFxsC+Gvr9cur1uG8SrWX+/uMusleTrNNrb
+        rNN/KK99W3lzrY7H6l9KblPKsBBbci18babFsTrEU/fx4uKiTgVvniW50B6ziKMBy3WUorz2pX/d
+        8VA55tw2z585qR/jOZQpHns7iy0QcOcCvvbgaEM/KlGve1O8gQ3puczQtVCFvzuiJw7lFMrKuYyO
+        eSseH+Y70PqzkUUkzjieN4gKKyOJOMGTnTwARb7wZ0VHw/bQI3LPxEwgZLydkhaOVzPXFYhFmam1
+        1ww5QFIi0QINqjjgFo/SyXgyPh9fn4+n3y7Hs6ur2eXlD8ypSvTAnp7zkeaUlUmfnjKlKUj/bazg
+        E7pSzzeC9t+Y1HECxJi0h/zWI2YHeklPIKIMTr8Xtafpsty/21+HwXZSlYsSdVr3ODdyg8/jnRor
+        UlWB08Hgils8NlCz9ENdXdYBUm4Cl0lGM6sr9BxppNTqQUTWDMf6TDaYuJILubOQashtt8A98nvh
+        udRatc1G11xo8zDahm3HM5aGh5noB1QpilbD4TZkJAqzNYNrANCWB9N3TNB8icWcV5kN3FuJ2qno
+        yaLBCncUOocZqOdF7da2s+IMQq7a7ZGyovuMhosVeRk477BqIag/CxSyiloF5t+Kw/WaC6xb7H5p
+        hrAVqsZ2f9GCrtPdNTECHK0ep3GA4rAldg3iYVvovU9che994vc+8Xuf2HXa6fo70CcuhF2hYTrI
+        psPnbZetH38CtUEkDxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:25 GMT
+      etag:
+      - W/"b116b9c9968fb5764371ef8ebfd5e67e"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482A7A:65393B3:5EDF6A9C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4925'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:25 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482ADD:6539436:5EDF6A9D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4924'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuySNgaIb0K3AgCTA0IeuLwIl0RZjSdRIyp4t5Lv3f6Rk
+        yZ6TOAkf85LYNPm74/HueLxmJNPRdHI1vr66+nBxfTIqVSoiGhvdfPljdZf/lSdfrzf8+9/LpFys
+        bze/X9xuks3tt8WnESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI0l/EpzTXs/ysqLZfcgjbj
+        uREnI7UqhR5Nm1Gu5rKEkAMYCCJNLy/HV5PJx/M95dd3i+v1j8mfNf9eZenXfBnf/zO5+ZKsb+7n
+        /2Ephzyuo1rnoGfWVmbKmB80H87m0mZ1XBuhE1VaUdqzRBWsZp2wz8tPvwIy1y3GmQwDe7hKtiS/
+        HDjDDu8ks0W+p4zXwa08vGam8lytwNzfxZFi2RZAZ+Zgspy/DQZAw5TNBEyL7T6QkSTO/LVUt7hh
+        9A9+STiDY9MifS2wXQ4lycUeGqZFpRy3jk2iZWWlKl+t7g4EUKXnvJQb/iYoIAYsUvTVirnFgIgl
+        nPnVFL+6YS5ckzWZTYtEyCXO423kPQzAdl1RdrkbWJBOSVoR8bSgpOByxcMJoveFsXMgAaVie/ij
+        aYn8RRGhF9uE9GRgO+MeCtIDgoj6jP2PxiGAAYNVFmIdjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Rs5LIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIbPg22BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazIJugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJezms+DydhC6TLCqXKnG+erdCOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq6nS7oXGGlQyTkzFYV8ruY5nt7idkIssAiKg30x9P350u1l2yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPZ2dnTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj8zUj/FcyhXPA12Flsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKmUyO
+        eSseH+Y70OazkWUiTjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlat1
+        0Aw5QFIi0QINqjTiFo/SyXgyPh1fno6vv52PpxcX0/PzH5hTV+iBPT7nI82papM9OmVyQVOQ/ttY
+        wSd0pZ5uBO2/ManjBIgxWQ/5rUdMD/SSHkEkOZx+L2pfp8ty/25/GQbbyVQhKtRp3ePcyA0+j3dq
+        rETVJU4Hgytu8dhAzdIPdXVZB8i4iXwmGU2trtFzpJFKq3uRWDMc6zPZYOJKLuTOQqoht90C/8jv
+        hRdSa9U2G31zoc3DaBu2Hc9UGh7noh9QlShbDYfbkIkozdYMvgFAWx5M3zGB+5KKGa9zG/m3ErVT
+        0ZNFgxXuKHQBM1DPi9qtbWfFG4RctdsjZUX/GQ0XK4oq8t5h1UJQfxYoZBW1isy/NYfruQusW+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYErsG8bAt9N4nruP3PvF7n/i9T+w77XT9HegTl8Ku0DAd
+        ZNPh87bL1g8/AUwRo/IVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:25 GMT
+      etag:
+      - W/"ca405b3dc344a48658699ca4a8651f7e"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:18 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482B3F:65394B3:5EDF6A9D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4923'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VS24rbMBD9lUXPyVqWLd+gUEr60IU4bPFu8ZYSRrIcK2vZxpLbXMi/r9R0oX1L
+        IH0RGo1mzpwz54h0AyhDjKY0jGq/ogIHLEqAUgDCKWFx7fOw5qEPKYljNENdX4m1rGzRclFGjyQ1
+        7FuLl1v+a1XwYHl4oiv1xV8VTzhX5e5l8dwuF7nMt02TF89NWTxs8+JB5qTclYevqjw87sridZ8f
+        +AfbfBpb27gxZtCZ58Eg7zfSNBO7573yRjH02lPCgDb9KOatZHMjtNGeO9drta/A5oTxbJFnK5S0
+        uSuoNUa1639H+Av+EuAz6DWYMJmmH1F2RB0oYcl/6tnd5x2ooRVWEKFAOklYzz6K86vTwmYsV/ed
+        YILnOJrjtPBxRmlGghd0mqHzJEb8h9ZmFBb5+Mc6PvgceMV4WsWURnHsVwHBVFAhUprQmAQRw4FP
+        brtdN4P2Lsa2giihNWycZAvrkgH4q43upsHpWNnhBhhFZzTKvr8zC4KYAK6rOIBU0CTBMdRJmpAk
+        rlkYEYbDyh40uC2zd99egX4z316MefoxQz/FKGvJwci+c3Y4x1bLrIZWixkaBWiXQlOn5ab7rbK7
+        gJlGu4dualsn+77twRa58HR6Awa9edqRBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:26 GMT
+      etag:
+      - W/"8b3b772b7e63e5a6817fbcfc87053808"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482BB0:653953D:5EDF6A9D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4922'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T32vbMBDH/xc/t5H8Q5YdGKMJXUlgGWsf6oRAkCw5VipLxlIa0tL/vVJjRpv2
+        IStj9EUSd7q7D3ffewwUaXgwDBixpCXlHVnzwcZoFZwFLbH1xx5TE+egNIUVg1kWIRjBPCYYwRin
+        DKcpy1ISM5zhqKygS2XEgysShslZsO2ki62tbc0QANKKwVrYeksHpW5Ax1ttQMMtMVZ3/FwKem65
+        sQb4c7Vq9p7TcAtKrSxXznEM/r3j1TeKcpSkVcgQhzFNM4IQIVGJIoqrsEyqMglJHmHs0GrbyNVb
+        qFdAp6BQqSk4teI7Xofg6h0RfLotLhXwPAb8xXSY3impCTuC6Miun83W8K5v+MuYTurKiSP4qCF2
+        33pNVkJy156+sjPwnV5PxlPIi5GcbNy7mT0wMTGTixf7dn4b9vYQLa5+wHkxk2x88C+V+7FfFLN7
+        Vkw3i+Kn+CVGdCwuXOQIH27/nu7mxbU+ZL+u2dXlPS3kfqn+RN6gTRnPRR+Z+7v43eZLvzJclZoJ
+        tfbb4WSaJs62kkLdmWD4GBguqy+lfaeWf8HzKdH5vXtV/P/u3NPTM3Z6qiT5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:26 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482C15:65395B8:5EDF6A9E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4921'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tagger": {"name": "Frodo Baggins", "email": "frodo@shire.net"},
+      "message": "Second version", "tag": "version-1.1", "type": "commit", "object":
+      "b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjcwOTc3MzU5OjZhMTIzYmJhYmVmOWMyN2JkODk1MTE1N2VmOGRkZmU2NWQ0M2E0NTg=","sha":"6a123bbabef9c27bd8951157ef8ddfe65d43a458","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6a123bbabef9c27bd8951157ef8ddfe65d43a458","tagger":{"name":"Frodo
+        Baggins","email":"frodo@shire.net","date":"2020-06-09T10:55:26Z"},"object":{"sha":"b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277"},"tag":"version-1.1","message":"Second
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '687'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:26 GMT
+      etag:
+      - '"9d40e9a2a52e968130d1c2244853451c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6a123bbabef9c27bd8951157ef8ddfe65d43a458
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482C78:6539637:5EDF6A9E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4920'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "6a123bbabef9c27bd8951157ef8ddfe65d43a458", "ref":
+      "refs/tags/version-1.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.1","node_id":"MDM6UmVmMjcwOTc3MzU5OnJlZnMvdGFncy92ZXJzaW9uLTEuMQ==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1","object":{"sha":"6a123bbabef9c27bd8951157ef8ddfe65d43a458","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6a123bbabef9c27bd8951157ef8ddfe65d43a458"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:27 GMT
+      etag:
+      - '"698a20f468eaeb38c2db35496ff0d4f5"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482D0A:65396EF:5EDF6A9E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4919'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482E0B:653982D:5EDF6A9F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4918'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuySNgaIb0K3AgCTA0IeuLwIl0RZjSdRIyp4t5Lv3f6Rk
+        yZ6TOAkf85LYNPm74/HueLxmJNPRdHI1vr66+nBxfTIqVSoiGhvdfPljdZf/lSdfrzf8+9/LpFys
+        bze/X9xuks3tt8WnESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI0l/EpzTXs/ysqLZfcgjbj
+        uREnI7UqhR5Nm1Gu5rKEkAMYCCJNLy/HV5PJx/M95dd3i+v1j8mfNf9eZenXfBnf/zO5+ZKsb+7n
+        /2Ephzyuo1rnoGfWVmbKmB80H87m0mZ1XBuhE1VaUdqzRBWsZp2wz8tPvwIy1y3GmQwDe7hKtiS/
+        HDjDDu8ks0W+p4zXwa08vGam8lytwNzfxZFi2RZAZ+Zgspy/DQZAw5TNBEyL7T6QkSTO/LVUt7hh
+        9A9+STiDY9MifS2wXQ4lycUeGqZFpRy3jk2iZWWlKl+t7g4EUKXnvJQb/iYoIAYsUvTVirnFgIgl
+        nPnVFL+6YS5ckzWZTYtEyCXO423kPQzAdl1RdrkbWJBOSVoR8bSgpOByxcMJoveFsXMgAaVie/ij
+        aYn8RRGhF9uE9GRgO+MeCtIDgoj6jP2PxiGAAYNVFmIdjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Rs5LIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIbPg22BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazIJugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJezms+DydhC6TLCqXKnG+erdCOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq6nS7oXGGlQyTkzFYV8ruY5nt7idkIssAiKg30x9P350u1l2yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPZ2dnTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj8zUj/FcyhXPA12Flsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKmUyO
+        eSseH+Y70OazkWUiTjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlat1
+        0Aw5QFIi0QINqjTiFo/SyXgyPh1fno6vv52PpxcX0/PzH5hTV+iBPTpn8pHmVLXJHp9yRVOQ/ttY
+        wSd0pZ5uBO2/ManjBIgxWQ/5rUdMD/SSHkEkOZx+L2pfp8ty/25/GQbbyVQhKtRp3ePcyA0+j3dq
+        rETVJU4Hgytu8dhAzdIPdXVZB8i4iXwmGU2trtFzpJFKq3uRWDMc6zPZYOJKLuTOQqoht90C/8jv
+        hRdSa9U2G31zoc3DaBu2Hc9UGh7noh9QlShbDYfbkIkozdYMvgFAWx5M3zGB+5KKGa9zG/m3ErVT
+        0ZNFgxXuKHQBM1DPi9qtbWfFG4RctdsjZUX/GQ0XK4oq8t5h1UJQfxYoZBW1isy/NYfruQusW+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYErsG8bAt9N4nruP3PvF7n/i9T+w77XT9HegTl8Ku0DAd
+        ZNPh87bL1g8/AfIri3kVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:29 GMT
+      etag:
+      - W/"37cc04f1a345255cdae42f89837f5655"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482E98:65398D7:5EDF6AA0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4917'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72RyWrDMBCG38XnxKpkS7YMORS6QKgJhaQNKSVoGccO3rDkFCf43av0WEoJdLnM
+        ZebXfKPv5eR1kHnJuRpkxc6gA3SmaOop9q+8iVc3GraFdhPpTcpW1VOV7tXbYqmC9Liii3pebur0
+        oO/vajVwslnPj+KZ9w/L2z69ns3cA31XunBubWsShERb+LvC5r30VVOhDtrGoAqsMLbpYFoWcmrB
+        WIfi6nZbDVq4HljkQm76a8ZG7kFZLzl5JhduGVaE04AwIiLKJM5AE8KVDHFEVMgYkEzjSGnu6OzQ
+        gku4w38X9eMnL+YYx8l3HvDPPDz+h4cz42cPTGASSCkkZFyRSOqYU4xpBFmsdQaM6jAQIY3/2sPF
+        HOP4+g7GHn8+EQMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:29 GMT
+      etag:
+      - W/"8e36af1b7442f4ddc2ea34b5fc7b8d69"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482F53:65399BF:5EDF6AA1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4916'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/1c2953262a756b1fed229cb4172c466e2fd17cd9
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61STWvjMBD9K0XnOJLl+BMKpaRZelByyW7BlyDLY0eOZRtL3pKW/PeOSH9AF/Yy
+        aPTmvXkzzCcZxhpOuiYFEVuR/Pm1G0Sn3g9HFYmP3/Gh23Wiu4Ti45UL8xLtj6UWb2Vfbl+vh7e9
+        3m9fImEE23dlL0x5Ece6K7eXR7Ii9ixRNFQ8jyOecJnGSRU2UHOeq2oTplxtkgR4U4epqnMkLHOP
+        hLNzky0olZNet9qdl2qtRkNnmEZLDThp3ThD0OsqcGCdpT6eTuZaS8TAUSRRJ1tL/6E11rcwk+KT
+        DNIAunjWfTU+POO3Hix6AyO1d1f5/yd71jOsB3CIYFtP4IyzgCUBy48hK+K4CLOS3FZkrDpQzivf
+        9xFFKZesqdNI5hBnGUtlk+UZz9Km2iS8YpsaQxyhsrtOXhmnN9p3+o/7uWta+mM3OAnuCN38hdnq
+        cQjCNUNLBqyVrXe507N1D98oIvjSjVbSYbGf/p4D3lkjewsrMoO0HiLLYHU7IIIngw/plhkFh6Xv
+        V2SS136USPLp7fYFkCmjPK4CAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:29 GMT
+      etag:
+      - W/"1c544e0113f352e8ad1875ba909e7b16"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482F9E:6539A1E:5EDF6AA1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4915'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:29 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5482FDD:6539A6A:5EDF6AA1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4914'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuySNgaIb0K3AgCTA0IeuLwIl0RZjSdRIyp4t5Lv3f6Rk
+        yZ6TOAkf85LYNPm74/HueLxmJNPRdHI1vr66+nBxfTIqVSoiGhvdfPljdZf/lSdfrzf8+9/LpFys
+        bze/X9xuks3tt8WnESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI0l/EpzTXs/ysqLZfcgjbj
+        uREnI7UqhR5Nm1Gu5rKEkAMYCCJNLy/HV5PJx/M95dd3i+v1j8mfNf9eZenXfBnf/zO5+ZKsb+7n
+        /2Ephzyuo1rnoGfWVmbKmB80H87m0mZ1XBuhE1VaUdqzRBWsZp2wz8tPvwIy1y3GmQwDe7hKtiS/
+        HDjDDu8ks0W+p4zXwa08vGam8lytwNzfxZFi2RZAZ+Zgspy/DQZAw5TNBEyL7T6QkSTO/LVUt7hh
+        9A9+STiDY9MifS2wXQ4lycUeGqZFpRy3jk2iZWWlKl+t7g4EUKXnvJQb/iYoIAYsUvTVirnFgIgl
+        nPnVFL+6YS5ckzWZTYtEyCXO423kPQzAdl1RdrkbWJBOSVoR8bSgpOByxcMJoveFsXMgAaVie/ij
+        aYn8RRGhF9uE9GRgO+MeCtIDgoj6jP2PxiGAAYNVFmIdjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Rs5LIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIbPg22BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazIJugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJezms+DydhC6TLCqXKnG+erdCOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq6nS7oXGGlQyTkzFYV8ruY5nt7idkIssAiKg30x9P350u1l2yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPZ2dnTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj8zUj/FcyhXPA12Flsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKmUyO
+        eSseH+Y70OazkWUiTjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlat1
+        0Aw5QFIi0QINqjTiFo/SyXgyPh1fno6vv52PpxcX0/PzH5hTV+iBPTpn8pHmVLXJHp9yRVOQ/ttY
+        wSd0pZ5uBO2/ManjBIgxWQ/5rUdMD/SSHkEkOZx+L2pfp8ty/25/GQbbyVQhKtRp3ePcyA0+j3dq
+        rETVJU4Hgytu8dhAzdIPdXVZB8i4iXwmGU2trtFzpJFKq3uRWDMc6zPZYOJKLuTOQqoht90C/8jv
+        hRdSa9U2G31zoc3DaBu2Hc9UGh7noh9QlShbDYfbkIkozdYMvgFAWx5M3zGB+5KKGa9zG/m3ErVT
+        0ZNFgxXuKHQBM1DPi9qtbWfFG4RctdsjZUX/GQ0XK4oq8t5h1UJQfxYoZBW1isy/NYfruQusW+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYErsG8bAt9N4nruP3PvF7n/i9T+w77XT9HegTl8Ku0DAd
+        ZNPh87bL1g8/AfIri3kVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:30 GMT
+      etag:
+      - W/"37cc04f1a345255cdae42f89837f5655"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5483039:6539AC8:5EDF6AA1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4913'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPyVmW/A2FUtKWHNihJcfRHCVI8jpWYtnGkpteQv57JdKD3lsC
+        6YuQNN6dndHgE9I1QxmiNCYMV2VMWQphkuCYVUmakCSueBARjoPSLiFFU9R2JWxkaYvy+Y/oG0kN
+        f25wvhOH5UrQ/PgULnf5sTg+1vnX9b44FvXy+clfzreHgnxRy/k+yHdbulYLXOweZT7/vs/V4lCs
+        8g+2+Tg0tnFtTK8zz2O9fNhKU4/8QXTKG6DvtKfAMG26AWaN5DMD2mjPrZuNei2ZxcB4tsizFUpa
+        7AZptVHN5v0I/9BfQ3whvYWTjabuBpSdUMsUWPGfOj75/JupvgFrCCgmnSW84x/hcuu8sIjV6j4n
+        mOAZjmY4Xfk4C8PMD9foPEWXSQz8h9ZmAMt8+hudOIYkokEVUI6pqKooLYM4CAXmEANUlHAQjEfh
+        fV/XzaC9q7mtIQq0Zltn2aKVRrJm4tLSM7G3t5OLXXbGng3QGo2ylzeBVRlhP0mtTM6JL4ifiFSE
+        QUzKGAMTlBIRpoRF9xX4Ft8b2O8W36s5zz+n6BcMspKCGdm1LhWXM9gfRMUaDVM0ANMOQmOr5ba1
+        yBS5DTPjYJ+jHZvG2f7adMwWueP5/AeigD3gmAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:30 GMT
+      etag:
+      - W/"946eb2be4d043c9d7d9f620de512de33"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548307D:6539B35:5EDF6AA2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4912'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=3372a0fd73a9e58807af898287fb462b04d2b053
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28ixY1sOjNKYrTjQlnUPdUIhSNbZVipLxlIastLvvnMbaJfu
+        IevG2IPEoZPu/+N/p0dPsxa8qSeYYx0r71kNo7U12jvxOuaaX2dswzBBIaGlSJlIUkiDIOQ+jaNx
+        EkdCQAxJ5Kd+SnnsYykrv6NIGp94m17h08a5zk4JYZ0c1dI1Gz4qTUt66IwlLThmnenhVEl+6sA6
+        S4Z9tWp3A6YFR0qjHWhMHHKf9VB9CsMkYH4lkpClEFHqJ6yiKQ1oUvFJHHB/InCLQiRrXKtWP0O9
+        AToGhSvDybGK73gRAfUOCD5sC5YiA48lv9EcYbZaGSYOIHq23fdmY6HfG/7cpmNc+RND3K4bRrKS
+        CtCevTIewNbUeTbfLG7HKl9j3I6j5cUXf1FcKZHlNj9/zu+WxdWDKObrZXEpr+WMZ/K8vtN5NkuG
+        KM+GNd8uihvzUuWmERefH3ihXl9+i9ZluJAv92fpnR6i4muHESKBLo2QukYmjuMYT/BspaS+t970
+        0bOgqv9qxnEq/gbPh4Zr+F9vxP/t33p6+gFf1uEw4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:30 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:15 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54830D6:6539B91:5EDF6AA2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4911'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/6a123bbabef9c27bd8951157ef8ddfe65d43a458
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S227bMAz9lULPcWwplhMbGDAMvWAFnGCb26J5CSibtpVYtmHJG9Ii/z4K2Qes
+        QF8Ekofn8JDQO+uHCg+6YhnLb/Pk+eG+z4/ln11RrvK3J7k77tu8+P72ah7bV/Nsdi/5eSseT7vb
+        E8+LO74VVHv4edqbJ7F9+RHl4i7aFs0XtmC2BRJNgIuVUqCwTkuxVtUmlZzLNdabqqoxkVW8glhu
+        iDBPHRFa50abhSGMetlo185qWQ4mnHAcbGjQgXXDhEGnVeDQOhv693Aw5woIQxcSKXTQ2PADo6m/
+        wYll76wHg+Tifhqq4eYblXVvyRsa0N5d7etfbasnXPboCKGxniAiEQVREkRpwaNMykwke3ZZsEEd
+        sXRe+XoPJVMZJzWvJEYrlWxASgBRSqHWNS/juow5pGK9JmV3Hr0ybW+0n/SJ97lq2vC/3dAmdCNy
+        8xsnq4c+4EtOlgxaC413+QvLoa9u/sEEUaRrXYKjbr/+NUf6aDV0FhdsQrAeYnNvddMTQn+GAnDz
+        RIr93HULNsK5G4BIPr1c/gKiT6bsrwIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:30 GMT
+      etag:
+      - W/"9d40e9a2a52e968130d1c2244853451c"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5483145:6539C09:5EDF6AA2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4910'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:31 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:5483197:6539C76:5EDF6AA2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4909'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuySNgaIb0K3AgCTA0IeuLwIl0RZjSdRIyp4t5Lv3f6Rk
+        yZ6TOAkf85LYNPm74/HueLxmJNPRdHI1vr66+nBxfTIqVSoiGhvdfPljdZf/lSdfrzf8+9/LpFys
+        bze/X9xuks3tt8WnESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI0l/EpzTXs/ysqLZfcgjbj
+        uREnI7UqhR5Nm1Gu5rKEkAMYCCJNLy/HV5PJx/M95dd3i+v1j8mfNf9eZenXfBnf/zO5+ZKsb+7n
+        /2Ephzyuo1rnoGfWVmbKmB80H87m0mZ1XBuhE1VaUdqzRBWsZp2wz8tPvwIy1y3GmQwDe7hKtiS/
+        HDjDDu8ks0W+p4zXwa08vGam8lytwNzfxZFi2RZAZ+Zgspy/DQZAw5TNBEyL7T6QkSTO/LVUt7hh
+        9A9+STiDY9MifS2wXQ4lycUeGqZFpRy3jk2iZWWlKl+t7g4EUKXnvJQb/iYoIAYsUvTVirnFgIgl
+        nPnVFL+6YS5ckzWZTYtEyCXO423kPQzAdl1RdrkbWJBOSVoR8bSgpOByxcMJoveFsXMgAaVie/ij
+        aYn8RRGhF9uE9GRgO+MeCtIDgoj6jP2PxiGAAYNVFmIdjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Rs5LIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIbPg22BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazIJugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJezms+DydhC6TLCqXKnG+erdCOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq6nS7oXGGlQyTkzFYV8ruY5nt7idkIssAiKg30x9P350u1l2yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPZ2dnTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj8zUj/FcyhXPA12Flsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKmUyO
+        eSseH+Y70OazkWUiTjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlat1
+        0Aw5QFIi0QINqjTiFo/SyXgyPh1fno6vv52PpxcX0/PzH5hTV+iBPTpn8pHmVLXJHp9yRVOQ/ttY
+        wSd0pZ5uBO2/ManjBIgxWQ/5rUdMD/SSHkEkOZx+L2pfp8ty/25/GQbbyVQhKtRp3ePcyA0+j3dq
+        rETVJU4Hgytu8dhAzdIPdXVZB8i4iXwmGU2trtFzpJFKq3uRWDMc6zPZYOJKLuTOQqoht90C/8jv
+        hRdSa9U2G31zoc3DaBu2Hc9UGh7noh9QlShbDYfbkIkozdYMvgFAWx5M3zGB+5KKGa9zG/m3ErVT
+        0ZNFgxXuKHQBM1DPi9qtbWfFG4RctdsjZUX/GQ0XK4oq8t5h1UJQfxYoZBW1isy/NYfruQusW+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYErsG8bAt9N4nruP3PvF7n/i9T+w77XT9HegTl8Ku0DAd
+        ZNPh87bL1g8/AfIri3kVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:31 GMT
+      etag:
+      - W/"37cc04f1a345255cdae42f89837f5655"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54831FD:6539CF7:5EDF6AA3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4908'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VS24rbMBD9lUXPyVqWLd+gUEr60IU4bPFu8ZYSRrIcK2vZxpLbXMi/r9R0oX1L
+        IH0RGo1mzpwz54h0AyhDjKY0jGq/ogIHLEqAUgDCKWFx7fOw5qEPKYljNENdX4m1rGzRclFGjyQ1
+        7FuLl1v+a1XwYHl4oiv1xV8VTzhX5e5l8dwuF7nMt02TF89NWTxs8+JB5qTclYevqjw87sridZ8f
+        +AfbfBpb27gxZtCZ58Eg7zfSNBO7573yRjH02lPCgDb9KOatZHMjtNGeO9drta/A5oTxbJFnK5S0
+        uSuoNUa1639H+Av+EuAz6DWYMJmmH1F2RB0oYcl/6tnd5x2ooRVWEKFAOklYzz6K86vTwmYsV/ed
+        YILnOJrjtPBxRmlGghd0mqHzJEb8h9ZmFBb5+Mc6PvgceMV4WsWURnHsVwHBVFAhUprQmAQRw4FP
+        brtdN4P2Lsa2giihNWycZAvrkgH4q43upsHpWNnhBhhFZzTKvr8zC4KYAK6rOIBU0CTBMdRJmpAk
+        rlkYEYbDyh40uC2zd99egX4z316MefoxQz/FKGvJwci+c3Y4x1bLrIZWixkaBWiXQlOn5ab7rbK7
+        gJlGu4dualsn+77twRa58HR6Awa9edqRBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:32 GMT
+      etag:
+      - W/"8b3b772b7e63e5a6817fbcfc87053808"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548326E:6539D80:5EDF6AA3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4907'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b59546f1d5e03b68a55aa2c52b7f1c4fc41a9277
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T32vbMBDH/xc/t5H8Q5YdGKMJXUlgGWsf6oRAkCw5VipLxlIa0tL/vVJjRpv2
+        IStj9EUSd7q7D3ffewwUaXgwDBixpCXlHVnzwcZoFZwFLbH1xx5TE+egNIUVg1kWIRjBPCYYwRin
+        DKcpy1ISM5zhqKygS2XEgysShslZsO2ki62tbc0QANKKwVrYeksHpW5Ax1ttQMMtMVZ3/FwKem65
+        sQb4c7Vq9p7TcAtKrSxXznEM/r3j1TeKcpSkVcgQhzFNM4IQIVGJIoqrsEyqMglJHmHs0GrbyNVb
+        qFdAp6BQqSk4teI7Xofg6h0RfLotLhXwPAb8xXSY3impCTuC6Miun83W8K5v+MuYTurKiSP4qCF2
+        33pNVkJy156+sjPwnV5PxlPIi5GcbNy7mT0wMTGTixf7dn4b9vYQLa5+wHkxk2x88C+V+7FfFLN7
+        Vkw3i+Kn+CVGdCwuXOQIH27/nu7mxbU+ZL+u2dXlPS3kfqn+RN6gTRnPRR+Z+7v43eZLvzJclZoJ
+        tfbb4WSaJs62kkLdmWD4GBguqy+lfaeWf8HzKdH5vXtV/P/u3NPTM3Z6qiT5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:32 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:23 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548332A:6539E49:5EDF6AA4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4906'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:32 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54833F6:6539F29:5EDF6AA4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4905'
+      x-ratelimit-reset:
+      - '1591703106'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOuySNgaIb0K3AgCTA0IeuLwIl0RZjSdRIyp4t5Lv3f6Rk
+        yZ6TOAkf85LYNPm74/HueLxmJNPRdHI1vr66+nBxfTIqVSoiGhvdfPljdZf/lSdfrzf8+9/LpFys
+        bze/X9xuks3tt8WnESbzQmCmFcZGUbFOueVGWPwwq/M8an8tBEat0uI0l/EpzTXs/ysqLZfcgjbj
+        uREnI7UqhR5Nm1Gu5rKEkAMYCCJNLy/HV5PJx/M95dd3i+v1j8mfNf9eZenXfBnf/zO5+ZKsb+7n
+        /2Ephzyuo1rnoGfWVmbKmB80H87m0mZ1XBuhE1VaUdqzRBWsZp2wz8tPvwIy1y3GmQwDe7hKtiS/
+        HDjDDu8ks0W+p4zXwa08vGam8lytwNzfxZFi2RZAZ+Zgspy/DQZAw5TNBEyL7T6QkSTO/LVUt7hh
+        9A9+STiDY9MifS2wXQ4lycUeGqZFpRy3jk2iZWWlKl+t7g4EUKXnvJQb/iYoIAYsUvTVirnFgIgl
+        nPnVFL+6YS5ckzWZTYtEyCXO423kPQzAdl1RdrkbWJBOSVoR8bSgpOByxcMJoveFsXMgAaVie/ij
+        aYn8RRGhF9uE9GRgO+MeCtIDgoj6jP2PxiGAAYNVFmIdjEmshuFvG28JEgOPleZI4sGE7EAbNvxK
+        TmUFL4LJcjBAM6XCWd7BAJXG1OIo3z/+VB3TsC7YyrqIfSY9JsSOF+Np2AM3Rs5LIYJZfAtsWHcJ
+        xJqXSRZORMdrmP/kvIbPg22BWEDGuYqDMXGhMwdsmMm4vxptFFJrkkC8HQFazIJugXhbAVYH9Bun
+        PgG3eNzWFi4UTP+Ox5r2BHJezms+DydhC6TLCqXKnG+erdCOj9meCDyVplrGddjE3DNpB74oQv4J
+        dwQ9shfgqq6nS7oXGGlQyTkzFYV8ruY5nt7idkIssAiKg30x9P350u1l2yBew/r7xV9mraRQp9He
+        Zp3+Q3nt2yqYa3U81vxScZtRhoXYimsRajMtjjUxnroPZ2dnTSa4e5YUQgfMIp4GLNdJhvI6lP5N
+        x0PlWHDrnj8zUj/FcyhXPA12Flsg4N4FQu3B04Z+VKFeD6a4gw3phczRtVBluDuiJw7llMrKmUyO
+        eSseH+Y70OazkWUiTjieN4gKKxOJOMGTnTwARb4IZ0VPw/bQI/LPxFwgZIKdkhae1zDfFUhFlat1
+        0Aw5QFIi0QINqjTiFo/SyXgyPh1fno6vv52PpxcX0/PzH5hTV+iBPTpn8pHmVLXJHp9yRVOQ/ttY
+        wSd0pZ5uBO2/ManjBIgxWQ/5rUdMD/SSHkEkOZx+L2pfp8ty/25/GQbbyVQhKtRp3ePcyA0+j3dq
+        rETVJU4Hgytu8dhAzdIPdXVZB8i4iXwmGU2trtFzpJFKq3uRWDMc6zPZYOJKLuTOQqoht90C/8jv
+        hRdSa9U2G31zoc3DaBu2Hc9UGh7noh9QlShbDYfbkIkozdYMvgFAWx5M3zGB+5KKGa9zG/m3ErVT
+        0ZNFgxXuKHQBM1DPi9qtbWfFG4RctdsjZUX/GQ0XK4oq8t5h1UJQfxYoZBW1isy/NYfruQusW+x/
+        cUPYClVju79oQdfp7poUAY5Wj9c4QnHYErsG8bAt9N4nruP3PvF7n/i9T+w77XT9HegTl8Ku0DAd
+        ZNPh87bL1g8/AfIri3kVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 09 Jun 2020 10:55:33 GMT
+      etag:
+      - W/"37cc04f1a345255cdae42f89837f5655"
+      last-modified:
+      - Tue, 09 Jun 2020 10:55:28 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:548344D:6539FA5:5EDF6AA4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4904'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 09 Jun 2020 10:55:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - D616:C611:54834AB:653A012:5EDF6AA5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4903'
+      x-ratelimit-reset:
+      - '1591703107'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_list_no_package.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_list_no_package.yaml
@@ -1,0 +1,243 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:56 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C960:2668D:A7CA06B:C7B332E:5ED660BF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3303'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:56 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C960:2668D:A7CA0D1:C7B3387:5ED660C0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3302'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:56 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C960:2668D:A7CA150:C7B3423:5ED660C0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3301'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_list_no_tags.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_list_no_tags.yaml
@@ -1,0 +1,3040 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:38 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB09FF:59D62A4:5ED660AE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3339'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:38 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0A4E:59D62E3:5ED660AE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3338'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821965,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE5NjU=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:22:38Z","updated_at":"2020-06-02T14:22:38Z","pushed_at":"2020-06-02T14:22:39Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:40 GMT
+      etag:
+      - '"9520984d645d3ec3c0f894be803e2d2e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0AA4:59D6356:5ED660AE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3337'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"d2a98771e24b46bea4e4360d7879abd39613aea2","node_id":"MDY6Q29tbWl0MjY4ODIxOTY1OmQyYTk4NzcxZTI0YjQ2YmVhNGU0MzYwZDc4NzlhYmQzOTYxM2FlYTI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d2a98771e24b46bea4e4360d7879abd39613aea2","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/d2a98771e24b46bea4e4360d7879abd39613aea2","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:40Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:40Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:41 GMT
+      etag:
+      - '"7d07387b12fd3ca9e2f3badc49bf731b"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0C83:59D6588:5ED660B0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3336'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTU/bQBD9K8jngB3HxEkk1B5oqxwARQ20pqqitT2OF9a77u46kET898445iM5
+        0BjRGxcU7+6bffPmY4e1I1kBzsgpmLGgnY6TqKLg1hmtHZMz3Eh9NhyEYRf8IA76MbAAgl7fS8NB
+        OGRx2hv2uz0GzEeoVCnMeIqgs9OoP/GHNv4hvLObKLg4Hd9fTKPuRTFZRtPb4HyV3F9Px150M/Gj
+        4io//3bpna2iu+vTBPdEHhWTFZ6/P/O/img6PtnixSqbK00MG+7fc5YzffBloZXEk1AwLpAE8sfl
+        I6Dlz3NaPELn8EDKLLnse7536PUPPX/aDUa+Pwq8a+fhUQFS479dUYAxbE4kxpJbzgRfwQHSYgca
+        SmW4VXqJRK0GPPMYiW7mDdPM74XhwA/CbnA8gNT3hyyM42CQhLgzSMMeeAisNAmQW1uakeuykh/N
+        uc2rmARw6yvcAiyGXGk4FDw+tGCscenvbFYsiYkB6yLIJQ7G3ftu1O8dL98ko3FbJCFBQNpZoiqJ
+        aex1nAVonvGEWY7pgWpuvgHzNGPCQMfRwAxtOZU0fC5xp+PQD2YrjfrLSoiOU7KlUAxB9Pnwfm6+
+        wcXcFmK2rfKL8O4T2M2lb5DV7Nz75tRq67bbxNVgbJ4bgFBzToEzeV3luEftp3983O9tt6NJ/+rn
+        uUhuou75NFqRjQXmuN71pl40flMtlQGdKGkxnerCqdza8qfFSYAW5rqxUXe8fxUd2TLuM8/XY/h8
+        LlNCqDvE7lLdrukt8+4TCFltfnM5b28AQWtX2RxQJ6T/QE5z7BNtLNWANXYS7Cw8JRMGJdaQtjHS
+        QJDMnUQe67qF1baq2CSal1TarWhtAdGQ0nMm+aruEa0MIZBSsu6pbVyqAQiEBWZXK+QGsXZLzRcs
+        WZIMGhLgC9S0vbUdKBqzy5IepkuMOCnMLcxYWlCZ1e1y94H8KMHmWf0owXaV81GCm0cLm9lW9e5V
+        giXT1Dec0a/fWJAzweUtfuCkCCJ7j8kv1kwmOQ5+T/8X0IP1wnLLgYOmyEdbSLjUykJiX8xgzUoz
+        ooFksdia0P5UnB4NfAlsZWZILdk4DDJTOoF65BPY/oijyjIUsX657xuNnu/EG17v0/uPxzsiYUeu
+        vSIfHv4CWpHDZVkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:41 GMT
+      etag:
+      - W/"a0fbf3ea2ab3eff12d77f7e7108d2d46"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0DD9:59D672B:5ED660B1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3335'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:41 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0E40:59D67A0:5ED660B1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3334'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d2a98771e24b46bea4e4360d7879abd39613aea2
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY/TMBD9K5XPbeO4Jl8SEocC6qFbVYRFKULVpJk2Xuyksp2lH+p/Z0w5wG1X
+        gktkz/ObN/NmcmWuBVawRkCepWmMQtYyqREkylnCmzRLc6ibWZ7EM0AQbMy6vsGtaoi0nFfJWuS+
+        /qL58qmSq/nitCqreGXW56r8Lh8uu9OmXPDqaS0q89g+fPzMl5fqx2a+I0y3lVlf6P1pKT7oqly8
+        peSD1ZS49f7oiiiCo5oelG+HerrrTWTx2LvIoAfne4sTreqJR+ddFL7brTk3QBj6iEgRMYwi7BWt
+        td7o7d8l/CH/EuG76Gs0YfBtb1lxZR0YpOY/tdCCHb1/tn1HjqABFTyhOVF4iiH87hCCwRN6QD0H
+        muCCT3gy4aKMZSFEIfmG3cbsXpHH/yjhLVIF19+rFO953uzFLE0zIdNYvsmwESKHtK5ltksJyZp0
+        hvzfTjvU4KIXa5MxBp2DQ7Bu0SmvQKsLjsICjX7tmaIVO1ONR7DYeceKr9/G7Bmt2qsdeEWzoY7v
+        d6SfYQ/a4ZhZBBcgNnROHTpCxiwcwA+WpLpB65DyrHsgUrjebj8BVAZRgIQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:42 GMT
+      etag:
+      - W/"500278743fdbd06742d5a18b96b16fe4"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:40 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0EC4:59D6840:5ED660B1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3333'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["d2a98771e24b46bea4e4360d7879abd39613aea2"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"d3c46a949d44081e3d93b462547b6d988c42da08","node_id":"MDY6Q29tbWl0MjY4ODIxOTY1OmQzYzQ2YTk0OWQ0NDA4MWUzZDkzYjQ2MjU0N2I2ZDk4OGM0MmRhMDg=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d3c46a949d44081e3d93b462547b6d988c42da08","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/d3c46a949d44081e3d93b462547b6d988c42da08","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:42Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:42Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"d2a98771e24b46bea4e4360d7879abd39613aea2","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d2a98771e24b46bea4e4360d7879abd39613aea2","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/d2a98771e24b46bea4e4360d7879abd39613aea2"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:42 GMT
+      etag:
+      - '"6633aba79fa545f5c972ef9c95ec449a"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d3c46a949d44081e3d93b462547b6d988c42da08
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0F12:59D6895:5ED660B2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3332'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vngpsPJSQzKgXJytKmgiU642tjFMeRfaCmiP/eQx27dOjyLu89
+        9z5XEfBd1PeMskcwUTqIhEE8iNEb7KzhVq1V8epap077vFlvP5uXfdKMu+Ewqgts2v7wrC767enL
+        bNqZwXMYGOqJplhLCZNdfljqz3p59E4GnDyPIPGMD7gYrF4QRorynl3nZgPcIUmG+Pq3l9cnPJKo
+        ryL2wEMmhWpVlgmmuc4LjZBjnhWPplyVFWiTVUWSAULKZjRPyAR7OEv/a/rzM8o/29xu30oY/CJ9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:42 GMT
+      etag:
+      - W/"6b3e43302e5060b2147bdb2a699bd225"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:40 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0F91:59D693D:5ED660B2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3331'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "d3c46a949d44081e3d93b462547b6d988c42da08"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngoG4aZIZlbaSlaVNBUtkx0dtFMeRfaCmiP/eQx27MLC85d13
+        7zuzCHtWXTNxC8ok7lVCiOyBDcFA6wy1ci3zD994ediKev36Xb9vl/Xw1u8GeVKbxu5e5El/Pv+Y
+        TTMReIw9QRZxTBXnanTzL4f2qOdd8DzCGGgEkGZChFnv9AwhYeLXbFs/GUUdICeIrv97BX2ADll1
+        ZskqGjJZJ3JVitIIsSiWkJky0yJfPYonnZuyKDqxMmpRkBlOIxBBHt7hfU3/fiZ+s83l8gtODcNQ
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:43 GMT
+      etag:
+      - W/"1edfcd8bcec11d84787b6a8ad9f16827"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB0FE8:59D69AC:5ED660B2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3330'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:43 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1100:59D6B00:5ED660B3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3329'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SOkmaJgaJ7aFdgQFpg2ICuLwIl0RJtSdRIyp4j5Lv3f6Rk
+        yZ6bOA4f85LYNPm74/HueLx2ItLJLLy5vQ0v727enU0qmfKIxib3Hz+tvxZ/FMnnuwf27c9VUi03
+        XxbZ9f3i07svi7/fTzCZlRwzDdcmispNygzT3OCHeVMUUfdryTFqpOLnhYjPaa4O/r+iVmLFDGhz
+        Vmh+NpHriqvJrJ0UMhMVhBzAQBBpenMz/TUMby/3lN98Xd5tvoe/N+xbnaefi1W8+Ce8/5hs7hfZ
+        f1jKII+pqFEF6LkxtZ4FgRvUVxeZMHkTN5qrRFaGV+YikWXQBL2wD6v314BkqsNYk2FgD1eLjuSW
+        A6eDwzvJTVnsKeN0sCsPr5nLopBrMPd3caTYYAugM7MwUWWvgwHQBtLkHKbFdh/JSAJnfirVLm4D
+        +ge/JJzGsSmengrslkNJcrHHNlC8lpbbxDpRojZCVieruwMBVKqMVeKBvQoKiAaLFD1ZMbsYEL6C
+        M59McavbwIZrsiGzKZ5wscJ5vI68hwHYbGrKLl9HFqRTEoZHLC0pKdhc8XiG6H1h7BxIQCnfHv5k
+        ViF/UUSo5TYhPRnY1riHgvSAIKI+Y/+jcQhgwGCVJd94YxKrDfC3i7cEiYHFUjEkcW9CdqBtMP5K
+        TmU4K73JsjBAcyn9Wd7CABVaN/wo3z/+VC1TB32wVU0Zu0x6TIgdL8bRsAemtcgqzr1ZfAtsg/4S
+        iBWrktyfiJ7XBu6T9RqWedsCsYCMCxl7Y+JCDyywDXTO3NVoIp9akwTi7QhQfO51C8TbCjDKo99Y
+        9Qm4xeO2NnAhb/r3vKDtTqBgVdawzJ+ELZAuK5QqGXt4tkI7PmYHIvBUmioRN34T88CkHbiiCPnH
+        3xEMyEGArbqeLuleYKRRJWfNVJbiuZrneHqH2wkxzyIoDvbF0PfnS7eXbYN4bTDcL+4y6yT5Oo3u
+        Nuv1H8vr3lbeXKvnBe0vNTM5ZViIrZnivjbT4YI2xlP38eLios05s8+SkiuPWcTRgGUqyVFe+9K/
+        7XmoHEtm7PNnTuqneA4VkqXezmILBNy5gK89ONrYj2rU694Ut7AxvRQFuhay8ndHDMSxnEoaMRfJ
+        MW/F48N8B9p+0KJK+BnD8wZRYUQiECd4spMHoMjn/qzoaNgeekTumVhwhIy3U1Lc8drAdQVSXhdy
+        4zVDjpCUSBRHgyqNmMGjNJyG0/Ppzfk0/OvyehaGs6vb75jT1OiB/XTO9RXNqRudPzMF6b+LFXxC
+        V+rpRtD+G5M6TpCjdT5AfhsQswO9pJ8gkgJOvxe1p+my2r/bX4bBdnJZ8hp1Wv841+IBn6c7NVYi
+        mwqng8E1M3hsoGYZhvq6rAfkTEcuk0xmRjXoOdJIreSCJ0aPx4ZMNpq4Fkuxs5BqyG23wD3yB+Gl
+        UEp2zUbXXOjyMNqGXcczFZrFBR8GZM2rTsPxNkTCK701g2sA0JZH03dMYL+kfM6awkTurUTtVPRk
+        0WCFO3JVwgzU86J2a9dZcQYhV+33SFnRfUbDxfCyjpx3GLnk1J8FCllFriP9b8PgevYC6xe7X+wQ
+        tkLV2O4vitN1ursmRYCj1eM0jlAcdsS+QTxuC731iZv4rU/81id+6xO7Tjtdfwf6xBU3azRMR9l0
+        /Lzts/XjD/CrP04VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:44 GMT
+      etag:
+      - W/"20e6b6803039a5f8e10795e1c54244fb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:43 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB115E:59D6B68:5ED660B3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3328'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:44 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB11B0:59D6BC4:5ED660B4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3327'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SOkmaJgaJ7aFdgQFpg2ICuLwIl0RJtSdRIyp4j5Lv3f6Rk
+        yZ6bOA4f85LYNPm74/HueLx2ItLJLLy5vQ0v727enU0qmfKIxib3Hz+tvxZ/FMnnuwf27c9VUi03
+        XxbZ9f3i07svi7/fTzCZlRwzDdcmispNygzT3OCHeVMUUfdryTFqpOLnhYjPaa4O/r+iVmLFDGhz
+        Vmh+NpHriqvJrJ0UMhMVhBzAQBBpenMz/TUMby/3lN98Xd5tvoe/N+xbnaefi1W8+Ce8/5hs7hfZ
+        f1jKII+pqFEF6LkxtZ4FgRvUVxeZMHkTN5qrRFaGV+YikWXQBL2wD6v314BkqsNYk2FgD1eLjuSW
+        A6eDwzvJTVnsKeN0sCsPr5nLopBrMPd3caTYYAugM7MwUWWvgwHQBtLkHKbFdh/JSAJnfirVLm4D
+        +ge/JJzGsSmengrslkNJcrHHNlC8lpbbxDpRojZCVieruwMBVKqMVeKBvQoKiAaLFD1ZMbsYEL6C
+        M59McavbwIZrsiGzKZ5wscJ5vI68hwHYbGrKLl9HFqRTEoZHLC0pKdhc8XiG6H1h7BxIQCnfHv5k
+        ViF/UUSo5TYhPRnY1riHgvSAIKI+Y/+jcQhgwGCVJd94YxKrDfC3i7cEiYHFUjEkcW9CdqBtMP5K
+        TmU4K73JsjBAcyn9Wd7CABVaN/wo3z/+VC1TB32wVU0Zu0x6TIgdL8bRsAemtcgqzr1ZfAtsg/4S
+        iBWrktyfiJ7XBu6T9RqWedsCsYCMCxl7Y+JCDyywDXTO3NVoIp9akwTi7QhQfO51C8TbCjDKo99Y
+        9Qm4xeO2NnAhb/r3vKDtTqBgVdawzJ+ELZAuK5QqGXt4tkI7PmYHIvBUmioRN34T88CkHbiiCPnH
+        3xEMyEGArbqeLuleYKRRJWfNVJbiuZrneHqH2wkxzyIoDvbF0PfnS7eXbYN4bTDcL+4y6yT5Oo3u
+        Nuv1H8vr3lbeXKvnBe0vNTM5ZViIrZnivjbT4YI2xlP38eLios05s8+SkiuPWcTRgGUqyVFe+9K/
+        7XmoHEtm7PNnTuqneA4VkqXezmILBNy5gK89ONrYj2rU694Ut7AxvRQFuhay8ndHDMSxnEoaMRfJ
+        MW/F48N8B9p+0KJK+BnD8wZRYUQiECd4spMHoMjn/qzoaNgeekTumVhwhIy3U1Lc8drAdQVSXhdy
+        4zVDjpCUSBRHgyqNmMGjNJyG0/Ppzfk0/OvyehaGs6vb75jT1OiB/XTO9RXNqRudPzMF6b+LFXxC
+        V+rpRtD+G5M6TpCjdT5AfhsQswO9pJ8gkgJOvxe1p+my2r/bX4bBdnJZ8hp1Wv841+IBn6c7NVYi
+        mwqng8E1M3hsoGYZhvq6rAfkTEcuk0xmRjXoOdJIreSCJ0aPx4ZMNpq4Fkuxs5BqyG23wD3yB+Gl
+        UEp2zUbXXOjyMNqGXcczFZrFBR8GZM2rTsPxNkTCK701g2sA0JZH03dMYL+kfM6awkTurUTtVPRk
+        0WCFO3JVwgzU86J2a9dZcQYhV+33SFnRfUbDxfCyjpx3GLnk1J8FCllFriP9b8PgevYC6xe7X+wQ
+        tkLV2O4vitN1ursmRYCj1eM0jlAcdsS+QTxuC731iZv4rU/81id+6xO7Tjtdfwf6xBU3azRMR9l0
+        /Lzts/XjD/CrP04VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:44 GMT
+      etag:
+      - W/"20e6b6803039a5f8e10795e1c54244fb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:43 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1200:59D6C1D:5ED660B4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3326'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d3c46a949d44081e3d93b462547b6d988c42da08
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJFZkxTcotJBS8uANaXcJ3lLC2B7HSnwJkrx0E/LvOyJtad+y
+        kL4Yz4yPzsyZY52ZqYElrPQLGUAs41JKHs3QL2M/l4GYyzAPyjiKCilK4BEbs64vcatKAqWLLFiL
+        2Oabhqf7TK4Wy5+rx2y2aten7LQW2eOBrzZr/rD4JNPN0+l5cThl+7VI90/8QSwFxXL1JeVp+7VO
+        F7sPdPigGzq4tvZoEs+Do5rulK2HfFr0rafx2BuvRQvG9honjconFo01nntut+1rCVRD6xHII0Sr
+        qPaO0WrbNtt/W/iL/hbiK+l7OGGwda9ZcmYdtEjDf6uhBj36/KL7jhTBFpTThPZE6Sm69MedSzpN
+        6AOa2cEEF3zCgwkXjzOZCJFI8cwuY3btyOJ/pLAaqYPzLyuFIUaBLyvp59wvqiogT4VyXvAcQ8TK
+        FzkWkAfz+27b9WC8m7lJmBaNgZ2Tbtkpq6AZOfccoThQdnSVjXo8gsbOGpZ8/z1gKSCOwnCGQtIv
+        kiNIlH7AyzAKY8hLPw5mPiCI+w74x863s9/PzrdyXn6M2QtqVakCrCL/kiuuMdKFUUFjcMw0gnEl
+        NnRG7TqqjJl7ATtoWkc3NI2T/bXpgUAuvFzeAI6C4OaoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:45 GMT
+      etag:
+      - W/"6633aba79fa545f5c972ef9c95ec449a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1256:59D6C92:5ED660B4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3325'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=d3c46a949d44081e3d93b462547b6d988c42da08
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28iJbdkKjNKYrTiwjnUPc0IhSNbFVipLxlIastLvvnMbWJfu
+        IevG2IPEoZPu/+N/p4fA8BaCaSC55x2v7ngNo42zJjgLOu6bX2dcwzGRQZpVknGZMmCTSSTCjCbj
+        lCZSAoU0CVnIMkFDLOXUNxRh9CzY9hqfNt53bkoI79SoVr7ZilFlW9JDZx1pwXPnbQ/nWolzD847
+        MuyrVbsfMB14UlnjwWDimPuih/U7GVUx5SxmMo7DbAyRZJGI6SSJU0Ely7IqnkgeZkjW+FavfoZ6
+        AXQKitBWkFMVX/EiAuodEbzZFixFBh5HfqM50u6MtlweQfR8d+jN1kF/MPypTae48ieG+H03jORa
+        aUB7Dsp4ADtbF/l8u/g61sUG43acLK8+hIvyWsu8cMXlU36/LK/vZTnfLMuP6pOaiVxd1remyGfp
+        EBX5sOa7RXljn6vcNPLq/b0o9Y+XX5JNFS3U8/0ZuzVDVH7uMEIkMJWVytTIJHAcaYxnK63MnQum
+        D4EDvf6vZhyn4m/wvGm4hv/1Qvzf/q3Hx+8w9MCp4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:45 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB12A0:59D6CDF:5ED660B5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3324'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "First version", "tag": "version-1.0", "type":
+      "commit", "object": "d3c46a949d44081e3d93b462547b6d988c42da08"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIxOTY1OjBhODU1NTQzNGM4OWI3MGI2YmJmM2IxODQ4ZTZhNmE2YjZjNTA2ZDE=","sha":"0a8555434c89b70b6bbf3b1848e6a6a6b6c506d1","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/0a8555434c89b70b6bbf3b1848e6a6a6b6c506d1","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:45Z"},"object":{"sha":"d3c46a949d44081e3d93b462547b6d988c42da08","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/d3c46a949d44081e3d93b462547b6d988c42da08"},"tag":"version-1.0","message":"First
+        version","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '692'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:45 GMT
+      etag:
+      - '"f06df8939b31e71835d83188aa26da1e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/0a8555434c89b70b6bbf3b1848e6a6a6b6c506d1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB12E7:59D6D3A:5ED660B5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3323'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "0a8555434c89b70b6bbf3b1848e6a6a6b6c506d1", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIxOTY1OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"0a8555434c89b70b6bbf3b1848e6a6a6b6c506d1","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/0a8555434c89b70b6bbf3b1848e6a6a6b6c506d1"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:46 GMT
+      etag:
+      - '"80e4f46b10450a1989dbdac9a037538e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1381:59D6DFF:5ED660B5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3322'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:47 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB149F:59D6F4F:5ED660B6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3321'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__otherdataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268821992,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjE5OTI=","name":"test__otherdataset","full_name":"metastore-lib-tests/test__otherdataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__otherdataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/deployments","created_at":"2020-06-02T14:22:47Z","updated_at":"2020-06-02T14:22:47Z","pushed_at":"2020-06-02T14:22:48Z","git_url":"git://github.com/metastore-lib-tests/test__otherdataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__otherdataset.git","clone_url":"https://github.com/metastore-lib-tests/test__otherdataset.git","svn_url":"https://github.com/metastore-lib-tests/test__otherdataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '7043'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:48 GMT
+      etag:
+      - '"9c482a27f5a4cc2980fa83aae2197375"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB14F8:59D6FB5:5ED660B7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3320'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__otherdataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__otherdataset/blob/master/README.md"}},"commit":{"sha":"d099cd0372443b09c0cd48a8b121979a0834d410","node_id":"MDY6Q29tbWl0MjY4ODIxOTkyOmQwOTljZDAzNzI0NDNiMDljMGNkNDhhOGIxMjE5NzlhMDgzNGQ0MTA=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/d099cd0372443b09c0cd48a8b121979a0834d410","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/d099cd0372443b09c0cd48a8b121979a0834d410","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:48Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:48Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1815'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:49 GMT
+      etag:
+      - '"9d7ca90a60e08c56ee306e9764315008"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1691:59D7190:5ED660B8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3319'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW0/bMBT+KyjPhaRp6E1CG1IR4qGp0LoLTFPkJE7i4tiZ7RTaiv++c9xwaR8Y
+        YeyNlyqx833+ztWnG0eQkjpjpyTaUOV0nESWJTPOeOPogsBG6o1GSer1Bn4Q9GJvlHhJGgzJMO76
+        3dFgRLxhL0iDrgdQIVMasRRA08lV/9Ifmfg796aLq2A2ubibzW9Ws/Lydjbni+vJ6TpcX3jhJGTT
+        CV9Mz8ObcFIUs/OLu+ni7Dhc82I6ydfh+aU3nZ+e7OgitSmkQoWN9i8FKYg6OFsqKeBLWhLGQQTo
+        h+Ujisufc1w8AuPgg5QYNNn3fO/Q6x96/rwbjH1/HAyvnfsHD6A3/tsRJdWa5CjiQjDDCGdregCy
+        yIGildTMSLUCoUZR+OYhEt3MG6WZ3xsMhn4w6AbHQ5r6/ogM4jgYJgPYGaaDHsVI1AodUBhT6bHr
+        kood5cwUdYwOcO0RbkkNhFwqeshZfGioNtrF3yiSpqAKxWhqXMC5KEO7rz4eXPi+529TUrstUhEh
+        VJgokbWAZPY6zpIqlrGEGAZJAj7dvlPI1oxwTTuOokTjllMLzXIBOx0HH4ipFURB1Jx3nIqsuCQA
+        wtf7d7X0DVYWpuTRrq+fxfmVEd6e+wbn6r2j/yXN2hrvNgHWEKSnfsBlzjCCurBFD3vYjfrHx/3e
+        bne67H/7EfJkcdUN51dr5FhCvqt9g+yi9pviqTVViRQG8srWUe1a5k/LkwAYctVw2Ab4txpELu0+
+        6Xw5kk/fZZJzeQvYfam7Jb5D7z6CQNX2mYm8PQGANq5tDhHy36PRDNpGGyYL2EBXgUbDUqTQ4GJF
+        0zYkDQTE3ArQsbEdzXLVsU4Uq7DGW8naAQKRVDkRbG2bRSsiAGJK2hbbxiQLACBdQna1Qm4RG7dS
+        bEmSFbpB0YSyJfi0PdseFMjMqsJ76itEHD3MDI1IWmKZ2b65f19+lGBzy36UYLvK+SjB7aUFzWyn
+        el9VghVR2Dec8c9fUJARZ+IGXmBwpDx7p0EwVkQkBcyBj/8U8M56Rt5+8sC58oEOZFdKGpqYZyNZ
+        s9JMbFSQmO8MbL9rhlcH3Aem1hGoS7ZmU5FJlVA7AXJogihTZhm40t7fd42nns6EE17u1q1m5j1X
+        QWu2hqEZ938AF5nXmHENAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:49 GMT
+      etag:
+      - W/"7f1e7088e86c8d3c5b37503d7e4e9f09"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB17CB:59D72F8:5ED660B9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3318'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"otherdataset\",
+      \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"05b0607cc662220661603d446d71eef5c4719212","size":99,"url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/blobs/05b0607cc662220661603d446d71eef5c4719212"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '686'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:50 GMT
+      etag:
+      - '"af7fbe6e808b96cd8a71d201501f97eb"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1819:59D7367:5ED660B9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3317'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/d099cd0372443b09c0cd48a8b121979a0834d410
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTYvbMBD9K0HnJJZl7foDCl3wEnKwQ2ig7JYSZHtiKSvbQZK3G4f8946aHtrb
+        LrQXYc3zzHvzZnQhVgqSkYamad3QKGacRxVNa1o3PBFJFbIwjVNBk4g3PKRkTvqhgb1qMKnIn+63
+        LHXVV02L4xPf5Ou3ze7lvOm2PzY7fXzOH6ZyWtMyL1WR62OxKl/KXMrNav1WHB/vyknLIm+ncrWl
+        xe7hExYfjcbC0rmTzYJAnNSyVU6O1bIeusDAabBBB05YNxhYaFUtHFhnA3/u94OTYBqBMLgA8wJM
+        6hTCH+hOuk7v/1bxh4J3ct94P0IrRicHQ7IL6UUHaMEXKaQws8dXM/ToC3RCeWdwWhhegg9/bn3Q
+        O4M/YNs+jVFGF/R+Qdku5BljGU+eyXVObooc/EcKZwAVXH4vVHigaXNgURwnjMchv0ugYSwVcVXx
+        pI4RSZo4Ar9Q/3bmXoYN3k2P3nRgrWi9e+teOSW0mmDm12j2a+EU7toZZZ6Egd5Zkn37PievYNRB
+        1cIpHA82fbsDvoqD0BbmxICwHiJjb1XbIzIn/kO40SBVP2rtS571IDDJX6/Xn3h/f9eNAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:50 GMT
+      etag:
+      - W/"596c80c49edc7383808d5551b918fc77"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1889:59D73FB:5ED660BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3316'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["d099cd0372443b09c0cd48a8b121979a0834d410"],
+      "message": "Initial datapackage commit", "tree": "fa0f09c21c1c7f2607347dd929f58fc34575b5fc"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"3856e1fef6487635cec5ee787b8821b542a09f8c","node_id":"MDY6Q29tbWl0MjY4ODIxOTkyOjM4NTZlMWZlZjY0ODc2MzVjZWM1ZWU3ODdiODgyMWI1NDJhMDlmOGM=","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/3856e1fef6487635cec5ee787b8821b542a09f8c","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/3856e1fef6487635cec5ee787b8821b542a09f8c","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:50Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:22:50Z"},"tree":{"sha":"fa0f09c21c1c7f2607347dd929f58fc34575b5fc","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/trees/fa0f09c21c1c7f2607347dd929f58fc34575b5fc"},"message":"Initial
+        datapackage commit","parents":[{"sha":"d099cd0372443b09c0cd48a8b121979a0834d410","url":"https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/d099cd0372443b09c0cd48a8b121979a0834d410","html_url":"https://github.com/metastore-lib-tests/test__otherdataset/commit/d099cd0372443b09c0cd48a8b121979a0834d410"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1207'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:50 GMT
+      etag:
+      - '"3f7a955f6584db522c62f3f5c400c49c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/commits/3856e1fef6487635cec5ee787b8821b542a09f8c
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB18CC:59D7449:5ED660BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3315'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsU7DMBRF/8UzrZ3GoknmilIkKwsE0SWy4wd2m8SR/VoRqv47r2JkYWC5y9W5
+        91xYhHdW3TJxB9omPuiEENkdG4OF1ltq1UbdvwzNoA5vst7sPuvn41yPT/1+VGe9bdz+UZ3N68OX
+        3TYzgafYE+QQp1Rxrie//PDoTmbZhYFHmAKdANJNiLDovVkgJEz8lm0b0EG0mmpAThwBv9WCOUCH
+        rLqw5DR9WVGWnRX5eiVlbkTZic7KQhcmW2XlutSiyKWVmSA5nCcgglQGj/8u+zOb+J+FrtdvsBZ6
+        T4MBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:51 GMT
+      etag:
+      - W/"4eb2dd49de8021e3713e78db5b6fae2f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1957:59D74EE:5ED660BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3314'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "3856e1fef6487635cec5ee787b8821b542a09f8c"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OO0/DMBSF/4tnWtM2D5O5ooAUZYEgukR+3GCXOI7s24pQ9b9zK0YWBpazHH3n
+        fGcWoWfVNRO3IE3iXiaEyG7YGAx0zlBbb+vixbe+Prxlzfbxs3n+mJvxadiP9UnuWrt/qE/q9f7L
+        7NqZwGMcCLKIU6o4l5Nbvju0R7XUwfMIU6ATQLoJERaDUwuEhIlfs+sCWohGUg3IiSPgt1pQB9DI
+        qjNLVtLXRuQFrHroi0yUxSbXoHOAUpRKiPVK5dla3t71QpMczhMQQSre4b/L/swm/mehy+UbRaBm
+        BoMBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:51 GMT
+      etag:
+      - W/"62c35416b30366bc2655c90dbeb1cb67"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB19AF:59D753F:5ED660BB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3313'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:52 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1A8E:59D765C:5ED660BB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3312'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOlqaNgaJ7aFdsQBZg6EPXF4GSaIuxJGokZc8R8t33P1Ky
+        ZMNNYoePeUlsmvwdj+Qdj/92IrPJLLr+8CG6vLmJziaVykRMbZPbz1/Wd8WfRfr15oF//3uVVsvN
+        X/eLq9v7L+/uvv3xcYLOvBToaYWxcaxsLnTGLTfC4rd5UxRx16EUaLVKi/NCJufU3bCDg2otV9yC
+        OeeFEWcTta6EnszaSaEWsoKpAyTYovleX0/fR9GHyz0XNnfLm82P6PeGf6/z7GuxSu7/iW4/p5vb
+        +8V/GMphj+u40QXoubW1mTHmG82vFwtp8yZpjNCpqqyo7EWqStaw3tin1ccrQBa6w7iFQ8MerpYd
+        yQ8HzrDDnuS2LPYm4+fgRh4eM1dFodZg7nvxQrNsC6BtczBZLV4HA6Bl7kTEtHqPtEgS234q1Q1u
+        Gf3D6SScwbZpkZ0K7IZjknTEHlumRa0ct0lMqmVtpapOnu4OBFClF7ySD/xVUEAMWDTRkyfmBgMi
+        VjjMJ1P86Ja5cE03tGxapEKusB+vI+9hALabmnLM3WgFaZekFTHPSkoKLlc8niF6j4ydwzkoE9v9
+        n8wqZDEKCr3c5qQnY9ut76E4PWyLwM/swjFERDJ4WJ6l2ITEEq5l+NvFXookwROlOXJ6SDs73JaN
+        v9IZs4KXIc05Hri5UkF3wfHAlcY04kUBcdQmO6xhfRBWTZn4DPuS0DvKkgfCE26MXFRChFz9LbNl
+        /RWRaF6leVArPbJl/pM7R3wR0hHCgZoUKgmJxb3PHLNlJuf+BrVx4LmTEULu2NBiHtoRQm5tWB32
+        JDkniLm1gNvd4lCF9KJHsrbbjYJXi4YvghrZMumKQ4Gz4A/P1nVHRfQAhQWqabVMmuBZfMCSH76g
+        Qo4Kuh0DdbDhiranK8LjVmtUC7r1Kkv5XNV0lIGOuBN94a1QfOxbou/Pl4BHO0PIlg1Xkr8CO2MB
+        d6a7A3svxia7l1rIw9YjWftLzW1OuRiWa65FQJc6ImsTvKAfLy4u2lxw99QphQ6bZjwQZK7THFV7
+        QC/aHolStOTWPazm5ESGh1aheBZyX7ZM8P2JCOiJB45PVo3HQMjpO97YQCkLaCOqCnqnDNCxqUpZ
+        OZfpS16kRyWBHW77ycgqFWccjyhEi5WpRPxAG6ADgReECLqcHggnoUr5J2khEEohd0wLj2yZFyEy
+        URdqEzqRjqiUabSAJJbF3OIZHE2j6fn0+nwafbu8mkXR7Or9D/RpaghvP+3z7pL61I3Jn+mCi6IL
+        IHyCDva09HTgSUsyF0wZkw+c3wbK7ICA9XNKWiAS9gL65Bmt9uuCo0nwK1elqFHy9bqAkQ/4PN2p
+        1VLVVNgpNK65xWMGVc/Q1Nd3PSDnJvZ5ZjKzuoHiSS21VvcitWbcNqS6Uce1XMqdgVSOboUKLy4M
+        xkupteqkTq9rdLkaomWnt2bS8KQQQ4OqRdXNcOyGTEVltsvgVQdyedR9Zwncl0zMeVPY2D/ESMyF
+        KAx5F0dT6BLLQIobib2druMXhI5t7yMlTP8Zco8VZR37M2LVUpA6DBRSjVrH5t+G4wy6e64f7H9x
+        TXCFKrndX7Sgi3d3TIZ4h9DkZxyjtuyIvTw9FqXeVOomeVOp31TqN5Xa6/x0Dx5QqSth11BpR9l0
+        /EDus/Xj/0PPUYGZGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:52 GMT
+      etag:
+      - W/"ea4b53ca412bcd471b4b0cf32e7ac857"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:51 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1B0B:59D76EB:5ED660BC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3311'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!python/unicode '[]'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '2'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:52 GMT
+      etag:
+      - '"a2a34b88b361a2f4c74e633018fff9f5"'
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:51 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1B6F:59D776D:5ED660BC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3310'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F51t6+HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPuarhf+/qkUR5AAVc
+        nUSKM7s7M9QpEKriMkiDBh1YpwwuBc+WDq2zwSLgRZBuNtFNktzGi0CqAlm/Fezuv3QPh233mHz1
+        8EPXxTfRZvufye4+73b76jdBvRF0sHZO2zQMQfNVxV3ts1WumlCZyoYflzSolWUXocMBS7WxReku
+        JRnBxFIrdbiUZMD2Alrr8VKSEUwsDTYZmktpJvSJBO9pzkSofSZ4zv6P9zXJnB5acGDemjhs2vWU
+        A2/R5Eo6cmqIhA+fgvapvbuiHgu0ueHacUX5lF6IXk3WouElRwphCcIiuQSWUZxA8j/Qn2XaqD3m
+        FN/UGT8dGILBKd7du8/TFGN00vWzNhXvr0AaLYJSCaGOpP9sxWU1rGrXiDdzzmL+ccJzg+CwYODo
+        giRREi2j62Vy+z1ep3GcRvFjf3t08c8zrtNIDA+z4QnplANBU3KSG9k0FnWqjpJqvt9/2nmZt+D2
+        wLyFitgJmNP4kCkDJN8oQcaFIAEYNsD7S25rqMGssDVKfqa+leYge1MHF0vwwo2NTA6gaSjag68B
+        aVHMEp6DZKM+LwiOz166o2Il5NQJff7lucGG8sNQQiZmmdACiPsUSGh6hUqDSDWshpyW25vN9Sa5
+        2m7J6tcqxRE95DeNR1JZcokK039veovO578+grlfMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:53 GMT
+      etag:
+      - W/"eef4b96c649fd2f8a9710166798d8c35"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1BC7:59D77D5:5ED660BC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3309'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOlqaNgaJ7aFdsQBZg6EPXF4GSaIuxJGokZc8R8t33P1Ky
+        ZMNNYoePeUlsmvwdj+Qdj/92IrPJLLr+8CG6vLmJziaVykRMbZPbz1/Wd8WfRfr15oF//3uVVsvN
+        X/eLq9v7L+/uvv3xcYLOvBToaYWxcaxsLnTGLTfC4rd5UxRx16EUaLVKi/NCJufU3bCDg2otV9yC
+        OeeFEWcTta6EnszaSaEWsoKpAyTYovleX0/fR9GHyz0XNnfLm82P6PeGf6/z7GuxSu7/iW4/p5vb
+        +8V/GMphj+u40QXoubW1mTHmG82vFwtp8yZpjNCpqqyo7EWqStaw3tin1ccrQBa6w7iFQ8MerpYd
+        yQ8HzrDDnuS2LPYm4+fgRh4eM1dFodZg7nvxQrNsC6BtczBZLV4HA6Bl7kTEtHqPtEgS234q1Q1u
+        Gf3D6SScwbZpkZ0K7IZjknTEHlumRa0ct0lMqmVtpapOnu4OBFClF7ySD/xVUEAMWDTRkyfmBgMi
+        VjjMJ1P86Ja5cE03tGxapEKusB+vI+9hALabmnLM3WgFaZekFTHPSkoKLlc8niF6j4ydwzkoE9v9
+        n8wqZDEKCr3c5qQnY9ut76E4PWyLwM/swjFERDJ4WJ6l2ITEEq5l+NvFXookwROlOXJ6SDs73JaN
+        v9IZs4KXIc05Hri5UkF3wfHAlcY04kUBcdQmO6xhfRBWTZn4DPuS0DvKkgfCE26MXFRChFz9LbNl
+        /RWRaF6leVArPbJl/pM7R3wR0hHCgZoUKgmJxb3PHLNlJuf+BrVx4LmTEULu2NBiHtoRQm5tWB32
+        JDkniLm1gNvd4lCF9KJHsrbbjYJXi4YvghrZMumKQ4Gz4A/P1nVHRfQAhQWqabVMmuBZfMCSH76g
+        Qo4Kuh0DdbDhiranK8LjVmtUC7r1Kkv5XNV0lIGOuBN94a1QfOxbou/Pl4BHO0PIlg1Xkr8CO2MB
+        d6a7A3svxia7l1rIw9YjWftLzW1OuRiWa65FQJc6ImsTvKAfLy4u2lxw99QphQ6bZjwQZK7THFV7
+        QC/aHolStOTWPazm5ESGh1aheBZyX7ZM8P2JCOiJB45PVo3HQMjpO97YQCkLaCOqCnqnDNCxqUpZ
+        OZfpS16kRyWBHW77ycgqFWccjyhEi5WpRPxAG6ADgReECLqcHggnoUr5J2khEEohd0wLj2yZFyEy
+        URdqEzqRjqiUabSAJJbF3OIZHE2j6fn0+nwafbu8mkXR7Or9D/RpaghvP+3z7pL61I3Jn+mCi6IL
+        IHyCDva09HTgSUsyF0wZkw+c3wbK7ICA9XNKWiAS9gL65Bmt9uuCo0nwK1elqFHy9bqAkQ/4PN2p
+        1VLVVNgpNK65xWMGVc/Q1Nd3PSDnJvZ5ZjKzuoHiSS21VvcitWbcNqS6Uce1XMqdgVSOboUKLy4M
+        xkupteqkTq9rdLkaomWnt2bS8KQQQ4OqRdXNcOyGTEVltsvgVQdyedR9Zwncl0zMeVPY2D/ESMyF
+        KAx5F0dT6BLLQIobib2druMXhI5t7yMlTP8Zco8VZR37M2LVUpA6DBRSjVrH5t+G4wy6e64f7H9x
+        TXCFKrndX7Sgi3d3TIZ4h9DkZxyjtuyIvTw9FqXeVOomeVOp31TqN5Xa6/x0Dx5QqSth11BpR9l0
+        /EDus/Xj/0PPUYGZGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:53 GMT
+      etag:
+      - W/"ea4b53ca412bcd471b4b0cf32e7ac857"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:51 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1C17:59D7835:5ED660BD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3308'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__otherdataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:22:54 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1C7B:59D78A5:5ED660BD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3307'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:54 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1D5F:59D79C8:5ED660BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3306'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SOm3iJgaJ7aFdgQBpg2ICuLwIl0RJtSdRIyp4j5Lv3f6Rk
+        yZ6TOA4f85LYNPm74/HueLxmJJLRbDK9uZlc3k6vz0alTHhIY6O7z1/W9/kfefz19oF9/3MVl8vN
+        t0V6dbf4cv1t8ffHESazgmOm4dqEYbFJmGGaG/wwr/M8bH8tOEaNVPw8F9E5zdXB/1dUSqyYAW3O
+        cs3PRnJdcjWaNaNcpqKEkAMYCCJNp9Pxr5PJzeWe8pv75e3mx+T3mn2vsuRrvooW/0zuPsebu0X6
+        H5YyyGMqrFUOemZMpWdB4Ab1h4tUmKyOas1VLEvDS3MRyyKog07Yp9XHK0BS1WKsyTCwh6tES3LL
+        gdPB4Z1kpsj3lHE62JWH18xlnss1mPu7OFJssAXQmVmYKNO3wQBoAmkyDtNiu49kJIEzP5VqFzcB
+        /YNfEk7j2BRPTgW2y6EkudhjEyheScutIx0rURkhy5PV3YEAKlXKSvHA3gQFRINFip6smF0MCF/B
+        mU+muNVNYMM13pDZFI+5WOE83kbewwBsNhVll/uBBemUhOEhSwpKCjZXPJ4hel8ZOwcSUMK3hz+a
+        lchfFBFquU1Izwa2Ne6hID0giKgv2P9oHAIYMFhlyTfemMRqAvxt4y1GYmCRVAxJ3JuQHWgTDL+S
+        UxnOCm+yLAzQTEp/lrcwQIXWNT/K948/VcvUQRdsZV1ELpMeE2LHi3E07IFpLdKSc28W3wKboLsE
+        IsXKOPMnouM1gftkvYal3rZALCCjXEbemLjQAwtsAp0xdzWa0KfWJIF4OwIUn3vdAvG2Aozy6DdW
+        fQJu8bitDVzIm/4dL2jaE8hZmdYs9SdhC6TLCqVKyh5erNCOj9meCDyVpkpEtd/E3DNpB64oQv7x
+        dwQ9shdgq67nS7pXGGlQyVkzFYV4qeY5nt7idkLMswiKg30x9P3l0u112yBeE/T3i7vMWkm+TqO9
+        zTr9h/Lat5U31+p4QfNLxUxGGRZiK6a4r820uKCJ8NR9vLi4aDLO7LOk4MpjFnE0YJmKM5TXvvRv
+        Oh4qx4IZ+/yZk/oJnkO5ZIm3s9gCAXcu4GsPjjb0owr1ujfFLWxIL0SOroUs/d0RPXEop5RGzEV8
+        zFvx+DDfgTaftChjfsbwvEFUGBELxAme7OQBKPK5Pys6GraHHpF7JuYcIePtlBR3vCZwXYGEV7nc
+        eM2QAyQlEsXRoEpCZvAonYwn4/Px9Hw8+evyajaZzD7c/MCcukIP7Mk5V9c0p6p19vSUKU1B+m9j
+        BZ/QlXq+EbT/xqSOEyBaZz3ktx4xO9BLegIR53D6vag9TZfV/t3+Ogy2k8mCV6jTuse5Fg/4PN6p
+        sWJZlzgdDK6ZwWMDNUs/1NVlHSBjOnSZZDQzqkbPkUYqJRc8Nno41meywcS1WIqdhVRDbrsF7pHf
+        Cy+EUrJtNrrmQpuH0TZsO56J0CzKeT8gK162Gg63IWJe6q0ZXAOAtjyYvmMC+yXhc1bnJnRvJWqn
+        oieLBivckasCZqCeF7Vb286KMwi5ardHyoruMxouhhdV6LzDyCWn/ixQyCpyHep/awbXsxdYt9j9
+        YoewFarGdn9RnK7T3TUJAhytHqdxiOKwJXYN4mFb6L1PXEfvfeL3PvF7n9h12un6O9AnLrlZo2E6
+        yKbD522XrR9/ApinLTAVGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:54 GMT
+      etag:
+      - W/"9a55babbc5617ddd1b8b8770420a5e72"
+      last-modified:
+      - Tue, 02 Jun 2020 14:22:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1DC3:59D7A21:5ED660BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3305'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:22:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C958:204C8:4BB1E26:59D7AA8:5ED660BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3304'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update.yaml
@@ -1,0 +1,5189 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:57 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581B889:687C2E4:5ED660C0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3300'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:57 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581B8CD:687C321:5ED660C1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3299'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822024,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjIwMjQ=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:22:57Z","updated_at":"2020-06-02T14:22:57Z","pushed_at":"2020-06-02T14:22:59Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:22:59 GMT
+      etag:
+      - '"2beffb4e00333b678acb684978d61ac4"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581B907:687C37D:5ED660C1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3298'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"afeae2fa88b84038991aaaaba0a5375be6f4fdbf","node_id":"MDY6Q29tbWl0MjY4ODIyMDI0OmFmZWFlMmZhODhiODQwMzg5OTFhYWFhYmEwYTUzNzViZTZmNGZkYmY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/afeae2fa88b84038991aaaaba0a5375be6f4fdbf","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/afeae2fa88b84038991aaaaba0a5375be6f4fdbf","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:00Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:00Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:00 GMT
+      etag:
+      - '"d1aa76d28c6921dd0be86132d50e9ad3"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581BBE8:687C704:5ED660C3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3297'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW0/bMBT+KyjPhaTpvRLaHgoTD6VCK7B2mionOUkMjp3ZTllb9b/vnDRc2gdG
+        EHsDqaix833+ztWnG0eyDJyhkzFjQTsNJ1RZxq0z3DgmZbjBYmDgx6zfD/ptr9UfDJoM/wLmsU6r
+        1wmgG7fjKIgRKlUECx4haDyada/8gQ1uhTe+m7Uno4vVeHThTbLzbH57LsbZPJ2MUj4ZXT2M10ln
+        Mj1PZ7f4yc4eZtPr9eX6hs+n8+zy2/x+ls1O93SxwqZKk8JK+/eUpUwfnS21kvgmZIwLFIH6cfkE
+        aPlrQosnaBy+EDFLJvue7x173WPPnzbbQ7819Ly5s330AHnjvx2RgTEsIREXklvOBF/DEcpiRxpy
+        ZbhVeoVCrQZ85zESzdgbRLHf6vX6frvXbHf6EPn+gPWCoN0Pe7jTj3ot8BBYaHJAam1uhq7Lcn6S
+        cJsWATnALY9wM7AYcqXhWPDg2IKxxqX/i0W2IiUGrIsglzQY981no/8+8PBdMhq3RhISBKRdhKqQ
+        mMZew1mC5jEPmeWYHujN3TNgnsZMGGg4GpihLaeQhicSdxoOfWG20Oh/WQjRcHK2EoohiB63H2fm
+        O0xMbSYW+15+Ed63BHZ36Dvcag7OfXdq1TXbreJqMDbPDUCohFPgTFpWOe5R++l2Ot3Wfju66t78
+        uBTh3ax5OZ2tiWOJOa4PrSkXjV9VS2FAh0paTKeycAq3ZP6yPG0jQ6IrjrLj/avoiMu4zzpfj+Hz
+        e7ESQj0g9lDqfk3v0btPIFS1+85lUp8AQRtX2RTQTyh/S0Zz7BN1mErABjsJdhYeEYVBF2uI6pBU
+        EBTzIFHHpmxhJVcRmFDznEq7lqw9IBIpnTDJ12WPqEWEQErJsqfWMakEIBCWmF21kDvExs01X7Jw
+        RW7QEAJfok/rsx1AkcyucrqYrjHi5GFuYcGijMqsbJeHF+RnCVbX6mcJ1quczxLcXVrYzPaq900l
+        mDNNfcMZ/vyFBbkQXN7jA06KIOKPmPwCzWSY4uD39LuALqwXzDUHDpoiH7lQcK6VhdC+mMGqlWpE
+        A8kCsTeh/S44XRp4E9jCLFBauDMYZKx0COXIJ7D9kUYV06+R8ub+U/no+Uw84fU+/fbx+MBJ2JFL
+        q8iG7V/8V9wOWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:01 GMT
+      etag:
+      - W/"7f5bd72921b364badef1b13585339659"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581BD43:687C8B0:5ED660C4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3296'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:01 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581BE17:687C999:5ED660C5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3295'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/afeae2fa88b84038991aaaaba0a5375be6f4fdbf
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPJDhAwodUqQc2VQ4sWjVtBFUVDWEAtxgi2+wqifLfd9z00N52
+        pRYJhOfx5r354Mp0Byxh0CCg10AUVVHA/SiOl0BXBRxWfriqcN0ETV01zGHDWONB1ETK0mL95MWm
+        2vc8+1EEebo9Z+mW53Ijy/2mz2TZ5Wkn8vTpJbu0q3y36Yo93fLhpdh9uTxevopyV8rHT+XPQhYf
+        KPmkekrcGXPSievCSSxaYbqpWhxH6So8jdqVaECbUeG8F9XcoDbatc/DQZ5rIAyNSySXGFIQ9o7S
+        OiP7w98W/pB/i/Bd9D2aMJluVCy5sgEkUvGfO+hAzR6e1ThQR1CCsD2hOVF4gTb8sbVB2xP6gGq2
+        NI97fM7Xc+7tlkHi+QnnJbs57O7I4H+UMArJwfX3Ki0bHteN54dh5AXhMlhFWHteDGFVBdExJCSq
+        Qx/5v5229aDdN2tTYyRqDa1t3XYQRkAvLjizCzT7tWeCVuxMHk+gcDCaJd++O+wZlWjEEYyg2VDF
+        9zPSz9BAr9FhCkFbiE2DFu1AiMPsC5hJkdQw9b1Nee5HIJI93m6vwj0di4QDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      etag:
+      - W/"2b2e1247b211353a9059ff199b8cf68b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581BF02:687CA95:5ED660C5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3294'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["afeae2fa88b84038991aaaaba0a5375be6f4fdbf"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"a72542095904bbac1c4495934d353fb321901957","node_id":"MDY6Q29tbWl0MjY4ODIyMDI0OmE3MjU0MjA5NTkwNGJiYWMxYzQ0OTU5MzRkMzUzZmIzMjE5MDE5NTc=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/a72542095904bbac1c4495934d353fb321901957","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:02Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:02Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"afeae2fa88b84038991aaaaba0a5375be6f4fdbf","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/afeae2fa88b84038991aaaaba0a5375be6f4fdbf","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/afeae2fa88b84038991aaaaba0a5375be6f4fdbf"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      etag:
+      - '"dd34c8f61d013a979c89f79a0c4abf61"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581BFA1:687CB6D:5ED660C6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3293'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBCG38VzwSkEGjJHpVSymJqqLNEZn2ujOI7sAylFvHsPdezSoTf8y913
+        /3cVCa2o75mlQzBZBsiESTyIIRrsvOGtatT6LbRBnT7KfbObVLMr9sNrfxjUBbatO7yoi35//jLb
+        dmLwnHqGHNGYaylh9PNPT+6s58cYZMIxcgkS18SEs97rGWGmLO/ZdWEywDskyRBf//aK+oRHEvVV
+        ZAdcBBYBFxaqSldlsaw2m0fg0VDAavm00ri2pTXashlNIzLBHsHT/5r+/Mzyzza32zfzEnwefQEA
+        AA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      etag:
+      - W/"6e8a2d52f6e86c05db0081ae2458ab47"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:00 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C08B:687CC7D:5ED660C6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3292'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "a72542095904bbac1c4495934d353fb321901957"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPWvDMBCG/4vmJvKH3GDPJmkKIlNdmsVI1qVSsCwjXQJuyH/vhY5dOnQ5ON57
+        7n1uLMKJNY+ZuAVlEvcqIUT2xKZgoHeGUtnK5zffeXn+EId2v8h2nx2m1/E4yavadfb4Iq/6fftl
+        dt1C4CWOBFnEOTWcq9mtPx3ai14PwfMIc6ASQKoJEVaj0yuEhIk/Zt/7xSjKADlBdP3bK+gzDMia
+        G0tWUZHaFJUosrqqM6G1GvJBCFpKYcqqPOmyyOssr6sNmeEyAxHk4R3+r+nPz8T/bHO/fwPMVOLT
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:03 GMT
+      etag:
+      - W/"a105db429d5595db8b5fbdef56bc42cd"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C109:687CD15:5ED660C6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3291'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:03 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C297:687CEEB:5ED660C7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3290'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ1Fdh1HM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vguQ
+        IqUqtmzj6IstQcCzi49dLN52ItPJfHZ9czObTWdXZ5NKpSKitsnt5583d8VvRfLlwz3/+uc6qVbb
+        35fZ1e3y183t8o+PE3TmpUBPK4yNonKbcsuNsPhh0RRF1P1aCrRapcV5IeNz6mvY/0fUWq65BW3B
+        CyPOJmpTCT2Zt5NCZbKCkSMYGCJPr6+n72ezm3cHzm/vVh+232a/NPxrnadfinW8/Ht2+znZ3i6z
+        fzGUwx7XUaML0HNrazNnzDeay4tM2ryJGyN0oiorKnuRqJI1rDf2af3xCpBMdxi3ZGg4wNWyI/nh
+        wBl2fCa5LYsDZ7wPbuTxMQtVFGoD5uEsTjTLdgDaMweTVfY6GAAtUzYXWFpM94EWSWLPX0p1g1tG
+        /3AuCWewbVqkLwV2w+EkHbGHlmlRK8dtYpNoWVupqhe7uwcBVOmMV/KevwoKiAGLHH2xY24wIGKN
+        w/xiih/dMheuyZaWTYtEyDX243XkAwzAdltTdrkbrSDtkrQi4mlJScHlioczRO8zY+dIAkrFbvMn
+        8wr5iyJCr3YJ6dHAdot7LEiPGCLqE+t/Mg4BDBhWZSW2wZjEahn+dvGWIDHwWGmOJB7MyB60ZeOv
+        dKis4GUwWw4GaK5UuJV3MEClMY046eyfvquOaVgfbFVTxj6TnhJip5vxNMyBGyOzSohgK74Dtqy/
+        BGLNqyQPZ6Lntcx/cqeGZ8GmQCwg40LFwZi40JkDtszk3F+NNgrpNVkg3p4BLRZBp0C8nQGrA54b
+        5z4Bd3jc1hZHKJj/PY+13Q4UvMoanoWzsAPSZYVSJeP3T1Zop8fsQASeSlMt4yZsYh6YNANfFCH/
+        hNuCATkYcFXX4yXdMxZpVMm5ZSpL+VTNczq9w+2FWGATFAeHZuj706Xb86ZBvJYN94u/zDpLoXaj
+        u816/8f2urdVsKPV81j7Q81tThkWZmuuRajJdDjWxnjqPlxcXLS54O5ZUgodMIt4GrBcJznK61D+
+        tz0PlWPJrXv+LMj9FM+hQvE02F7sgID7IxBqDp42Pkc16vVgjjvYmF7KAqqFqsLdEQNxbKdSVi5k
+        cspb8fQw34O2n4ysEnHG8bxBVFiZSMQJnux0AlDki3Cr6GmYHjQi/0wsBEIm2C5p4Xkt86pAKupC
+        bYNmyBGSEokWEKjSiFs8SiGWTc+n1+fT2V/vruaz2fzH99/Qp6mhgX2nz+V8ekl96sbkT3RB+u9i
+        BZ+gSj0uBB2+MUlxgh1j8gHy04CYH9GSvoNIChz6g6h9mS/rw7v9eRhMJ1elqFGn9Y9zI+/xebpX
+        YyWqqbA7aNxwi8cGapahqa/LekDOTeQzyWRudQPNkVpqrZYisWbcNmSyUceNXMm9gVRD7tQC/8gf
+        jJdSa9WJjV5c6PIwZMNO8Uyl4XEhhgZVi6rzcDwNmYjK7JbBCwA05VH3vSVwX1Kx4E1hI/9WIjkV
+        miwEVhxHoUssA2leJLd2yopfEDqq/RwpK/rPEFysKOvInw6rVoL0WaCQVdQmMv80HEfPXWD9YP+L
+        a8JUqBrb/0ULuk73x6QIcEg93uMIxWFH7AXisSz0phM38ZtO/KYTv+nEXmmn6++ITlwJu4FgOsqm
+        4+dtn60f/gN8hOOrFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:04 GMT
+      etag:
+      - W/"2c66e45e69a54b9853a952c195389733"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C33F:687CFAD:5ED660C7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3289'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:04 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C3B3:687D035:5ED660C8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3288'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ1Fdh1HM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vguQ
+        IqUqtmzj6IstQcCzi49dLN52ItPJfHZ9czObTWdXZ5NKpSKitsnt5583d8VvRfLlwz3/+uc6qVbb
+        35fZ1e3y183t8o+PE3TmpUBPK4yNonKbcsuNsPhh0RRF1P1aCrRapcV5IeNz6mvY/0fUWq65BW3B
+        CyPOJmpTCT2Zt5NCZbKCkSMYGCJPr6+n72ezm3cHzm/vVh+232a/NPxrnadfinW8/Ht2+znZ3i6z
+        fzGUwx7XUaML0HNrazNnzDeay4tM2ryJGyN0oiorKnuRqJI1rDf2af3xCpBMdxi3ZGg4wNWyI/nh
+        wBl2fCa5LYsDZ7wPbuTxMQtVFGoD5uEsTjTLdgDaMweTVfY6GAAtUzYXWFpM94EWSWLPX0p1g1tG
+        /3AuCWewbVqkLwV2w+EkHbGHlmlRK8dtYpNoWVupqhe7uwcBVOmMV/KevwoKiAGLHH2xY24wIGKN
+        w/xiih/dMheuyZaWTYtEyDX243XkAwzAdltTdrkbrSDtkrQi4mlJScHlioczRO8zY+dIAkrFbvMn
+        8wr5iyJCr3YJ6dHAdot7LEiPGCLqE+t/Mg4BDBhWZSW2wZjEahn+dvGWIDHwWGmOJB7MyB60ZeOv
+        dKis4GUwWw4GaK5UuJV3MEClMY046eyfvquOaVgfbFVTxj6TnhJip5vxNMyBGyOzSohgK74Dtqy/
+        BGLNqyQPZ6Lntcx/cqeGZ8GmQCwg40LFwZi40JkDtszk3F+NNgrpNVkg3p4BLRZBp0C8nQGrA54b
+        5z4Bd3jc1hZHKJj/PY+13Q4UvMoanoWzsAPSZYVSJeP3T1Zop8fsQASeSlMt4yZsYh6YNANfFCH/
+        hNuCATkYcFXX4yXdMxZpVMm5ZSpL+VTNczq9w+2FWGATFAeHZuj706Xb86ZBvJYN94u/zDpLoXaj
+        u816/8f2urdVsKPV81j7Q81tThkWZmuuRajJdDjWxnjqPlxcXLS54O5ZUgodMIt4GrBcJznK61D+
+        tz0PlWPJrXv+LMj9FM+hQvE02F7sgID7IxBqDp42Pkc16vVgjjvYmF7KAqqFqsLdEQNxbKdSVi5k
+        cspb8fQw34O2n4ysEnHG8bxBVFiZSMQJnux0AlDki3Cr6GmYHjQi/0wsBEIm2C5p4Xkt86pAKupC
+        bYNmyBGSEokWEKjSiFs8SiGWTc+n1+fT2V/vruaz2fzH99/Qp6mhgX2nz+V8ekl96sbkT3RB+u9i
+        BZ+gSj0uBB2+MUlxgh1j8gHy04CYH9GSvoNIChz6g6h9mS/rw7v9eRhMJ1elqFGn9Y9zI+/xebpX
+        YyWqqbA7aNxwi8cGapahqa/LekDOTeQzyWRudQPNkVpqrZYisWbcNmSyUceNXMm9gVRD7tQC/8gf
+        jJdSa9WJjV5c6PIwZMNO8Uyl4XEhhgZVi6rzcDwNmYjK7JbBCwA05VH3vSVwX1Kx4E1hI/9WIjkV
+        miwEVhxHoUssA2leJLd2yopfEDqq/RwpK/rPEFysKOvInw6rVoL0WaCQVdQmMv80HEfPXWD9YP+L
+        a8JUqBrb/0ULuk73x6QIcEg93uMIxWFH7AXisSz0phM38ZtO/KYTv+nEXmmn6++ITlwJu4FgOsqm
+        4+dtn60f/gN8hOOrFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      etag:
+      - W/"2c66e45e69a54b9853a952c195389733"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C4A6:687D14F:5ED660C8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3287'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU74vaQBD9V2Q/q1mzm8QECi0oxUJOrlUOrxSZTSZmNT8ku7n2FP/3zmJb2m8e
+        2HwImZl9+2bePHJmpgSWMIj8QPo8DmIulYJskklJgZC5CEShhD+J+SQOIjZkTZvjVucESmeb8NGP
+        rXqqeLrfyOVs8ZrOFnxZz0W6X1PuQ/CwOnx/+PhJb57SH5vTI1+u1kF6+nxIT+vTc704pft5kM7m
+        dC57R5f3XUUXl9YeTeJ5cNTjnbZlr8ZZW3sdHlvj1WjB2LbDUaXVyKKxxnPv7bZ+zYFqaD0CeYSo
+        NdXeMFpp62r7bwt/0d9CfCV9Cyf0tmw7lpxZAzXS8F9KKKEbzF+6tiFFsAbtNKE9UXqMLv1+55JO
+        EzpAMzuYz30+4uGI+6uJTHyRcP+ZXYbs2pHF/0hhO6QOzr+sFEU4DYUspFBcZEURxrmMZJBxhRFi
+        IXyFGagwuO+2XQ/Gu5mbhKnRGNg56RaNthqqgXPPEbIDZQdX2ajHI3TYWMOSr78HhAIB/QKmUzWV
+        XEzjeAL0KOAQiChQGBayyFVx3wH/2Pl29vvZ+VbOy7che8FOFzoDq8m/5IprjPTDKKAyOGQdgnEl
+        1jdG7xqqDJn7ANt3tI6mryon+2vVAoFceLn8BNqaD9qoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      etag:
+      - W/"dd34c8f61d013a979c89f79a0c4abf61"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C537:687D1FF:5ED660C9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3286'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5H/OwqM0pitONCWdS/qhEKQrIutVJaMpTRkpd995zbQLt2L
+        rBtjL2TOOunux3OPHj3NWvAmnmCOday6ZzWM1tZo78TrmGt+nbENw8QYsnElKBMZBRqGEffHaRJk
+        aSIEpJAlPvXpmKc+lrLyOzah6Ym36RVebZzr7IQQ1slRLV2z4aPKtKSHzljSgmPWmR5OleSnDqyz
+        ZPgul+1uwLTgSGW0A42JQ+6zHlafWBYmcejThPox56wKqjjGnygWURKteBQG1A9okiFZ41q1/Bnq
+        DdAxKFwZTo7t+I4XEbDfAcGHZcFSZOCx5DeGI8xWK8PEAUTPtvvZbCz0e8Gfx3SMKn8iiNt1gyVX
+        UgHKs++MG7A1dZHPNvPbQBVrjNsgWVx88efllRJ5YYvz5/xuUV49iHK2XpSX8lpOeS7P6ztd5NNs
+        iIp8WLPtvLwxL1VuGnHx+YGX6vXmt2RdRXP5cn5K7/QQlV87jBAJdGWE1DUycbRjGuPeUkl9b73J
+        o2dBrf4rj6Mr/gbPh8w1vK83zf/t23p6+gE5zXxm4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C5B1:687D292:5ED660C9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3285'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "a72542095904bbac1c4495934d353fb321901957"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMDI0OjVmNDE0MTQzZjBlMTQ0NmUzYzljNWI4MWVhNmFjYzY4YzFkZDk5MmI=","sha":"5f414143f0e1446e3c9c5b81ea6acc68c1dd992b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5f414143f0e1446e3c9c5b81ea6acc68c1dd992b","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:06Z"},"object":{"sha":"a72542095904bbac1c4495934d353fb321901957","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:06 GMT
+      etag:
+      - '"200c9b95dd1945d3d15e7fe514ec3f9f"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5f414143f0e1446e3c9c5b81ea6acc68c1dd992b
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C617:687D302:5ED660C9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3284'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "5f414143f0e1446e3c9c5b81ea6acc68c1dd992b", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyMDI0OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"5f414143f0e1446e3c9c5b81ea6acc68c1dd992b","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5f414143f0e1446e3c9c5b81ea6acc68c1dd992b"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:07 GMT
+      etag:
+      - '"94ba5f8f0520e17e2dfc4d0e9f7696cb"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C6EE:687D3F1:5ED660CA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3283'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:07 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C815:687D53D:5ED660CB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3282'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ1FcZxEM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vAuQ
+        IqXKtmzj6IstQcCzi49dLN52ItPJfHb14cNsNp1dnk0qlYqI2ibXX37Z3BS/F8nXj7f821/rpFpt
+        /1hml9fL3zbXyz8/TdCZlwI9rTA2isptyi03wuKHRVMUUfdrKdBqlRbnhYzPqa9h/x9Ra7nmFrQF
+        L4w4m6hNJfRk3k4KlckKRo5gYIg8vbqavp/NPrw5cH57s/q4/T77teHf6jz9Wqzj5T+z6y/J9nqZ
+        /YehHPa4jhpdgJ5bW5s5Y77RvL3IpM2buDFCJ6qyorIXiSpZw3pjn9efLgHJdIdxS4aGA1wtO5If
+        Dpxhx2eS27I4cMb74EYeH7NQRaE2YB7O4kSzbAegPXMwWWUvgwHQMmVzgaXFdO9okST2/LlUN7hl
+        9A/nknAG26ZF+lxgNxxO0hG7a5kWtXLcJjaJlrWVqnq2u3sQQJXOeCVv+YuggBiwyNFnO+YGAyLW
+        OMzPpvjRLXPhmmxp2bRIhFxjP15GPsAAbLc1ZZeb0QrSLkkrIp6WlBRcrrg7Q/Q+MXaOJKBU7DZ/
+        Mq+Qvygi9GqXkB4MbLe4x4L0iCGiPrL+J+MQwIBhVVZiG4xJrJbhbxdvCRIDj5XmSOLBjOxBWzb+
+        SofKCl4Gs+VggOZKhVt5BwNUGtOIk87+6bvqmIb1wVY1Zewz6SkhdroZT8McuDEyq4QItuI7YMv6
+        SyDWvErycCZ6Xsv8J3dqeBZsCsQCMi5UHIyJC505YMtMzv3VaKOQXpMF4u0Z0GIRdArE2xmwOuC5
+        ce4TcIfHbW1xhIL53/NY2+1Awaus4Vk4CzsgXVYoVTJ++2iFdnrMDkTgqTTVMm7CJuaBSTPwRRHy
+        T7gtGJCDAVd1PVzSPWGRRpWcW6aylI/VPKfTO9xeiAU2QXFwaIa+P166PW0axGvZcL/4y6yzFGo3
+        utus939sr3tbBTtaPY+1P9Xc5pRhYbbmWoSaTIdjbYyn7t3FxUWbC+6eJaXQAbOIpwHLdZKjvA7l
+        f9vzUDmW3Lrnz4LcT/EcKhRPg+3FDgi4PwKh5uBp43NUo14P5riDjemlLKBaqCrcHTEQx3YqZeVC
+        Jqe8FU8P8z1o+9nIKhFnHM8bRIWViUSc4MlOJwBFvgi3ip6G6UEj8s/EQiBkgu2SFp7XMq8KpKIu
+        1DZohhwhKZFoAYEqjbjFoxRi2fR8enU+nf395nI+m83fvf+OPk0NDeyePm/n03fUp25Mfn8Xh0H6
+        72IFn6BKPSwEHb4xSXECxJh8gPw8IOZHtKR7EEmBQ38Qtc/zZX14tz8Ng+nkqhQ16rT+cW7kLT5P
+        92qsRDUVdgeNG27x2EDNMjT1dVkPyLmJfCaZzK1uoDlSS63VUiTWjNuGTDbquJEruTeQasidWuAf
+        +YPxUmqtOrHRiwtdHoZs2CmeqTQ8LsTQoGpRdR6OpyETUZndMngBgKY86r63BO5LKha8KWzk30ok
+        p0KThcCK4yh0iWUgzYvk1k5Z8QtCR7WfI2VF/xmCixVlHfnTYdVKkD4LFLKK2kTm34bj6LkLrB/s
+        f3FNmApVY/u/aEHX6f6YFAEOqcd7HKE47Ii9QDyWhV514iZ+1YlfdeJXndgr7XT9HdGJK2E3EExH
+        2XT8vO2z9d0PgX96zRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:07 GMT
+      etag:
+      - W/"2fee636c65f2dc72472bf71bbffac6c0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C896:687D5B8:5ED660CB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3281'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:08 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C929:687D679:5ED660CB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3280'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ1FcZxEM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vAuQ
+        IqXKtmzj6IstQcCzi49dLN52ItPJfHb14cNsNp1dnk0qlYqI2ibXX37Z3BS/F8nXj7f821/rpFpt
+        /1hml9fL3zbXyz8/TdCZlwI9rTA2isptyi03wuKHRVMUUfdrKdBqlRbnhYzPqa9h/x9Ra7nmFrQF
+        L4w4m6hNJfRk3k4KlckKRo5gYIg8vbqavp/NPrw5cH57s/q4/T77teHf6jz9Wqzj5T+z6y/J9nqZ
+        /YehHPa4jhpdgJ5bW5s5Y77RvL3IpM2buDFCJ6qyorIXiSpZw3pjn9efLgHJdIdxS4aGA1wtO5If
+        Dpxhx2eS27I4cMb74EYeH7NQRaE2YB7O4kSzbAegPXMwWWUvgwHQMmVzgaXFdO9okST2/LlUN7hl
+        9A/nknAG26ZF+lxgNxxO0hG7a5kWtXLcJjaJlrWVqnq2u3sQQJXOeCVv+YuggBiwyNFnO+YGAyLW
+        OMzPpvjRLXPhmmxp2bRIhFxjP15GPsAAbLc1ZZeb0QrSLkkrIp6WlBRcrrg7Q/Q+MXaOJKBU7DZ/
+        Mq+Qvygi9GqXkB4MbLe4x4L0iCGiPrL+J+MQwIBhVVZiG4xJrJbhbxdvCRIDj5XmSOLBjOxBWzb+
+        SofKCl4Gs+VggOZKhVt5BwNUGtOIk87+6bvqmIb1wVY1Zewz6SkhdroZT8McuDEyq4QItuI7YMv6
+        SyDWvErycCZ6Xsv8J3dqeBZsCsQCMi5UHIyJC505YMtMzv3VaKOQXpMF4u0Z0GIRdArE2xmwOuC5
+        ce4TcIfHbW1xhIL53/NY2+1Awaus4Vk4CzsgXVYoVTJ++2iFdnrMDkTgqTTVMm7CJuaBSTPwRRHy
+        T7gtGJCDAVd1PVzSPWGRRpWcW6aylI/VPKfTO9xeiAU2QXFwaIa+P166PW0axGvZcL/4y6yzFGo3
+        utus939sr3tbBTtaPY+1P9Xc5pRhYbbmWoSaTIdjbYyn7t3FxUWbC+6eJaXQAbOIpwHLdZKjvA7l
+        f9vzUDmW3Lrnz4LcT/EcKhRPg+3FDgi4PwKh5uBp43NUo14P5riDjemlLKBaqCrcHTEQx3YqZeVC
+        Jqe8FU8P8z1o+9nIKhFnHM8bRIWViUSc4MlOJwBFvgi3ip6G6UEj8s/EQiBkgu2SFp7XMq8KpKIu
+        1DZohhwhKZFoAYEqjbjFoxRi2fR8enU+nf395nI+m83fvf+OPk0NDeyePm/n03fUp25Mfn8Xh0H6
+        72IFn6BKPSwEHb4xSXECxJh8gPw8IOZHtKR7EEmBQ38Qtc/zZX14tz8Ng+nkqhQ16rT+cW7kLT5P
+        92qsRDUVdgeNG27x2EDNMjT1dVkPyLmJfCaZzK1uoDlSS63VUiTWjNuGTDbquJEruTeQasidWuAf
+        +YPxUmqtOrHRiwtdHoZs2CmeqTQ8LsTQoGpRdR6OpyETUZndMngBgKY86r63BO5LKha8KWzk30ok
+        p0KThcCK4yh0iWUgzYvk1k5Z8QtCR7WfI2VF/xmCixVlHfnTYdVKkD4LFLKK2kTm34bj6LkLrB/s
+        f3FNmApVY/u/aEHX6f6YFAEOqcd7HKE47Ii9QDyWhV514iZ+1YlfdeJXndgr7XT9HdGJK2E3EExH
+        2XT8vO2z9d0PgX96zRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:08 GMT
+      etag:
+      - W/"2fee636c65f2dc72472bf71bbffac6c0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581C99E:687D706:5ED660CC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3279'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT2+DMAzFv0vOg5CWooLUwyS2qdWiXva3FxQSU1IRgoipxKp+93k777BDZeld
+        /J79sy9shIYVPxo4qmPgZxiD9X0k4oTdsd4bqKwhhyxl9urenDx9pvtyO8tym+z7XXfo5dk8PfZ6
+        zheHj92Xes+n55eHSd5vNjRgGjsKt4hDKDhXg42PFtupjrV3fITBB+4AVUA/QtTZOkIISCikVeVm
+        o6gHyClE7r8ZfX0Cjay4sNAqWrZqUkG1bBIQaZrBUud6Va8FqExpna21MCbPFzXR4TwAJejw26L+
+        fvLfHNfrN8+u1fWHAQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:08 GMT
+      etag:
+      - W/"94ba5f8f0520e17e2dfc4d0e9f7696cb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CA03:687D791:5ED660CC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3278'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/5f414143f0e1446e3c9c5b81ea6acc68c1dd992b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61SbWukMBD+K0s+6xo12ioclGL32A9uOa7d4n5ZYhw11qiYWNCy//0m7B+4gyOQ
+        ZF6eZ54Z5psMYwVXWZGU5Fken38ehrwr2Gt2XPPsSF+7szplLzR/+7VduuceX3pS71ux9d3p48jy
+        j3N7Uoeu2ApWbIfPS/YZ5er4gzhEtxxJo5r5eMKags9YDKFIRFQ++sBjLkT8KPyqSpKgRMAy9who
+        jZl06nl8kvtGmnYp92JU3gzTqD0FhmszzuD2snQNaKM9e1+vaq04xsB4CPIMb7T3D6Uxv4GZpN9k
+        4ApQxe+Wt3zevXzN44DSQHFpxWFP6N6DdT811mnFYQIWt7CABtSlsUuDN5+lQZjS+EJuDhnLDoSx
+        /Pep8IcgYgFNooSysuTCF4yhEbIqjMK6DAM/oX4SPSCzWSfLjGWUNP93SndO7f21GuwEJ4VqvmDW
+        chxcf09RkgKteWNV5utukAJ2vTSmh51NdmyyrKXgBhF2BHcbcOVq3mtwyAxc2xBZBi2bASO4Pfjh
+        ZpmRdVj63iETX/uRI8iat9sfo4xDeLkCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:08 GMT
+      etag:
+      - W/"200c9b95dd1945d3d15e7fe514ec3f9f"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CA57:687D800:5ED660CC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3277'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:09 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CABD:687D864:5ED660CC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3276'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ1FcZxEM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vAuQ
+        IqXKtmzj6IstQcCzi49dLN52ItPJfHb14cNsNp1dnk0qlYqI2ibXX37Z3BS/F8nXj7f821/rpFpt
+        /1hml9fL3zbXyz8/TdCZlwI9rTA2isptyi03wuKHRVMUUfdrKdBqlRbnhYzPqa9h/x9Ra7nmFrQF
+        L4w4m6hNJfRk3k4KlckKRo5gYIg8vbqavp/NPrw5cH57s/q4/T77teHf6jz9Wqzj5T+z6y/J9nqZ
+        /YehHPa4jhpdgJ5bW5s5Y77RvL3IpM2buDFCJ6qyorIXiSpZw3pjn9efLgHJdIdxS4aGA1wtO5If
+        Dpxhx2eS27I4cMb74EYeH7NQRaE2YB7O4kSzbAegPXMwWWUvgwHQMmVzgaXFdO9okST2/LlUN7hl
+        9A/nknAG26ZF+lxgNxxO0hG7a5kWtXLcJjaJlrWVqnq2u3sQQJXOeCVv+YuggBiwyNFnO+YGAyLW
+        OMzPpvjRLXPhmmxp2bRIhFxjP15GPsAAbLc1ZZeb0QrSLkkrIp6WlBRcrrg7Q/Q+MXaOJKBU7DZ/
+        Mq+Qvygi9GqXkB4MbLe4x4L0iCGiPrL+J+MQwIBhVVZiG4xJrJbhbxdvCRIDj5XmSOLBjOxBWzb+
+        SofKCl4Gs+VggOZKhVt5BwNUGtOIk87+6bvqmIb1wVY1Zewz6SkhdroZT8McuDEyq4QItuI7YMv6
+        SyDWvErycCZ6Xsv8J3dqeBZsCsQCMi5UHIyJC505YMtMzv3VaKOQXpMF4u0Z0GIRdArE2xmwOuC5
+        ce4TcIfHbW1xhIL53/NY2+1Awaus4Vk4CzsgXVYoVTJ++2iFdnrMDkTgqTTVMm7CJuaBSTPwRRHy
+        T7gtGJCDAVd1PVzSPWGRRpWcW6aylI/VPKfTO9xeiAU2QXFwaIa+P166PW0axGvZcL/4y6yzFGo3
+        utus939sr3tbBTtaPY+1P9Xc5pRhYbbmWoSaTIdjbYyn7t3FxUWbC+6eJaXQAbOIpwHLdZKjvA7l
+        f9vzUDmW3Lrnz4LcT/EcKhRPg+3FDgi4PwKh5uBp43NUo14P5riDjemlLKBaqCrcHTEQx3YqZeVC
+        Jqe8FU8P8z1o+9nIKhFnHM8bRIWViUSc4MlOJwBFvgi3ip6G6UEj8s/EQiBkgu2SFp7XMq8KpKIu
+        1DZohhwhKZFoAYEqjbjFoxRi2fR8enU+nf395nI+m83fvf+OPk0NDeyePm/n03fUp25Mfn8Xh0H6
+        72IFn6BKPSwEHb4xSXECxJh8gPw8IOZHtKR7EEmBQ38Qtc/zZX14tz8Ng+nkqhQ16rT+cW7kLT5P
+        92qsRDUVdgeNG27x2EDNMjT1dVkPyLmJfCaZzK1uoDlSS63VUiTWjNuGTDbquJEruTeQasidWuAf
+        +YPxUmqtOrHRiwtdHoZs2CmeqTQ8LsTQoGpRdR6OpyETUZndMngBgKY86r63BO5LKha8KWzk30ok
+        p0KThcCK4yh0iWUgzYvk1k5Z8QtCR7WfI2VF/xmCixVlHfnTYdVKkD4LFLKK2kTm34bj6LkLrB/s
+        f3FNmApVY/u/aEHX6f6YFAEOqcd7HKE47Ii9QDyWhV514iZ+1YlfdeJXndgr7XT9HdGJK2E3EExH
+        2XT8vO2z9d0PgX96zRUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:09 GMT
+      etag:
+      - W/"2fee636c65f2dc72472bf71bbffac6c0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CB1E:687D8DF:5ED660CD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3275'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU74vaQBD9V2Q/q1mzm8QECi0oxUJOrlUOrxSZTSZmNT8ku7n2FP/3zmJb2m8e
+        2HwImZl9+2bePHJmpgSWMIj8QPo8DmIulYJskklJgZC5CEShhD+J+SQOIjZkTZvjVucESmeb8NGP
+        rXqqeLrfyOVs8ZrOFnxZz0W6X1PuQ/CwOnx/+PhJb57SH5vTI1+u1kF6+nxIT+vTc704pft5kM7m
+        dC57R5f3XUUXl9YeTeJ5cNTjnbZlr8ZZW3sdHlvj1WjB2LbDUaXVyKKxxnPv7bZ+zYFqaD0CeYSo
+        NdXeMFpp62r7bwt/0d9CfCV9Cyf0tmw7lpxZAzXS8F9KKKEbzF+6tiFFsAbtNKE9UXqMLv1+55JO
+        EzpAMzuYz30+4uGI+6uJTHyRcP+ZXYbs2pHF/0hhO6QOzr+sFEU4DYUspFBcZEURxrmMZJBxhRFi
+        IXyFGagwuO+2XQ/Gu5mbhKnRGNg56RaNthqqgXPPEbIDZQdX2ajHI3TYWMOSr78HhAIB/QKmUzWV
+        XEzjeAL0KOAQiChQGBayyFVx3wH/2Pl29vvZ+VbOy7che8FOFzoDq8m/5IprjPTDKKAyOGQdgnEl
+        1jdG7xqqDJn7ANt3tI6mryon+2vVAoFceLn8BNqaD9qoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:09 GMT
+      etag:
+      - W/"dd34c8f61d013a979c89f79a0c4abf61"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CB76:687D94F:5ED660CD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3274'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5H/OwqM0pitONCWdS/qhEKQrIutVJaMpTRkpd995zbQLt2L
+        rBtjL2TOOunux3OPHj3NWvAmnmCOday6ZzWM1tZo78TrmGt+nbENw8QYsnElKBMZBRqGEffHaRJk
+        aSIEpJAlPvXpmKc+lrLyOzah6Ym36RVebZzr7IQQ1slRLV2z4aPKtKSHzljSgmPWmR5OleSnDqyz
+        ZPgul+1uwLTgSGW0A42JQ+6zHlafWBYmcejThPox56wKqjjGnygWURKteBQG1A9okiFZ41q1/Bnq
+        DdAxKFwZTo7t+I4XEbDfAcGHZcFSZOCx5DeGI8xWK8PEAUTPtvvZbCz0e8Gfx3SMKn8iiNt1gyVX
+        UgHKs++MG7A1dZHPNvPbQBVrjNsgWVx88efllRJ5YYvz5/xuUV49iHK2XpSX8lpOeS7P6ztd5NNs
+        iIp8WLPtvLwxL1VuGnHx+YGX6vXmt2RdRXP5cn5K7/QQlV87jBAJdGWE1DUycbRjGuPeUkl9b73J
+        o2dBrf4rj6Mr/gbPh8w1vK83zf/t23p6+gE5zXxm4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:10 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CC26:687DA22:5ED660CD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3273'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My newer better tag", "tag": "v-1.0", "type":
+      "commit", "object": "a72542095904bbac1c4495934d353fb321901957"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMDI0OjMxZjJiZjU5MTJjNjI5ZTExYjY3MzU2ZjgyYWUwZjQ1YjU2MDBkZTk=","sha":"31f2bf5912c629e11b67356f82ae0f45b5600de9","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/31f2bf5912c629e11b67356f82ae0f45b5600de9","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:10Z"},"object":{"sha":"a72542095904bbac1c4495934d353fb321901957","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957"},"tag":"v-1.0","message":"My
+        newer better tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '692'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:10 GMT
+      etag:
+      - '"fd6087224dd8916cad9fc5bb5251dbb9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/31f2bf5912c629e11b67356f82ae0f45b5600de9
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CC85:687DA8B:5ED660CE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3272'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "31f2bf5912c629e11b67356f82ae0f45b5600de9", "ref":
+      "refs/tags/v-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '77'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/v-1.0","node_id":"MDM6UmVmMjY4ODIyMDI0OnJlZnMvdGFncy92LTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/v-1.0","object":{"sha":"31f2bf5912c629e11b67356f82ae0f45b5600de9","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/31f2bf5912c629e11b67356f82ae0f45b5600de9"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '371'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:11 GMT
+      etag:
+      - '"7f12fe6b58334c79bc2c7f9d36abbd9c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/v-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CD1D:687DB60:5ED660CE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3271'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT2+DMAzFv0vOg5CWooLUwyS2qdWiXva3FxQSU1IRgoipxKp+93k777BDZeld
+        /J79sy9shIYVPxo4qmPgZxiD9X0k4oTdsd4bqKwhhyxl9urenDx9pvtyO8tym+z7XXfo5dk8PfZ6
+        zheHj92Xes+n55eHSd5vNjRgGjsKt4hDKDhXg42PFtupjrV3fITBB+4AVUA/QtTZOkIISCikVeVm
+        o6gHyClE7r8ZfX0Cjay4sNAqWrZqUkG1bBIQaZrBUud6Va8FqExpna21MCbPFzXR4TwAJejw26L+
+        fvLfHNfrN8+u1fWHAQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:11 GMT
+      etag:
+      - W/"94ba5f8f0520e17e2dfc4d0e9f7696cb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CE1D:687DC89:5ED660CF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3270'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:23:12 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CE5E:687DCD5:5ED660CF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3269'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:12 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CF3C:687DDDB:5ED660D0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3268'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:12 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CF84:687DE39:5ED660D0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3267'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:13 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581CFE9:687DEB6:5ED660D0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3266'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:13 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D0B1:687DF91:5ED660D1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3265'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIBAF0auYtVW3sPMAll7BIHzRRFgDi43x7tLNy7wUkLPxoIkW0WaWEh11
+        5MSWgKhGT4lrSVf9h+qdJ2aHB5fcSIM/9SjbYCXwM3IVJ+yZWw/tTV8bCdGCvh8u9SX+ZwAAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D114:687E021:5ED660D1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3264'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:14 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D16E:687E08A:5ED660D2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3263'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:14 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D1CB:687E0FA:5ED660D2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3262'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:15 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D232:687E16E:5ED660D2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3261'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:15 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D2B8:687E209:5ED660D3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3260'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/v-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QsU7DMBCG38UziR23MSRSB6QAKsLqAkiwRHZ8blLFSRRfKkVV352DkYmB5Zb/
+        Pv3f3YXN4Fn5PSNHc4z8nGSpYDdsGB3UnaNMV1q9hfegTx/bQ7VfdbUXh+G5/xz02T09Ds1ayJfX
+        h0Xf73YELnNPUIs4xZJzM3XpscN2sWkzBj7DNEYeAE3EcYak72yCEJHKadZ1WJ2hDJATRNu/rUZ7
+        ggZZeWGxNVSzyby0Pi8y2ShZQJZZdbvJlb+TBoTf5jZXQjgoyAvXCYigI/9X8udrf/a4Xr8A/bTj
+        n3MBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:15 GMT
+      etag:
+      - W/"7f12fe6b58334c79bc2c7f9d36abbd9c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D33A:687E29F:5ED660D3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3259'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/31f2bf5912c629e11b67356f82ae0f45b5600de9
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9laDnOJbkS2pDoZRsSxbcpTTpYr8E2R7b0vqGJGfXXfLvHZEfaGFf
+        JM3lnDlz0DsZpxousiYpyQ5Z/Pv7tzFTefh0OK7Z4UifVPZWqEdZqHOUnR7VD3WMitPDW67yIPtz
+        5oVq1/z5/FqonyxXZ54dvr4Up5fPZEtMJ5A0YA0vmyhhvIp5AoyV8T6I4uYTF0CbMCqjmNIaEgQs
+        ukdAZ+1sUt8Xs9y10nZLuaumwdcwT8YfwApjJw1eL0vPgrHGd+flMqy1wBpYH0G+Fa3x/2M09reg
+        SfpORjEAqvjViU7ozcNVTyNKg0FIJw53wvQOXPpL65JOHDbgcAfjlFOPxh7lJxamPEgZLchtS6ZS
+        QWUd/90VsedRyGkSJTQsS1GxKgwxCMI6iIKmDDhLKEuiPTLbdXbMOGaQ9mNdunMa/5/V4CboFKq5
+        emxHUcwAxojW6cvWzQivoDclWIuX69uSK2jZyEpYiTbi9vcY8Lc1ojewJRqEcSWyjEa2I1bw4+BD
+        2EUj7bj0/ZbMYu0ngSAX3m5/AZWRC3u0AgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:15 GMT
+      etag:
+      - W/"fd6087224dd8916cad9fc5bb5251dbb9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D385:687E309:5ED660D3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3258'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:16 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D3D3:687E36D:5ED660D3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3257'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:16 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D42A:687E3C6:5ED660D4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3256'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU74vaQBD9V2Q/q1mzm8QECi0oxUJOrlUOrxSZTSZmNT8ku7n2FP/3zmJb2m8e
+        2HwImZl9+2bePHJmpgSWMIj8QPo8DmIulYJskklJgZC5CEShhD+J+SQOIjZkTZvjVucESmeb8NGP
+        rXqqeLrfyOVs8ZrOFnxZz0W6X1PuQ/CwOnx/+PhJb57SH5vTI1+u1kF6+nxIT+vTc704pft5kM7m
+        dC57R5f3XUUXl9YeTeJ5cNTjnbZlr8ZZW3sdHlvj1WjB2LbDUaXVyKKxxnPv7bZ+zYFqaD0CeYSo
+        NdXeMFpp62r7bwt/0d9CfCV9Cyf0tmw7lpxZAzXS8F9KKKEbzF+6tiFFsAbtNKE9UXqMLv1+55JO
+        EzpAMzuYz30+4uGI+6uJTHyRcP+ZXYbs2pHF/0hhO6QOzr+sFEU4DYUspFBcZEURxrmMZJBxhRFi
+        IXyFGagwuO+2XQ/Gu5mbhKnRGNg56RaNthqqgXPPEbIDZQdX2ajHI3TYWMOSr78HhAIB/QKmUzWV
+        XEzjeAL0KOAQiChQGBayyFVx3wH/2Pl29vvZ+VbOy7che8FOFzoDq8m/5IprjPTDKKAyOGQdgnEl
+        1jdG7xqqDJn7ANt3tI6mryon+2vVAoFceLn8BNqaD9qoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:16 GMT
+      etag:
+      - W/"dd34c8f61d013a979c89f79a0c4abf61"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D48A:687E42E:5ED660D4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3255'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5H/OwqM0pitONCWdS/qhEKQrIutVJaMpTRkpd995zbQLt2L
+        rBtjL2TOOunux3OPHj3NWvAmnmCOday6ZzWM1tZo78TrmGt+nbENw8QYsnElKBMZBRqGEffHaRJk
+        aSIEpJAlPvXpmKc+lrLyOzah6Ym36RVebZzr7IQQ1slRLV2z4aPKtKSHzljSgmPWmR5OleSnDqyz
+        ZPgul+1uwLTgSGW0A42JQ+6zHlafWBYmcejThPox56wKqjjGnygWURKteBQG1A9okiFZ41q1/Bnq
+        DdAxKFwZTo7t+I4XEbDfAcGHZcFSZOCx5DeGI8xWK8PEAUTPtvvZbCz0e8Gfx3SMKn8iiNt1gyVX
+        UgHKs++MG7A1dZHPNvPbQBVrjNsgWVx88efllRJ5YYvz5/xuUV49iHK2XpSX8lpOeS7P6ztd5NNs
+        iIp8WLPtvLwxL1VuGnHx+YGX6vXmt2RdRXP5cn5K7/QQlV87jBAJdGWE1DUycbRjGuPeUkl9b73J
+        o2dBrf4rj6Mr/gbPh8w1vK83zf/t23p6+gE5zXxm4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:17 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D52E:687E505:5ED660D4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3254'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU74vaQBD9V2Q/q1mzm8QECi0oxUJOrlUOrxSZTSZmNT8ku7n2FP/3zmJb2m8e
+        2HwImZl9+2bePHJmpgSWMIj8QPo8DmIulYJskklJgZC5CEShhD+J+SQOIjZkTZvjVucESmeb8NGP
+        rXqqeLrfyOVs8ZrOFnxZz0W6X1PuQ/CwOnx/+PhJb57SH5vTI1+u1kF6+nxIT+vTc704pft5kM7m
+        dC57R5f3XUUXl9YeTeJ5cNTjnbZlr8ZZW3sdHlvj1WjB2LbDUaXVyKKxxnPv7bZ+zYFqaD0CeYSo
+        NdXeMFpp62r7bwt/0d9CfCV9Cyf0tmw7lpxZAzXS8F9KKKEbzF+6tiFFsAbtNKE9UXqMLv1+55JO
+        EzpAMzuYz30+4uGI+6uJTHyRcP+ZXYbs2pHF/0hhO6QOzr+sFEU4DYUspFBcZEURxrmMZJBxhRFi
+        IXyFGagwuO+2XQ/Gu5mbhKnRGNg56RaNthqqgXPPEbIDZQdX2ajHI3TYWMOSr78HhAIB/QKmUzWV
+        XEzjeAL0KOAQiChQGBayyFVx3wH/2Pl29vvZ+VbOy7che8FOFzoDq8m/5IprjPTDKKAyOGQdgnEl
+        1jdG7xqqDJn7ANt3tI6mryon+2vVAoFceLn8BNqaD9qoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:17 GMT
+      etag:
+      - W/"dd34c8f61d013a979c89f79a0c4abf61"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D57C:687E55F:5ED660D5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3253'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5H/OwqM0pitONCWdS/qhEKQrIutVJaMpTRkpd995zbQLt2L
+        rBtjL2TOOunux3OPHj3NWvAmnmCOday6ZzWM1tZo78TrmGt+nbENw8QYsnElKBMZBRqGEffHaRJk
+        aSIEpJAlPvXpmKc+lrLyOzah6Ym36RVebZzr7IQQ1slRLV2z4aPKtKSHzljSgmPWmR5OleSnDqyz
+        ZPgul+1uwLTgSGW0A42JQ+6zHlafWBYmcejThPox56wKqjjGnygWURKteBQG1A9okiFZ41q1/Bnq
+        DdAxKFwZTo7t+I4XEbDfAcGHZcFSZOCx5DeGI8xWK8PEAUTPtvvZbCz0e8Gfx3SMKn8iiNt1gyVX
+        UgHKs++MG7A1dZHPNvPbQBVrjNsgWVx88efllRJ5YYvz5/xuUV49iHK2XpSX8lpOeS7P6ztd5NNs
+        iIp8WLPtvLwxL1VuGnHx+YGX6vXmt2RdRXP5cn5K7/QQlV87jBAJdGWE1DUycbRjGuPeUkl9b73J
+        o2dBrf4rj6Mr/gbPh8w1vK83zf/t23p6+gE5zXxm4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:17 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D5C4:687E5BF:5ED660D5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3252'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:17 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D60A:687E61C:5ED660D5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3251'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:18 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D65B:687E674:5ED660D5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3250'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QsU7DMBCG38UzieO0MSRSB6S0qAirCyABQpEdn5tUcRLFl0pR1XfnYGRiYLnl
+        v0//d/dxYRM4VnzPwFEfAz9HIk7YDesHC1VrKVOlki/+1avT2/pQ7hdV7pND/9i99+psH3Z9veTp
+        0/N2VvebDYHz1BHUII6h4FyPbXxssZlNXA+eTzAOgXtAHXCYIOpaEyEEpHKaVeUXqykD5ATR9m+r
+        wZygRlZcWGg01ayES43LcpHWMs1BCCNvV5l0d6mGxK0zk8kksZCTFy4jEEFH/q/kz9f+7HG9fn4B
+        cF1dinUBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:18 GMT
+      etag:
+      - W/"660c12f063d7c32fb7fffffca9198ce1"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D6AC:687E6D3:5ED660D6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3249'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/31f2bf5912c629e11b67356f82ae0f45b5600de9
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9laDnOJbkS2pDoZRsSxbcpTTpYr8E2R7b0vqGJGfXXfLvHZEfaGFf
+        JM3lnDlz0DsZpxousiYpyQ5Z/Pv7tzFTefh0OK7Z4UifVPZWqEdZqHOUnR7VD3WMitPDW67yIPtz
+        5oVq1/z5/FqonyxXZ54dvr4Up5fPZEtMJ5A0YA0vmyhhvIp5AoyV8T6I4uYTF0CbMCqjmNIaEgQs
+        ukdAZ+1sUt8Xs9y10nZLuaumwdcwT8YfwApjJw1eL0vPgrHGd+flMqy1wBpYH0G+Fa3x/2M09reg
+        SfpORjEAqvjViU7ozcNVTyNKg0FIJw53wvQOXPpL65JOHDbgcAfjlFOPxh7lJxamPEgZLchtS6ZS
+        QWUd/90VsedRyGkSJTQsS1GxKgwxCMI6iIKmDDhLKEuiPTLbdXbMOGaQ9mNdunMa/5/V4CboFKq5
+        emxHUcwAxojW6cvWzQivoDclWIuX69uSK2jZyEpYiTbi9vcY8Lc1ojewJRqEcSWyjEa2I1bw4+BD
+        2EUj7bj0/ZbMYu0ngSAX3m5/AZWRC3u0AgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:18 GMT
+      etag:
+      - W/"fd6087224dd8916cad9fc5bb5251dbb9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D6E6:687E721:5ED660D6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3248'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:18 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D713:687E756:5ED660D6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3247'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:19 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D74B:687E796:5ED660D6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3246'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU74vaQBD9V2Q/q1mzm8QECi0oxUJOrlUOrxSZTSZmNT8ku7n2FP/3zmJb2m8e
+        2HwImZl9+2bePHJmpgSWMIj8QPo8DmIulYJskklJgZC5CEShhD+J+SQOIjZkTZvjVucESmeb8NGP
+        rXqqeLrfyOVs8ZrOFnxZz0W6X1PuQ/CwOnx/+PhJb57SH5vTI1+u1kF6+nxIT+vTc704pft5kM7m
+        dC57R5f3XUUXl9YeTeJ5cNTjnbZlr8ZZW3sdHlvj1WjB2LbDUaXVyKKxxnPv7bZ+zYFqaD0CeYSo
+        NdXeMFpp62r7bwt/0d9CfCV9Cyf0tmw7lpxZAzXS8F9KKKEbzF+6tiFFsAbtNKE9UXqMLv1+55JO
+        EzpAMzuYz30+4uGI+6uJTHyRcP+ZXYbs2pHF/0hhO6QOzr+sFEU4DYUspFBcZEURxrmMZJBxhRFi
+        IXyFGagwuO+2XQ/Gu5mbhKnRGNg56RaNthqqgXPPEbIDZQdX2ajHI3TYWMOSr78HhAIB/QKmUzWV
+        XEzjeAL0KOAQiChQGBayyFVx3wH/2Pl29vvZ+VbOy7che8FOFzoDq8m/5IprjPTDKKAyOGQdgnEl
+        1jdG7xqqDJn7ANt3tI6mryon+2vVAoFceLn8BNqaD9qoBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:19 GMT
+      etag:
+      - W/"dd34c8f61d013a979c89f79a0c4abf61"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D78B:687E7EA:5ED660D7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3245'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=a72542095904bbac1c4495934d353fb321901957
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5H/OwqM0pitONCWdS/qhEKQrIutVJaMpTRkpd995zbQLt2L
+        rBtjL2TOOunux3OPHj3NWvAmnmCOday6ZzWM1tZo78TrmGt+nbENw8QYsnElKBMZBRqGEffHaRJk
+        aSIEpJAlPvXpmKc+lrLyOzah6Ym36RVebZzr7IQQ1slRLV2z4aPKtKSHzljSgmPWmR5OleSnDqyz
+        ZPgul+1uwLTgSGW0A42JQ+6zHlafWBYmcejThPox56wKqjjGnygWURKteBQG1A9okiFZ41q1/Bnq
+        DdAxKFwZTo7t+I4XEbDfAcGHZcFSZOCx5DeGI8xWK8PEAUTPtvvZbCz0e8Gfx3SMKn8iiNt1gyVX
+        UgHKs++MG7A1dZHPNvPbQBVrjNsgWVx88efllRJ5YYvz5/xuUV49iHK2XpSX8lpOeS7P6ztd5NNs
+        iIp8WLPtvLwxL1VuGnHx+YGX6vXmt2RdRXP5cn5K7/QQlV87jBAJdGWE1DUycbRjGuPeUkl9b73J
+        o2dBrf4rj6Mr/gbPh8w1vK83zf/t23p6+gE5zXxm4AQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:19 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D7BF:687E833:5ED660D7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3244'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:20 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D84D:687E8CC:5ED660D7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3243'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTXPbNhCG/4uutQ2ZcRxHM5n0kDbTzriednpIc+GAJERCIgkWAKXKHP/3vEuQ
+        IqXKtizj6IstQcCzi49dLN5mIpPJLLi+uQmCaXB1NilVIkJqm9x++WV9l/+ex18/3vNvf63icrn5
+        Y5Fe3S5+W98u/vw0QWdeCPS0wtgwLDYJt9wIix/mdZ6H3a+FQKtVWpznMjqnvob9f0Sl5Ypb0OY8
+        N+Jsotal0JNZM8lVKksYOYCBIfL0+nr6IQhuLvec39wtP26+B7/W/FuVJV/zVbT4J7j9Em9uF+l/
+        GMphj+uw1jnombWVmTHmGs27i1TarI5qI3SsSitKexGrgtWsN/Z59ekKkFR3mHbJ0LCHq2RHcsOB
+        M+zwTDJb5HvOOB/akYfHzFWeqzWY+7M40izbAmjPWpgs09fBAGiYspnA0mK6D7RIEnt+KrUd3DD6
+        h3NJOINt0yI5FdgNh5N0xB4apkWlWm4dmVjLykpVnuzuDgRQpVNeynv+KiggBixy9GTH2sGAiBUO
+        88kUN7phbbjGG1o2LWIhV9iP15H3MADbTUXZ5W60grRL0oqQJwUlhTZXPJwhel8YOwcSUCK2mz+Z
+        lchfFBF6uU1ITwZ2u7iHgvSAIaI+s/5H4xDAgGFVlmLjjUmshuFvF28xEgOPlOZI4t6M7EAbNv5K
+        h8oKXniz1cIAzZTyt/ItDFBpTC2OOvvH72rLNKwPtrIuIpdJjwmx4804GubAjZFpKYS3Fd8CG9Zf
+        ApHmZZz5M9HzGuY+taeGp96mQCwgo1xF3pi40FkLbJjJuLsabejTa7JAvB0DWsy9ToF4WwNWezw3
+        rfsE3OJxW1scIW/+9zzWdDuQ8zKteerPwhZIlxVKlZTfP1uhHR+zAxF4Kk21jGq/iXlg0gxcUYT8
+        428LBuRgoK26ni7pXrBIo0quXaaikM/VPMfTO9xOiHk2QXGwb4a+P1+6vWwaxGvYcL+4y6yz5Gs3
+        utus939sr3tbeTtaPY81P1XcZpRhYbbiWviaTIdjTYSn7sPFxUWTCd4+SwqhPWYRRwOW6zhDee3L
+        /6bnoXIsuG2fP3NyP8FzKFc88bYXWyDg7gj4moOjjc9RhXrdm+MtbEwvZA7VQpX+7oiBOLZTKivn
+        Mj7mrXh8mO9Am89GlrE443jeICqsjCXiBE92OgEo8oW/VXQ0TA8akXsm5gIh422XtHC8hjlVIBFV
+        rjZeM+QISYlECwhUScgtHqUQy6bn0+vzafD35dUsCGbvP3xHn7qCBvZIn3ez6XvqU9Ume7TLZUBd
+        kP67WMEnqFJPC0H7b0xSnAAxJhsgPw+I2QEt6RFEnOPQ70Xtab6s9u/2l2EwnUwVokKd1j/OjbzH
+        5+lOjRWrusTuoHHNLR4bqFmGpr4u6wEZN6HLJJOZ1TU0R2qptFqI2Jpx25DJRh3Xcil3BlINuVUL
+        3CN/MF5IrVUnNjpxocvDkA07xTORhke5GBpUJcrOw/E0ZCxKs10GJwDQlEfdd5ag/ZKIOa9zG7q3
+        Esmp0GQhsOI4Cl1gGUjzIrm1U1bcgtBR7edIWdF9huBiRVGF7nRYtRSkzwKFrKLWofm35jh67QXW
+        D3a/tE2YClVju79oQdfp7pgEAQ6px3kcojjsiL1APJaF3nTiOnrTid904jed2CntdP0d0IlLYdcQ
+        TEfZdPy87bP1ww98uqM3FRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:20 GMT
+      etag:
+      - W/"e096e4a80f31d28527131d1a5703000d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D88F:687E91B:5ED660D8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3242'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:23:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C961:33B79:581D8D6:687E976:5ED660D8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3241'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_desc_only.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_desc_only.yaml
@@ -1,0 +1,4686 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:00 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839CEC5:9C84C61:5ED661B4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2810'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:00 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839CF2B:9C84CB0:5ED661B4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2809'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822986,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI5ODY=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:27:00Z","updated_at":"2020-06-02T14:27:00Z","pushed_at":"2020-06-02T14:27:01Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:02 GMT
+      etag:
+      - '"d674b5f365c552ca55af2b5a5a33db86"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839CF94:9C84D27:5ED661B4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2808'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"7d594384be71d73b5e077d0700f43a685f566531","node_id":"MDY6Q29tbWl0MjY4ODIyOTg2OjdkNTk0Mzg0YmU3MWQ3M2I1ZTA3N2QwNzAwZjQzYTY4NWY1NjY1MzE=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7d594384be71d73b5e077d0700f43a685f566531","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/7d594384be71d73b5e077d0700f43a685f566531","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:27:02Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:27:02Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:03 GMT
+      etag:
+      - '"d716cb6f0be3d0e8b63cabfa11fe5a9d"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839D333:9C85150:5ED661B6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2807'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XTW+bQBD9KxFnJ2DAxrFUtZHSQw52ZNVt6lSVtcAAmyy7dHdxalv5753B5MM+
+        tCFKb7lYsMubffP1drx1JCvBGTslMxa003MSVZbcOuOtYwqGG1E6OA2DURhD1E+jIB6AF0WpF3le
+        FgZsOBpkg+FwEPQRKlUKS54iaHK+GM78UxtfCW9yswgvzy/Wl/Pcv7xJb6fzW2+yyb1F+TWYXM2C
+        iX/Rv56fBVN/djfdnN1d38w2i/kinF4t+tObRX+y+fxhjxerbaE0MWy5fylYwfTR55VWEr+EknGB
+        JJA/Lp8ALX/KafEEncMPUmbJZd/zvWNveOz583449qOx51879w8RoGj8tyNKMIblROJCcsuZ4Bs4
+        QlrsSEOlDLdKr5Go1YDfPGSin3mnaeYHUTTyw6gfDkaQ+v4pi+I4HCUR7owwQeAhsNYUgMLayoxd
+        l1X8JOe2qGMKgNsc4ZZgMeVKw7Hg8bEFY41Lv8tluSYmBqyLIJc4GPfFZ2P83vDwXTEat0MREgSk
+        XSaqlljGXs9ZgeYZT5jlWB4Yzd07YJ1mTBjoORqYoS2nlobnEnd6Dj0wW2uMv6yF6DkVWwvFEESv
+        92/n5itcLGwplvtRfpbelyR2d+grwmoOzn11aXV1223zajA3TwIgVM4pcaZouhz3SH6Gg8Ew2Jej
+        2fDb96lIUE6m88WGbKywxvWhN82i8dtuqQ3oREmL5dQ0Tu02lj+uPoRoIdetjUbx/tV0ZMu4Tzz/
+        nsOn7zIlhLpD7CHV/Z7eM+8+gpDV7pnLvLsBBG1dZQvAOCH9e3Kao050sdQAtqgkqCw8JRMGQ6wh
+        7WKkhSCZO4k8to2ENbbq2CSaV9TanWjtAdGQ0jmTfNNoRCdDCKSSbDS1i0sNAIGwwurqhNwhtm6l
+        +YolawqDhgT4CmPa3doBFI3ZdUUX01fMOEWYW1iytKQ2a+Ty8IJ8b8H2Wn1vwW6d896Cu0sLxWyv
+        e1/UghXTpBvO+MdPbMil4PIWX3BSBJG9xeQXayaTAge/x/8FdGE9s9xx4KAp8sEWEq60spDYZzNY
+        u9KOaCBZLPYmtF81p0sDbwJbmyVSS3YOg8yUTqAZ+QTKH3FUWYZBbG7u322Mns7EE/6u0y8fjw+C
+        hIrceEU+3P8BNKdYB1kNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:03 GMT
+      etag:
+      - W/"f710bef8184334500c9a3e2498d177f4"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839D575:9C853F9:5ED661B7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2806'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:03 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839D60C:9C8549F:5ED661B7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2805'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7d594384be71d73b5e077d0700f43a685f566531
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTWvjMBD9K0FnJ5blDzmGwhbaQw52COslOMsS5HhsK/VHkOSWJOS/76jZw+6t
+        he1FWPM8897MPF2JbgVJCK/CZeDHQQncq7hfhkA5ryintA58EcVhHUZR6HvEIcNYwV5WmJQ+FdGG
+        LU257Wh6LIL10+q8zhu2PlYvWf5C00tDi/6Hn243fspW3i5/9DO2ecsuj2+74+ZS5EWQbQsvOxZe
+        enl+wOKT6rBwa8xJJ64rTnLRSNNO5eIw9q6C06jdHozQZlQw72Q5N6CNdu253/fnSiAGxsUkFzN6
+        idgnWmtN3+3/lfAX/UeI76Sf4RSTaUdFkisZRA/Y/PdWtELNnl/VOOBEoBfSzgT3hOEF2PC3xgbt
+        TPAH7NmmMcronEZzynIvSBhPKNuRm0Puigx8IYVRgAquf6zk1XRZ1cznPGYB94IwhoqxpeBlGcQH
+        jkiMDgP6f7dtNWj3w9w4mB60Fo0d3WqQRopOXmBmDTR795lEi51R40koGIwmyc9fDnkFJWt5EEbi
+        brDj+x3wMdSi0+AQBUJbiEyDls2AiEPshzCTQqph6jpb8tyNApPs9Xb7DdDmseOEAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      etag:
+      - W/"142a070dc50c5e26cc40bf8ef2d149cd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839D712:9C855A5:5ED661B7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2804'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["7d594384be71d73b5e077d0700f43a685f566531"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f","node_id":"MDY6Q29tbWl0MjY4ODIyOTg2OjU0OTVmZjhlNDhlNDNmNjRhNDFjZjlhOTRkN2EyM2UyMDU1ZjNjOWY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:27:04Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:27:04Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"7d594384be71d73b5e077d0700f43a685f566531","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/7d594384be71d73b5e077d0700f43a685f566531","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/7d594384be71d73b5e077d0700f43a685f566531"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      etag:
+      - '"1f1f077d6f80f65634e6577ea9f8a992"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839D78D:9C85667:5ED661B8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2803'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWqdNHJfMFQWkKAsE0SWy60vtKo4j+1opVP3vXMXIwsDylnff
+        ve/KIvSsumfiFpRJ3KuEENkDG4OBzhlq621dvvvW16fPotm+zM3bcd2Mr8N+rC9q19r9c33RH09f
+        ZtfOBJ7jQJBFnFLFuZrc8ujQnvXyEDyPMAUaAaSZEGExOL1ASJj4PbvOz0ZRB8gJouvfXkGf4ICs
+        urJkFQ1JIx6LfFNokCsjcy0gk9JkMsv6IlflRvSiLEW+IjOcJyCCPLzD/zX9+Zn4n21ut2+JeKql
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:05 GMT
+      etag:
+      - W/"2b5032d8272af02f3462005d8539b6fb"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:02 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839D979:9C8581A:5ED661B8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2802'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsU7DMBCG38UzrUviFJK5agHJygJBdImc+Fy7iuPIvlYKVd+9VzGyMCCd/uXu
+        u/+7sAiGVfdM3ILSiXuVECJ7YGPQ0DpNW7mR6w/feHn8EvXmda7fD1k9vg37UZ7VrrH7F3nuPrff
+        etfMBJ7iQJBFnFLFuZrc8uDQnrplHzyPMAUqAaSaEGExuG6BkDDxe7atn7WiHSAniK5/e4XuCD2y
+        6sKSVVRUiLIw5hkETW7WQonH3pSqFPpJZTlkq6IweV8aMsN5AiLIwzv8X9Ofn4n/2eZ6vQGbLaS/
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:06 GMT
+      etag:
+      - W/"24954d634c339f71a0c04e96ce9651cf"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DA08:9C85933:5ED661B9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2801'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:06 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DBFA:9C85B55:5ED661BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2800'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpFXzXoTA4vtIe2iBdIARQ+7exEoiZYYS6JKUnYdIe/ef0jJ
+        kl0ncRwec0lsmvxmOJwZDqediHQyD2dXV2F4fTU7m1Qy5RGNTW5vfl3fFX8UydfrB/btr1VSLTd/
+        3meXt/e/f7y7+f55gsms5JhpuDZRVG5SZpjmBj8smqKIul9LjlEjFT8vRHxOc3Xw/xW1EitmQFuw
+        QvOziVxXXE3m7aSQmagg5AAGgkjT2Wz6KQyvPuwpv7lbXm9+hL817Fudp1+LVXz/Pby9STa399m/
+        WMogj6moUQXouTG1ngeBG9Q/X2TC5E3caK4SWRlemYtElkET9MK+rD5fApKpDmNNhoE9XC06klsO
+        nA4O7yQ3ZbGnjNPBrjy8ZiGLQq7B3N/FkWKDLYDOzMJElb0NBkAbSJNzmBbbfSQjCZz5qVS7uA3o
+        H/yScBrHpnh6KrBbDiXJxR7bQPFaWm4T60SJ2ghZnazuDgRQqTJWiQf2JiggGixS9GTF7GJA+ArO
+        fDLFrW4DG67JhsymeMLFCufxNvIeBmCzqSm73I0sSKckDI9YWlJSsLni8QzR+8rYOZCAUr49/Mm8
+        Qv6iiFDLbUJ6NrCtcQ8F6QFBRH3B/kfjEMCAwSpLvvHGJFYb4G8XbwkSA4ulYkji3oTsQNtg/JWc
+        ynBWepNlYYDmUvqzvIUBKrRu+FG+f/ypWqYO+mCrmjJ2mfSYEDtejKNhD0xrkVWce7P4FtgG/SUQ
+        K1YluT8RPa8N3CfrNSzztgViARkXMvbGxIUeWGAb6Jy5q9FEPrUmCcTbEaD4wusWiLcVYJRHv7Hq
+        E3CLx21t4ELe9O95QdudQMGqrGGZPwlbIF1WKFUy9vBihXZ8zA5E4Kk0VSJu/CbmgUk7cEUR8o+/
+        IxiQgwBbdT1f0r3CSKNKzpqpLMVLNc/x9A63E2KeRVAc7Iuh7y+Xbq/bBvHaYLhf3GXWSfJ1Gt1t
+        1us/lte9rby5Vs8L2p9qZnLKsBBbM8V9babDBW2Mp+7jxcVFm3NmnyUlVx6ziKMBy1SSo7z2pX/b
+        81A5lszY58+C1E/xHCokS72dxRYIuHMBX3twtLEf1ajXvSluYWN6KQp0LWTl744YiGM5lTRiIZJj
+        3orHh/kOtP2iRZXwM4bnDaLCiEQgTvBkJw9Akc/9WdHRsD30iNwzseAIGW+npLjjtYHrCqS8LuTG
+        a4YcISmRKI4GVRoxg0dpOA2n59PZ+TT8+8PlPPw0n05/YE5Towf29JyPNKdudP70lBlNQfrvYgWf
+        0JV6vhG0/8akjhMgWucD5JcBMT/QS3oCkRRw+r2oPU2X1f7d/joMtpPLkteo0/rHuRYP+DzdqbES
+        2VQ4HQyumcFjAzXLMNTXZT0gZzpymWQyN6pBz5FGaiXveWL0eGzIZKOJa7EUOwuphtx2C9wjfxBe
+        CqVk12x0zYUuD6Nt2HU8U6FZXPBhQNa86jQcb0MkvNJbM7gGAG15NH3HBPZLyhesKUzk3krUTkVP
+        Fg1WuCNXJcxAPS9qt3adFWcQctV+j5QV3Wc0XAwv68h5h5FLTv1ZoJBV5DrS/zQMrmcvsH6x+8UO
+        YStUje3+ojhdp7trUgQ4Wj1O4wjFYUfsG8TjttB7n7iJ3/vE733i9z6x67TT9XegT1xxs0bDdJRN
+        x8/bPls//gd4Uj8JFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:06 GMT
+      etag:
+      - W/"8d9fa88588495647c6065239156b90dd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DC81:9C85C28:5ED661BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2799'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:06 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DD12:9C85CCC:5ED661BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2798'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpFXzXoTA4vtIe2iBdIARQ+7exEoiZYYS6JKUnYdIe/ef0jJ
+        kl0ncRwec0lsmvxmOJwZDqediHQyD2dXV2F4fTU7m1Qy5RGNTW5vfl3fFX8UydfrB/btr1VSLTd/
+        3meXt/e/f7y7+f55gsms5JhpuDZRVG5SZpjmBj8smqKIul9LjlEjFT8vRHxOc3Xw/xW1EitmQFuw
+        QvOziVxXXE3m7aSQmagg5AAGgkjT2Wz6KQyvPuwpv7lbXm9+hL817Fudp1+LVXz/Pby9STa399m/
+        WMogj6moUQXouTG1ngeBG9Q/X2TC5E3caK4SWRlemYtElkET9MK+rD5fApKpDmNNhoE9XC06klsO
+        nA4O7yQ3ZbGnjNPBrjy8ZiGLQq7B3N/FkWKDLYDOzMJElb0NBkAbSJNzmBbbfSQjCZz5qVS7uA3o
+        H/yScBrHpnh6KrBbDiXJxR7bQPFaWm4T60SJ2ghZnazuDgRQqTJWiQf2JiggGixS9GTF7GJA+ArO
+        fDLFrW4DG67JhsymeMLFCufxNvIeBmCzqSm73I0sSKckDI9YWlJSsLni8QzR+8rYOZCAUr49/Mm8
+        Qv6iiFDLbUJ6NrCtcQ8F6QFBRH3B/kfjEMCAwSpLvvHGJFYb4G8XbwkSA4ulYkji3oTsQNtg/JWc
+        ynBWepNlYYDmUvqzvIUBKrRu+FG+f/ypWqYO+mCrmjJ2mfSYEDtejKNhD0xrkVWce7P4FtgG/SUQ
+        K1YluT8RPa8N3CfrNSzztgViARkXMvbGxIUeWGAb6Jy5q9FEPrUmCcTbEaD4wusWiLcVYJRHv7Hq
+        E3CLx21t4ELe9O95QdudQMGqrGGZPwlbIF1WKFUy9vBihXZ8zA5E4Kk0VSJu/CbmgUk7cEUR8o+/
+        IxiQgwBbdT1f0r3CSKNKzpqpLMVLNc/x9A63E2KeRVAc7Iuh7y+Xbq/bBvHaYLhf3GXWSfJ1Gt1t
+        1us/lte9rby5Vs8L2p9qZnLKsBBbM8V9babDBW2Mp+7jxcVFm3NmnyUlVx6ziKMBy1SSo7z2pX/b
+        81A5lszY58+C1E/xHCokS72dxRYIuHMBX3twtLEf1ajXvSluYWN6KQp0LWTl744YiGM5lTRiIZJj
+        3orHh/kOtP2iRZXwM4bnDaLCiEQgTvBkJw9Akc/9WdHRsD30iNwzseAIGW+npLjjtYHrCqS8LuTG
+        a4YcISmRKI4GVRoxg0dpOA2n59PZ+TT8+8PlPPw0n05/YE5Towf29JyPNKdudP70lBlNQfrvYgWf
+        0JV6vhG0/8akjhMgWucD5JcBMT/QS3oCkRRw+r2oPU2X1f7d/joMtpPLkteo0/rHuRYP+DzdqbES
+        2VQ4HQyumcFjAzXLMNTXZT0gZzpymWQyN6pBz5FGaiXveWL0eGzIZKOJa7EUOwuphtx2C9wjfxBe
+        CqVk12x0zYUuD6Nt2HU8U6FZXPBhQNa86jQcb0MkvNJbM7gGAG15NH3HBPZLyhesKUzk3krUTkVP
+        Fg1WuCNXJcxAPS9qt3adFWcQctV+j5QV3Wc0XAwv68h5h5FLTv1ZoJBV5DrS/zQMrmcvsH6x+8UO
+        YStUje3+ojhdp7trUgQ4Wj1O4wjFYUfsG8TjttB7n7iJ3/vE733i9z6x67TT9XegT1xxs0bDdJRN
+        x8/bPls//gd4Uj8JFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:07 GMT
+      etag:
+      - W/"8d9fa88588495647c6065239156b90dd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DD9E:9C85D68:5ED661BA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2797'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIsh0bCn3IFe4hNr3m7khKCWt7Fcvnj2DJByHkv3dF2tK+
+        5SAFS1i7Xs3O7OAzMxWwhAUyDpRaoqTHV6EEuShUDLEsIxA+Ch4Eyi9ixaas60vc65KK1qtt+FXE
+        Nn9t+Lreymz1eMo2B5HVzzzbvLS7umrSlVtpm9ZPVbr6Uu/qpso2T2+peDitxfNpvXpe7Oq0zl63
+        n+jycWjo4srao0k8D456ftC2GvN50bfegMfeeC1aMLYfcNbofGbRWOO5fb9vTyVQDq1HRR5VtJpy
+        H6BW2bbZ/9vCX/C3AF9BP4IJo636gSVn1kGLRP5bBRUMk4f3oe9IEWxBO01oThSeowt/Prig04Q+
+        IM6uTHDBZzyccbFZyERECZc7dpmya0cW/yOEHZA6OP+yUhThMvSlkn7O/UKpMC5lJIOC5xghKl/k
+        WEAeBvedtuvBeDdjkzAtGgMHJ91jp62GZuLcc4TijaKTq2zU4xEG7Kxhyfc/BMsglv5SEp9FGfl5
+        gDyKSh5xTpwhXAYqCMPAX9yX4G87R7ej383ON2NefkzZOw5a6QKsJv+SK65npB+GgsbglA0IxqXY
+        2Bl96CgzZe4F7DjQOLqxaZzsp6YHKnLHy+Une/GmhqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:07 GMT
+      etag:
+      - W/"1f1f077d6f80f65634e6577ea9f8a992"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DE34:9C85E11:5ED661BB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2796'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5ET/1VglMZsxYG2rHtRJxSCbJ1spbJkLKUhK/3uO7eBdule
+        ZN0YA1kcOuueH3ePHj3NWvCmHmeOday6ZzWM1tZo78TrmGt+nbENw0QKSVpxynhCgU4mQemncTRO
+        4ohziCGJfOrTtIx9LGXldxSh8Ym36RVebZzr7JQQ1slRLV2zKUeVaUkPnbGkBcesMz2cKlmeOrDO
+        kmFfrdrdgGnBkcpoBxoTh9xnPYhPUUgjIVIIcQUiDlk4rgRlNOQJmwQw8aNIBBUVSNa4Vq1+hnoD
+        dAxKqUxJjlV8x4sIqHdA8OG2YCky8FjyG8PhZquVYfwAomfb/Ww2Fvp9w5/HdExX/qQhbtcNlhRS
+        AbZnr4wHsDV1ns03i9uxytcYt+NoefHFXxRXime5zc+f87tlcfXAi/l6WVzKazkrM3le3+k8myVD
+        lGfDN98uihvzUuWm4RefH8pCvd78Fq2rYCFf/p/ROz1ExdcOI0QCXRkudY1MJdoxDvFspaS+t970
+        0bOgxH/lcXTF3+D5kLmG9/VG/N++raenHwZEbhrgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:07 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DEAF:9C85EA8:5ED661BB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2795'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyOTg2OjUzZDRjMzA5ZWU0OTkwZTI5ODcwNzEyMWE0NDMxMTIzODJkMDRjMmU=","sha":"53d4c309ee4990e298707121a443112382d04c2e","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/53d4c309ee4990e298707121a443112382d04c2e","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:27:07Z"},"object":{"sha":"5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      etag:
+      - '"8708e7ec61001cd0693f77adf455cf13"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/53d4c309ee4990e298707121a443112382d04c2e
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839DF25:9C85F30:5ED661BB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2794'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "53d4c309ee4990e298707121a443112382d04c2e", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyOTg2OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"53d4c309ee4990e298707121a443112382d04c2e","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/53d4c309ee4990e298707121a443112382d04c2e"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:09 GMT
+      etag:
+      - '"815ed2451c472055e090ca4b4415c81b"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E045:9C86030:5ED661BC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2793'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:09 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E24D:9C8629F:5ED661BD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2792'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyiXUg4yc3N9oL1pZygznT7c3YtHthVbxLZcSU4aPHz3+69k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+rf1bfFnkXy5uudf/14l1XLz
+        1112fnP3xy+3198+TTCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRanhYxPaa5h/19Ra7niFrQF
+        L4w4mah1JfRk3k4KlckKQg5gIIg0vbiYfpzNLj/sKb+5XV5tvs9+b/jXOk+/FKv47tvs5jrZ3Nxl
+        /2Ephzyuo0YXoOfW1mbOmB80P59l0uZN3BihE1VZUdmzRJWsYb2wz6tP54BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9rORVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmf/fDifzz7Op9PvmNPU6IE9PueS5tSNyR+fckVTkP67WMEn
+        dKWebgTtvzGp4wSIMfkA+XVAzA/0kh5BJAWcfi9qX6fLav9ufxkG28lVKWrUaf3j3Mh7fJ7u1FiJ
+        aiqcDgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVZ3IrFmPDZkstHEtVzKnYVUQ267Bf6RPwgv
+        pdaqazb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6In
+        iwYr3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxsO13MXWL/Y/+KG
+        sBWqxnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+i9T9zE733i9z7xe5/Yd9rp+jvQJ66EXaNhOsqm
+        4+dtn60ffgDFEx7VFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:09 GMT
+      etag:
+      - W/"3d37af9b68289cec63ff75e300c00c4b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E2E0:9C8637E:5ED661BD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2791'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:10 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E38B:9C8644F:5ED661BD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2790'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyiXUg4yc3N9oL1pZygznT7c3YtHthVbxLZcSU4aPHz3+69k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+rf1bfFnkXy5uudf/14l1XLz
+        1112fnP3xy+3198+TTCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRanhYxPaa5h/19Ra7niFrQF
+        L4w4mah1JfRk3k4KlckKQg5gIIg0vbiYfpzNLj/sKb+5XV5tvs9+b/jXOk+/FKv47tvs5jrZ3Nxl
+        /2Ephzyuo0YXoOfW1mbOmB80P59l0uZN3BihE1VZUdmzRJWsYb2wz6tP54BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9rORVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmf/fDifzz7Op9PvmNPU6IE9PueS5tSNyR+fckVTkP67WMEn
+        dKWebgTtvzGp4wSIMfkA+XVAzA/0kh5BJAWcfi9qX6fLav9ufxkG28lVKWrUaf3j3Mh7fJ7u1FiJ
+        aiqcDgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVZ3IrFmPDZkstHEtVzKnYVUQ267Bf6RPwgv
+        pdaqazb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6In
+        iwYr3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxsO13MXWL/Y/+KG
+        sBWqxnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+i9T9zE733i9z7xe5/Yd9rp+jvQJ66EXaNhOsqm
+        4+dtn60ffgDFEx7VFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:10 GMT
+      etag:
+      - W/"3d37af9b68289cec63ff75e300c00c4b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E402:9C864DF:5ED661BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2789'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QP2+DMBDFv4vngsG4TYyUoVLaqlERS/ovCzL4Co4wRviIRKN89147d+jQ5S33
+        3t3v3ZlN8MHybw0cdRv4CaZg/RClccKu2OANVNaQo9gWN8/uxRXHd1luH5dy34py2PWHoTiZh/uh
+        WZQ4vO0+9auan/Z3c3G72dCCeeop3CGOIedcjzZuLXZzHTfe8QlGH7gD1AH9BFFv6wghIKGQVpVb
+        jKYZIKcQuX9n9PURGmT5mYVO07HrzMgmSxSAVCoBodarZJWKVEuZpanI1sIkshFAdLiMQAkq/r+o
+        P5/8M8fl8gX1Gk+IhwEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:10 GMT
+      etag:
+      - W/"815ed2451c472055e090ca4b4415c81b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E49D:9C86593:5ED661BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2788'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/53d4c309ee4990e298707121a443112382d04c2e
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S7YrbMBB8laDfdizLchwbCi04LSn4DG3S4/InbOy1rZy/sOS7OkfevSuuD9DC
+        gRDS7szsaNAb64cSz6pkCcvSbPPr29c+uz7JPN0v+aEW+fV4O6U/rtntS3h6PPL88Px6OuzDPC1e
+        H267JXvc8Yc0+50d9rc8/f6cWWx3/MQcphsg0TAoZRHwGFHGMUcRbyMe+cIHKQPfF8FWlFwWAokw
+        Ty0RGmNGnXgejGpdK9PMl3UxdN6E46C9Dg1oM0zoturiGtRGe3Y/n7ulBOqh8YjkGai19x+jCV/j
+        xJI31kOH5OJnAw1Mq93LNPRkDTtQ1hy9icprtOXPtS1acwSg4ZYmuOAu37hcHHyZiCjh0YndHTZc
+        rlgYq/83FRmHVbVFSSuoNhKkX1QxxLKMQAQoeBhWQRFXpGyW0SrTmE6Zj03pXZOC+lc39BJKity8
+        4KTV0Lv+mpOlDrWG2rrMllWvCly1ypgWVxbsWLCqVAGGGDaC9zvSl6ug1eiwCUHbFpt7reqeOvR7
+        6ABmnki1n9vWYSMs7QBEstf7/Q/ujgsNuQIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:10 GMT
+      etag:
+      - W/"8708e7ec61001cd0693f77adf455cf13"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E526:9C8663B:5ED661BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2787'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:11 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E5AA:9C866D7:5ED661BE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2786'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyiXUg4yc3N9oL1pZygznT7c3YtHthVbxLZcSU4aPHz3+69k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+rf1bfFnkXy5uudf/14l1XLz
+        1112fnP3xy+3198+TTCZlwIzrTA2ispNyi03wuKHRVMUUfdrKTBqlRanhYxPaa5h/19Ra7niFrQF
+        L4w4mah1JfRk3k4KlckKQg5gIIg0vbiYfpzNLj/sKb+5XV5tvs9+b/jXOk+/FKv47tvs5jrZ3Nxl
+        /2Ephzyuo0YXoOfW1mbOmB80P59l0uZN3BihE1VZUdmzRJWsYb2wz6tP54BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9rORVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmf/fDifzz7Op9PvmNPU6IE9PueS5tSNyR+fckVTkP67WMEn
+        dKWebgTtvzGp4wSIMfkA+XVAzA/0kh5BJAWcfi9qX6fLav9ufxkG28lVKWrUaf3j3Mh7fJ7u1FiJ
+        aiqcDgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVZ3IrFmPDZkstHEtVzKnYVUQ267Bf6RPwgv
+        pdaqazb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6In
+        iwYr3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxsO13MXWL/Y/+KG
+        sBWqxnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+i9T9zE733i9z7xe5/Yd9rp+jvQJ66EXaNhOsqm
+        4+dtn60ffgDFEx7VFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:11 GMT
+      etag:
+      - W/"3d37af9b68289cec63ff75e300c00c4b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E62F:9C86773:5ED661BF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2785'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIsh0bCn3IFe4hNr3m7khKCWt7Fcvnj2DJByHkv3dF2tK+
+        5SAFS1i7Xs3O7OAzMxWwhAUyDpRaoqTHV6EEuShUDLEsIxA+Ch4Eyi9ixaas60vc65KK1qtt+FXE
+        Nn9t+Lreymz1eMo2B5HVzzzbvLS7umrSlVtpm9ZPVbr6Uu/qpso2T2+peDitxfNpvXpe7Oq0zl63
+        n+jycWjo4srao0k8D456ftC2GvN50bfegMfeeC1aMLYfcNbofGbRWOO5fb9vTyVQDq1HRR5VtJpy
+        H6BW2bbZ/9vCX/C3AF9BP4IJo636gSVn1kGLRP5bBRUMk4f3oe9IEWxBO01oThSeowt/Prig04Q+
+        IM6uTHDBZzyccbFZyERECZc7dpmya0cW/yOEHZA6OP+yUhThMvSlkn7O/UKpMC5lJIOC5xghKl/k
+        WEAeBvedtuvBeDdjkzAtGgMHJ91jp62GZuLcc4TijaKTq2zU4xEG7Kxhyfc/BMsglv5SEp9FGfl5
+        gDyKSh5xTpwhXAYqCMPAX9yX4G87R7ej383ON2NefkzZOw5a6QKsJv+SK65npB+GgsbglA0IxqXY
+        2Bl96CgzZe4F7DjQOLqxaZzsp6YHKnLHy+Une/GmhqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:11 GMT
+      etag:
+      - W/"1f1f077d6f80f65634e6577ea9f8a992"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E6A6:9C86812:5ED661BF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2784'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5ET/1VglMZsxYG2rHtRJxSCbJ1spbJkLKUhK/3uO7eBdule
+        ZN0YA1kcOuueH3ePHj3NWvCmHmeOday6ZzWM1tZo78TrmGt+nbENw0QKSVpxynhCgU4mQemncTRO
+        4ohziCGJfOrTtIx9LGXldxSh8Ym36RVebZzr7JQQ1slRLV2zKUeVaUkPnbGkBcesMz2cKlmeOrDO
+        kmFfrdrdgGnBkcpoBxoTh9xnPYhPUUgjIVIIcQUiDlk4rgRlNOQJmwQw8aNIBBUVSNa4Vq1+hnoD
+        dAxKqUxJjlV8x4sIqHdA8OG2YCky8FjyG8PhZquVYfwAomfb/Ww2Fvp9w5/HdExX/qQhbtcNlhRS
+        AbZnr4wHsDV1ns03i9uxytcYt+NoefHFXxRXime5zc+f87tlcfXAi/l6WVzKazkrM3le3+k8myVD
+        lGfDN98uihvzUuWm4RefH8pCvd78Fq2rYCFf/p/ROz1ExdcOI0QCXRkudY1MJdoxDvFspaS+t970
+        0bOgxH/lcXTF3+D5kLmG9/VG/N++raenHwZEbhrgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:12 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E724:9C868A1:5ED661BF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2783'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My newer better tag", "tag": "version-1.0",
+      "type": "commit", "object": "5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyOTg2OjQ2NWRkNjNmZDQ0MDA0Njk2ZTMxNjk5MjgwNWJiZDlmZDM0YTI3MTY=","sha":"465dd63fd44004696e316992805bbd9fd34a2716","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/465dd63fd44004696e316992805bbd9fd34a2716","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:27:12Z"},"object":{"sha":"5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f"},"tag":"version-1.0","message":"My
+        newer better tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '698'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:12 GMT
+      etag:
+      - '"13513a1f7d012f4d90ce6f7a474b2c49"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/465dd63fd44004696e316992805bbd9fd34a2716
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E7A1:9C86941:5ED661C0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2782'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QP2+DMBDFv4vngsG4TYyUoVLaqlERS/ovCzL4Co4wRviIRKN89147d+jQ5S33
+        3t3v3ZlN8MHybw0cdRv4CaZg/RClccKu2OANVNaQo9gWN8/uxRXHd1luH5dy34py2PWHoTiZh/uh
+        WZQ4vO0+9auan/Z3c3G72dCCeeop3CGOIedcjzZuLXZzHTfe8QlGH7gD1AH9BFFv6wghIKGQVpVb
+        jKYZIKcQuX9n9PURGmT5mYVO07HrzMgmSxSAVCoBodarZJWKVEuZpanI1sIkshFAdLiMQAkq/r+o
+        P5/8M8fl8gX1Gk+IhwEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:12 GMT
+      etag:
+      - W/"815ed2451c472055e090ca4b4415c81b"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E881:9C86A1B:5ED661C0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2781'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "465dd63fd44004696e316992805bbd9fd34a2716"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QO0/DQBCE/8vV2OfH5eAspUAKiYiw3AQIaayzb/2IbJ/lW0cyUf47CzUFBc00
+        O7P7zV7ZBBVLvtVx1LXjF5hcawcv9AN2xwZrIG8NOdJNKl/7tz49f4hs87xkhzrKhn13GtKL2W2H
+        clHR6bj/1O9qfjk8zenjek0L5qmjcIM4uoRzPbZ+3WIzF35pez7BaB3vAbVDO4HXtYWH4JBQSPO8
+        X4ymGSCnELl/Z7TFGUpkyZW5RtMxIVfGyLgyQgSBkEpCHEqloodgVRRGVSYWOroPJdHhMgIlqPj/
+        ov588s8ct9sXBrzsq4cBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:13 GMT
+      etag:
+      - W/"bf1fc3bead2259dc7121c2de7fc7376a"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839E902:9C86ACD:5ED661C0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2780'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:13 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EA73:9C86C7F:5ED661C1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2779'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkrhxk5ub6QHvTzlBmOn24uxePbCu2iG25kpw0ePju/a9k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+tf1bfFHkXy9uuff/lol1XLz
+        51328ebu959vr79/nmAyLwVmWmFsFJWblFtuhMUPi6Yoou7XUmDUKi1OCxmf0lzD/r+i1nLFLWgL
+        XhhxMlHrSujJvJ0UKpMVhBzAQBBpenEx/TSbXZ7vKb+5XV5tfsx+a/i3Ok+/Fqv47vvs5jrZ3Nxl
+        /2Iphzyuo0YXoOfW1mbOmB80H84yafMmbozQiaqsqOxZokrWsF7Yl9Xnj4BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9ouRVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmd/n3+czz7Np9MfmNPU6IE9PueS5tSNyR+dcv6BpiD9d7GC
+        T+hKPd0I2n9jUscJEGPyAfLLgJgf6CU9gkgKOP1e1L5Ol9X+3f4yDLaTq1LUqNP6x7mR9/g83amx
+        EtVUOB0MrrnFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kRizXhsyGSjiWu5lDsLqYbcdgv8I38Q
+        XkqtVdds9M2FLg+jbdh1PFNpeFyIYUDVouo0HG9DJqIyWzP4BgBteTR9xwTuSyoWvCls5N9K1E5F
+        TxYNVrij0CXMQD0vard2nRVvEHLVfo+UFf1nNFysKOvIe4dVS0H9WaCQVdQ6Mv80HK7nLrB+sf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFH7BvE47bQe5+4id/7xO994vc+se+00/V3oE9cCbtGw3SU
+        TcfP2z5bP/wHe6wroBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:14 GMT
+      etag:
+      - W/"19b48c95825c6b392725646841445a28"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EAD7:9C86D09:5ED661C1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2778'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:14 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EC0F:9C86E2E:5ED661C2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2777'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkrhxk5ub6QHvTzlBmOn24uxePbCu2iG25kpw0ePju/a9k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+tf1bfFHkXy9uuff/lol1XLz
+        51328ebu959vr79/nmAyLwVmWmFsFJWblFtuhMUPi6Yoou7XUmDUKi1OCxmf0lzD/r+i1nLFLWgL
+        XhhxMlHrSujJvJ0UKpMVhBzAQBBpenEx/TSbXZ7vKb+5XV5tfsx+a/i3Ok+/Fqv47vvs5jrZ3Nxl
+        /2Iphzyuo0YXoOfW1mbOmB80H84yafMmbozQiaqsqOxZokrWsF7Yl9Xnj4BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9ouRVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmd/n3+czz7Np9MfmNPU6IE9PueS5tSNyR+dcv6BpiD9d7GC
+        T+hKPd0I2n9jUscJEGPyAfLLgJgf6CU9gkgKOP1e1L5Ol9X+3f4yDLaTq1LUqNP6x7mR9/g83amx
+        EtVUOB0MrrnFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kRizXhsyGSjiWu5lDsLqYbcdgv8I38Q
+        XkqtVdds9M2FLg+jbdh1PFNpeFyIYUDVouo0HG9DJqIyWzP4BgBteTR9xwTuSyoWvCls5N9K1E5F
+        TxYNVrij0CXMQD0vard2nRVvEHLVfo+UFf1nNFysKOvIe4dVS0H9WaCQVdQ6Mv80HK7nLrB+sf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFH7BvE47bQe5+4id/7xO994vc+se+00/V3oE9cCbtGw3SU
+        TcfP2z5bP/wHe6wroBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:14 GMT
+      etag:
+      - W/"19b48c95825c6b392725646841445a28"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EC8D:9C86F07:5ED661C2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2776'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QO0/DQBCE/8vV2OfH5eAspUAKiYiw3AQIaayzb/2IbJ/lW0cyUf47CzUFBc00
+        O7P7zV7ZBBVLvtVx1LXjF5hcawcv9AN2xwZrIG8NOdJNKl/7tz49f4hs87xkhzrKhn13GtKL2W2H
+        clHR6bj/1O9qfjk8zenjek0L5qmjcIM4uoRzPbZ+3WIzF35pez7BaB3vAbVDO4HXtYWH4JBQSPO8
+        X4ymGSCnELl/Z7TFGUpkyZW5RtMxIVfGyLgyQgSBkEpCHEqloodgVRRGVSYWOroPJdHhMgIlqPj/
+        ov588s8ct9sXBrzsq4cBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:15 GMT
+      etag:
+      - W/"bf1fc3bead2259dc7121c2de7fc7376a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839ED23:9C86F8D:5ED661C2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2775'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/465dd63fd44004696e316992805bbd9fd34a2716
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61SbYucMBD+K0s+6xpjdM+FQgu25Qq6XCs9dr8sUScazzeSeFc59r/fhP0DLRRC
+        knl5nnlmmHcyzQ1cVUOOJM/y5Pf3b1Pen/kpe9xOZctO/RMrnn++FH0xXrInmmdfaNG/sEuZ/8E3
+        zvv2rXj+oS7ZgPGcnsvHKC/Pn4hHTCeQlCdx0ySRbDinlCdpAlGYpCl7oHFVNalsIi7YIUwQsOoB
+        AZ21izkGgVjUvlW2W6t9PY+BhmU2wQhWGDtr8AdV+RaMNYG7r9dxawTGwAYICqxoTfAPpTG/BU2O
+        72QSI6CKX53ohN59fdXzhNJgFMqJw57QvQfn/tw6pxOHCVjcwRhl1KeJT1kZ8iM7HEN2ITePzFUP
+        tXX896nEPI2lfACOJ5IJFzysZSpS3hwEi4DROJZRnUpkttvimLHMqOz/ndKd0wR/rQY7wUmhmlfQ
+        Rs2TH+4pShrBGNE6lfm2m+AN9K4Ca/Fx2Z7LVlLVwiLEzeBuA+6cFIMBj2gQxoXIOhnVThjB9cGP
+        sKtG2mkdBo8sYhtmgSBn3m4fqfkaILoCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:15 GMT
+      etag:
+      - W/"13513a1f7d012f4d90ce6f7a474b2c49"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EDA2:9C87046:5ED661C3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2774'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:15 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EE0B:9C870CB:5ED661C3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2773'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkrhxk5ub6QHvTzlBmOn24uxePbCu2iG25kpw0ePju/a9k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+tf1bfFHkXy9uuff/lol1XLz
+        51328ebu959vr79/nmAyLwVmWmFsFJWblFtuhMUPi6Yoou7XUmDUKi1OCxmf0lzD/r+i1nLFLWgL
+        XhhxMlHrSujJvJ0UKpMVhBzAQBBpenEx/TSbXZ7vKb+5XV5tfsx+a/i3Ok+/Fqv47vvs5jrZ3Nxl
+        /2Iphzyuo0YXoOfW1mbOmB80H84yafMmbozQiaqsqOxZokrWsF7Yl9Xnj4BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9ouRVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmd/n3+czz7Np9MfmNPU6IE9PueS5tSNyR+dcv6BpiD9d7GC
+        T+hKPd0I2n9jUscJEGPyAfLLgJgf6CU9gkgKOP1e1L5Ol9X+3f4yDLaTq1LUqNP6x7mR9/g83amx
+        EtVUOB0MrrnFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kRizXhsyGSjiWu5lDsLqYbcdgv8I38Q
+        XkqtVdds9M2FLg+jbdh1PFNpeFyIYUDVouo0HG9DJqIyWzP4BgBteTR9xwTuSyoWvCls5N9K1E5F
+        TxYNVrij0CXMQD0vard2nRVvEHLVfo+UFf1nNFysKOvIe4dVS0H9WaCQVdQ6Mv80HK7nLrB+sf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFH7BvE47bQe5+4id/7xO994vc+se+00/V3oE9cCbtGw3SU
+        TcfP2z5bP/wHe6wroBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:16 GMT
+      etag:
+      - W/"19b48c95825c6b392725646841445a28"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EE79:9C8715B:5ED661C3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2772'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIsh0bCn3IFe4hNr3m7khKCWt7Fcvnj2DJByHkv3dF2tK+
+        5SAFS1i7Xs3O7OAzMxWwhAUyDpRaoqTHV6EEuShUDLEsIxA+Ch4Eyi9ixaas60vc65KK1qtt+FXE
+        Nn9t+Lreymz1eMo2B5HVzzzbvLS7umrSlVtpm9ZPVbr6Uu/qpso2T2+peDitxfNpvXpe7Oq0zl63
+        n+jycWjo4srao0k8D456ftC2GvN50bfegMfeeC1aMLYfcNbofGbRWOO5fb9vTyVQDq1HRR5VtJpy
+        H6BW2bbZ/9vCX/C3AF9BP4IJo636gSVn1kGLRP5bBRUMk4f3oe9IEWxBO01oThSeowt/Prig04Q+
+        IM6uTHDBZzyccbFZyERECZc7dpmya0cW/yOEHZA6OP+yUhThMvSlkn7O/UKpMC5lJIOC5xghKl/k
+        WEAeBvedtuvBeDdjkzAtGgMHJ91jp62GZuLcc4TijaKTq2zU4xEG7Kxhyfc/BMsglv5SEp9FGfl5
+        gDyKSh5xTpwhXAYqCMPAX9yX4G87R7ej383ON2NefkzZOw5a6QKsJv+SK65npB+GgsbglA0IxqXY
+        2Bl96CgzZe4F7DjQOLqxaZzsp6YHKnLHy+Une/GmhqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:16 GMT
+      etag:
+      - W/"1f1f077d6f80f65634e6577ea9f8a992"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EEEE:9C871DE:5ED661C4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2771'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5ET/1VglMZsxYG2rHtRJxSCbJ1spbJkLKUhK/3uO7eBdule
+        ZN0YA1kcOuueH3ePHj3NWvCmHmeOday6ZzWM1tZo78TrmGt+nbENw0QKSVpxynhCgU4mQemncTRO
+        4ohziCGJfOrTtIx9LGXldxSh8Ym36RVebZzr7JQQ1slRLV2zKUeVaUkPnbGkBcesMz2cKlmeOrDO
+        kmFfrdrdgGnBkcpoBxoTh9xnPYhPUUgjIVIIcQUiDlk4rgRlNOQJmwQw8aNIBBUVSNa4Vq1+hnoD
+        dAxKqUxJjlV8x4sIqHdA8OG2YCky8FjyG8PhZquVYfwAomfb/Ww2Fvp9w5/HdExX/qQhbtcNlhRS
+        AbZnr4wHsDV1ns03i9uxytcYt+NoefHFXxRXime5zc+f87tlcfXAi/l6WVzKazkrM3le3+k8myVD
+        lGfDN98uihvzUuWm4RefH8pCvd78Fq2rYCFf/p/ROz1ExdcOI0QCXRkudY1MJdoxDvFspaS+t970
+        0bOgxH/lcXTF3+D5kLmG9/VG/N++raenHwZEbhrgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:16 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839EFD4:9C872CF:5ED661C4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2770'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIsh0bCn3IFe4hNr3m7khKCWt7Fcvnj2DJByHkv3dF2tK+
+        5SAFS1i7Xs3O7OAzMxWwhAUyDpRaoqTHV6EEuShUDLEsIxA+Ch4Eyi9ixaas60vc65KK1qtt+FXE
+        Nn9t+Lreymz1eMo2B5HVzzzbvLS7umrSlVtpm9ZPVbr6Uu/qpso2T2+peDitxfNpvXpe7Oq0zl63
+        n+jycWjo4srao0k8D456ftC2GvN50bfegMfeeC1aMLYfcNbofGbRWOO5fb9vTyVQDq1HRR5VtJpy
+        H6BW2bbZ/9vCX/C3AF9BP4IJo636gSVn1kGLRP5bBRUMk4f3oe9IEWxBO01oThSeowt/Prig04Q+
+        IM6uTHDBZzyccbFZyERECZc7dpmya0cW/yOEHZA6OP+yUhThMvSlkn7O/UKpMC5lJIOC5xghKl/k
+        WEAeBvedtuvBeDdjkzAtGgMHJ91jp62GZuLcc4TijaKTq2zU4xEG7Kxhyfc/BMsglv5SEp9FGfl5
+        gDyKSh5xTpwhXAYqCMPAX9yX4G87R7ej383ON2NefkzZOw5a6QKsJv+SK65npB+GgsbglA0IxqXY
+        2Bl96CgzZe4F7DjQOLqxaZzsp6YHKnLHy+Une/GmhqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:17 GMT
+      etag:
+      - W/"1f1f077d6f80f65634e6577ea9f8a992"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F040:9C87375:5ED661C4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2769'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5ET/1VglMZsxYG2rHtRJxSCbJ1spbJkLKUhK/3uO7eBdule
+        ZN0YA1kcOuueH3ePHj3NWvCmHmeOday6ZzWM1tZo78TrmGt+nbENw0QKSVpxynhCgU4mQemncTRO
+        4ohziCGJfOrTtIx9LGXldxSh8Ym36RVebZzr7JQQ1slRLV2zKUeVaUkPnbGkBcesMz2cKlmeOrDO
+        kmFfrdrdgGnBkcpoBxoTh9xnPYhPUUgjIVIIcQUiDlk4rgRlNOQJmwQw8aNIBBUVSNa4Vq1+hnoD
+        dAxKqUxJjlV8x4sIqHdA8OG2YCky8FjyG8PhZquVYfwAomfb/Ww2Fvp9w5/HdExX/qQhbtcNlhRS
+        AbZnr4wHsDV1ns03i9uxytcYt+NoefHFXxRXime5zc+f87tlcfXAi/l6WVzKazkrM3le3+k8myVD
+        lGfDN98uihvzUuWm4RefH8pCvd78Fq2rYCFf/p/ROz1ExdcOI0QCXRkudY1MJdoxDvFspaS+t970
+        0bOgxH/lcXTF3+D5kLmG9/VG/N++raenHwZEbhrgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:17 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F094:9C873D7:5ED661C5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2768'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:17 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F0F7:9C87457:5ED661C5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2767'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkrhxk5ub6QHvTzlBmOn24uxePbCu2iG25kpw0ePju/a9k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+tf1bfFHkXy9uuff/lol1XLz
+        51328ebu959vr79/nmAyLwVmWmFsFJWblFtuhMUPi6Yoou7XUmDUKi1OCxmf0lzD/r+i1nLFLWgL
+        XhhxMlHrSujJvJ0UKpMVhBzAQBBpenEx/TSbXZ7vKb+5XV5tfsx+a/i3Ok+/Fqv47vvs5jrZ3Nxl
+        /2Iphzyuo0YXoOfW1mbOmB80H84yafMmbozQiaqsqOxZokrWsF7Yl9Xnj4BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9ouRVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmd/n3+czz7Np9MfmNPU6IE9PueS5tSNyR+dcv6BpiD9d7GC
+        T+hKPd0I2n9jUscJEGPyAfLLgJgf6CU9gkgKOP1e1L5Ol9X+3f4yDLaTq1LUqNP6x7mR9/g83amx
+        EtVUOB0MrrnFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kRizXhsyGSjiWu5lDsLqYbcdgv8I38Q
+        XkqtVdds9M2FLg+jbdh1PFNpeFyIYUDVouo0HG9DJqIyWzP4BgBteTR9xwTuSyoWvCls5N9K1E5F
+        TxYNVrij0CXMQD0vard2nRVvEHLVfo+UFf1nNFysKOvIe4dVS0H9WaCQVdQ6Mv80HK7nLrB+sf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFH7BvE47bQe5+4id/7xO994vc+se+00/V3oE9cCbtGw3SU
+        TcfP2z5bP/wHe6wroBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:17 GMT
+      etag:
+      - W/"19b48c95825c6b392725646841445a28"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F159:9C874D0:5ED661C5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2766'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QS0/DMBCE/4vPJM7DNThSD0gFREWUS4FShCIn3jyqJI7iTaVQ9b+zcObAgctc
+        dmb3m30/swkqlnyr46hrx08wudYOXugH7IoN1kDeGnKkm1Q+9y99enwT2eZxyXZ1lA3b7jCkJ/Nw
+        P5SLig777ad+VfPT7m5Ob9drWjBPHYUbxNElnOux9esWm7nwS9vzCUbreA+oHdoJvK4tPASHhEKa
+        5/1iNM0AOYXI/TujLY5QIkvOzDWajgm5MkbGlREiCIRUEuJQKhXdBKuiMKoysdDRdSiJDpcRKEHF
+        /xf155N/5rhcPr4AWAxmd4kBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:18 GMT
+      etag:
+      - W/"c2d4ec1bc7242797498c2a0c269a3d5e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F1CE:9C8755D:5ED661C5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2765'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/465dd63fd44004696e316992805bbd9fd34a2716
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61SbYucMBD+K0s+6xpjdM+FQgu25Qq6XCs9dr8sUScazzeSeFc59r/fhP0DLRRC
+        knl5nnlmmHcyzQ1cVUOOJM/y5Pf3b1Pen/kpe9xOZctO/RMrnn++FH0xXrInmmdfaNG/sEuZ/8E3
+        zvv2rXj+oS7ZgPGcnsvHKC/Pn4hHTCeQlCdx0ySRbDinlCdpAlGYpCl7oHFVNalsIi7YIUwQsOoB
+        AZ21izkGgVjUvlW2W6t9PY+BhmU2wQhWGDtr8AdV+RaMNYG7r9dxawTGwAYICqxoTfAPpTG/BU2O
+        72QSI6CKX53ohN59fdXzhNJgFMqJw57QvQfn/tw6pxOHCVjcwRhl1KeJT1kZ8iM7HEN2ITePzFUP
+        tXX896nEPI2lfACOJ5IJFzysZSpS3hwEi4DROJZRnUpkttvimLHMqOz/ndKd0wR/rQY7wUmhmlfQ
+        Rs2TH+4pShrBGNE6lfm2m+AN9K4Ca/Fx2Z7LVlLVwiLEzeBuA+6cFIMBj2gQxoXIOhnVThjB9cGP
+        sKtG2mkdBo8sYhtmgSBn3m4fqfkaILoCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:18 GMT
+      etag:
+      - W/"13513a1f7d012f4d90ce6f7a474b2c49"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F29A:9C8763E:5ED661C6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2764'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:18 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F2F2:9C876BB:5ED661C6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2763'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkrhxk5ub6QHvTzlBmOn24uxePbCu2iG25kpw0ePju/a9k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+tf1bfFHkXy9uuff/lol1XLz
+        51328ebu959vr79/nmAyLwVmWmFsFJWblFtuhMUPi6Yoou7XUmDUKi1OCxmf0lzD/r+i1nLFLWgL
+        XhhxMlHrSujJvJ0UKpMVhBzAQBBpenEx/TSbXZ7vKb+5XV5tfsx+a/i3Ok+/Fqv47vvs5jrZ3Nxl
+        /2Iphzyuo0YXoOfW1mbOmB80H84yafMmbozQiaqsqOxZokrWsF7Yl9Xnj4BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9ouRVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmd/n3+czz7Np9MfmNPU6IE9PueS5tSNyR+dcv6BpiD9d7GC
+        T+hKPd0I2n9jUscJEGPyAfLLgJgf6CU9gkgKOP1e1L5Ol9X+3f4yDLaTq1LUqNP6x7mR9/g83amx
+        EtVUOB0MrrnFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kRizXhsyGSjiWu5lDsLqYbcdgv8I38Q
+        XkqtVdds9M2FLg+jbdh1PFNpeFyIYUDVouo0HG9DJqIyWzP4BgBteTR9xwTuSyoWvCls5N9K1E5F
+        TxYNVrij0CXMQD0vard2nRVvEHLVfo+UFf1nNFysKOvIe4dVS0H9WaCQVdQ6Mv80HK7nLrB+sf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFH7BvE47bQe5+4id/7xO994vc+se+00/V3oE9cCbtGw3SU
+        TcfP2z5bP/wHe6wroBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:19 GMT
+      etag:
+      - W/"19b48c95825c6b392725646841445a28"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F362:9C87744:5ED661C6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2762'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXYvbMBD8K0HPSazIsh0bCn3IFe4hNr3m7khKCWt7Fcvnj2DJByHkv3dF2tK+
+        5SAFS1i7Xs3O7OAzMxWwhAUyDpRaoqTHV6EEuShUDLEsIxA+Ch4Eyi9ixaas60vc65KK1qtt+FXE
+        Nn9t+Lreymz1eMo2B5HVzzzbvLS7umrSlVtpm9ZPVbr6Uu/qpso2T2+peDitxfNpvXpe7Oq0zl63
+        n+jycWjo4srao0k8D456ftC2GvN50bfegMfeeC1aMLYfcNbofGbRWOO5fb9vTyVQDq1HRR5VtJpy
+        H6BW2bbZ/9vCX/C3AF9BP4IJo636gSVn1kGLRP5bBRUMk4f3oe9IEWxBO01oThSeowt/Prig04Q+
+        IM6uTHDBZzyccbFZyERECZc7dpmya0cW/yOEHZA6OP+yUhThMvSlkn7O/UKpMC5lJIOC5xghKl/k
+        WEAeBvedtuvBeDdjkzAtGgMHJ91jp62GZuLcc4TijaKTq2zU4xEG7Kxhyfc/BMsglv5SEp9FGfl5
+        gDyKSh5xTpwhXAYqCMPAX9yX4G87R7ej383ON2NefkzZOw5a6QKsJv+SK65npB+GgsbglA0IxqXY
+        2Bl96CgzZe4F7DjQOLqxaZzsp6YHKnLHy+Une/GmhqgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:19 GMT
+      etag:
+      - W/"1f1f077d6f80f65634e6577ea9f8a992"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F409:9C877D9:5ED661C7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2761'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=5495ff8e48e43f64a41cf9a94d7a23e2055f3c9f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5ET/1VglMZsxYG2rHtRJxSCbJ1spbJkLKUhK/3uO7eBdule
+        ZN0YA1kcOuueH3ePHj3NWvCmHmeOday6ZzWM1tZo78TrmGt+nbENw0QKSVpxynhCgU4mQemncTRO
+        4ohziCGJfOrTtIx9LGXldxSh8Ym36RVebZzr7JQQ1slRLV2zKUeVaUkPnbGkBcesMz2cKlmeOrDO
+        kmFfrdrdgGnBkcpoBxoTh9xnPYhPUUgjIVIIcQUiDlk4rgRlNOQJmwQw8aNIBBUVSNa4Vq1+hnoD
+        dAxKqUxJjlV8x4sIqHdA8OG2YCky8FjyG8PhZquVYfwAomfb/Ww2Fvp9w5/HdExX/qQhbtcNlhRS
+        AbZnr4wHsDV1ns03i9uxytcYt+NoefHFXxRXime5zc+f87tlcfXAi/l6WVzKazkrM3le3+k8myVD
+        lGfDN98uihvzUuWm4RefH8pCvd78Fq2rYCFf/p/ROz1ExdcOI0QCXRkudY1MJdoxDvFspaS+t970
+        0bOgxH/lcXTF3+D5kLmG9/VG/N++raenHwZEbhrgBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:19 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:04 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F463:9C87878:5ED661C7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2760'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:19 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F4D5:9C878F5:5ED661C7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2759'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkrhxk5ub6QHvTzlBmOn24uxePbCu2iG25kpw0ePju/a9k
+        x04aIIAeeYFEkX67Wu2uVttOZDqZzy4uL2ezq8uLk0mlUhHR2OTm+tf1bfFHkXy9uuff/lol1XLz
+        51328ebu959vr79/nmAyLwVmWmFsFJWblFtuhMUPi6Yoou7XUmDUKi1OCxmf0lzD/r+i1nLFLWgL
+        XhhxMlHrSujJvJ0UKpMVhBzAQBBpenEx/TSbXZ7vKb+5XV5tfsx+a/i3Ok+/Fqv47vvs5jrZ3Nxl
+        /2Iphzyuo0YXoOfW1mbOmB80H84yafMmbozQiaqsqOxZokrWsF7Yl9Xnj4BkusM4k2FgD1fLjuSX
+        A2fY4Z3ktiz2lPE6uJWH1yxUUag1mPu7OFIs2wLozBxMVtnbYAC0TNlcwLTY7gMZSeLMX0t1i1tG
+        /+CXhDM4Ni3S1wK75VCSXOyhZVrUynGb2CRa1laq6tXq7kAAVTrjlbznb4ICYsAiRV+tmFsMiFjB
+        mV9N8atb5sI12ZDZtEiEXOE83kbewwBsNzVll9uRBemUpBURT0tKCi5XPJwgel8YOwcSUCq2hz+Z
+        V8hfFBF6uU1ITwa2M+6hID0giKjP2P9oHAIYMFhlKTbBmMRqGf528ZYgMfBYaY4kHkzIDrRl46/k
+        VFbwMpgsBwM0Vyqc5R0MUGlMI47y/eNP1TEN64OtasrYZ9JjQux4MZ6GPXBjZFYJEcziW2DL+ksg
+        1rxK8nAiel7L/CfnNTwLtgViARkXKg7GxIXOHLBlJuf+arRRSK1JAvF2BGixCLoF4m0FWB3Qb5z6
+        BNzicVtbuFAw/Xsea7sTKHiVNTwLJ2ELpMsKpUrG75+t0I6P2YEIPJWmWsZN2MQ8MGkHvihC/gl3
+        BANyEOCqrqdLuhcYaVTJOTOVpXyu5jme3uF2QiywCIqDfTH0/fnS7WXbIF7LhvvFX2adpFCn0d1m
+        vf5jed3bKphr9TzW/lRzm1OGhdiaaxFqMx2OtTGeug9nZ2dtLrh7lpRCB8wingYs10mO8jqU/m3P
+        Q+VYcuuePwtSP8VzqFA8DXYWWyDg3gVC7cHTxn5Uo14PpriDjemlLNC1UFW4O2IgjuVUysqFTI55
+        Kx4f5jvQ9ouRVSJOOJ43iAorE4k4wZOdPABFvghnRU/D9tAj8s/EQiBkgp2SFp7XMt8VSEVdqE3Q
+        DDlCUiLRAg2qNOIWj9LZdDY9nV6cTmd/n3+czz7Np9MfmNPU6IE9PueS5tSNyR+dcv6BpiD9d7GC
+        T+hKPd0I2n9jUscJEGPyAfLLgJgf6CU9gkgKOP1e1L5Ol9X+3f4yDLaTq1LUqNP6x7mR9/g83amx
+        EtVUOB0MrrnFYwM1yzDU12U9IOcm8plkMre6Qc+RRmqt7kRizXhsyGSjiWu5lDsLqYbcdgv8I38Q
+        XkqtVdds9M2FLg+jbdh1PFNpeFyIYUDVouo0HG9DJqIyWzP4BgBteTR9xwTuSyoWvCls5N9K1E5F
+        TxYNVrij0CXMQD0vard2nRVvEHLVfo+UFf1nNFysKOvIe4dVS0H9WaCQVdQ6Mv80HK7nLrB+sf/F
+        DWErVI3t/qIFXae7a1IEOFo9XuMIxWFH7BvE47bQe5+4id/7xO994vc+se+00/V3oE9cCbtGw3SU
+        TcfP2z5bP/wHe6wroBUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:27:20 GMT
+      etag:
+      - W/"19b48c95825c6b392725646841445a28"
+      last-modified:
+      - Tue, 02 Jun 2020 14:27:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F540:9C87978:5ED661C7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2758'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:27:20 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C9AB:160FF:839F5B8:9C87A02:5ED661C8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '2757'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_existing_name.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_existing_name.yaml
@@ -1,0 +1,5796 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:05 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FF37F:C7E8F46:5ED66105
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3132'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:06 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FF406:C7E8FB3:5ED66105
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3131'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822309,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjIzMDk=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:24:06Z","updated_at":"2020-06-02T14:24:06Z","pushed_at":"2020-06-02T14:24:07Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:07 GMT
+      etag:
+      - '"0399008cfb4a204b07318123ed1489e6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FF4C0:C7E9091:5ED66106
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3130'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad","node_id":"MDY6Q29tbWl0MjY4ODIyMzA5OjE0YWUzYjc3Y2E5ZmJhMzk3YWEyY2YzMmI2OTJmZjRkZDA3MWUxYWQ=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:08Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:08Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:08 GMT
+      etag:
+      - '"eb6311d7a8b1883ac1faccb082d4af2d"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FF87A:C7E94D1:5ED66107
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3129'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XW2/aMBT+K1WeaROSQACp2iq1D61Eq27tWDpNyElOiKljZ7bDBqj/fccmvcBD
+        R6rurS8osXO+8537Ye1wUoIzckqiNEin46SiLKl2RmtHFQQvuiGBIImilAzzhATDiBA/zQM/6Q/9
+        PA+zzIu60CUZinKRwZRmKDQ+jfvX/lAnE+aN53F4dXq+HK9OelfzMy+e3K7ieRrE/lnvrrwoxqv7
+        IJ6cLWM/Xo3Lc//q5qK8m3+5vzs9CcaT2z/x5Pp4ixepdSGkYdhw/1qQgsiDs4UUHL+EklCGJJA/
+        Hh+BOf48M4dHaBx+kBFtTPY93zv0+oeef9MNR3448gZ3zsOjB4w3/puKEpQiM0PinFNNCaMrOEBa
+        5EBCJRTVQi6RqJaA3zxFIveGWe4HUTTww6gb9gaQ+f6QREkSDtIIbwZZFICHgrU0Dii0rtTIdUlF
+        j2ZUF3ViHOBaFW4JGkMuJBwymhxqUFq55nc6LZeGiQLtopBrOCi3u69u9N87Kt8kI6rfPwmNCHA9
+        TUXNMY29jrMASXOaEk0xPdCbm3fAPM0JU9BxJBBlrpyaKzrjeNNxzAPRtUT/85qxjlORJROY5vb1
+        4f3MfIOJhS7ZdNvLL8K7T2A3St/gVrWj982p1dZst4mrwtg8NwAmZtQEThW2yvHOtJ9+r9cPttvR
+        df/b90uWzuPu5U28MhgLzHG5a409VH5TLbUCmQquMZ1s4dSuRf60OA4RYSYbDNvx/lV0Bku5zzxf
+        j+Hzd7lgTPxG2V2q2zW9Be8+CSGrzTPls/YAKLR2hS4A/YT0H4zRFPtEGyQrsMZOgp2FZgZCoYsl
+        ZG1AGhEk85sjj7VtYRarTlQqaWVKuxWtLUEEEnJGOF3ZHtEKCAVNStqe2sYkK4CCsMDsaiW5kVi7
+        laQLki6NGySkQBfo0/ZoO6IIppeVGUy3GHHjYaphSrLSlJltl7sD8qMEm7H6UYLtKuejBDdDC5vZ
+        VvXuVYIVkaZvOKMfP7Egp4zye3zBTRFY/h6bXyIJTwtc/J7+F5iB9QK55cJhtshHLCRcSaEh1S92
+        sOakWdGAk4RtbWi/amqGBk4CXaspUks3BgPPhUzBrnwM25/hKPIcnWgn95/GR886UcPrfXr/9XjH
+        SdiRrVXGhoe/+SYiilkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:09 GMT
+      etag:
+      - W/"9777bf57014e9ec4661c0d545fcc7452"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FFA60:C7E972A:5ED66108
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3128'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:09 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FFAE2:C7E97C3:5ED66109
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3127'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTUWujQBD+K2GfTdTVxCgcXCF5SEFC71qCKUcYdYybuhp213Ia8t8723BwfWvh
+        7kV253Pm++ab2QvTNbCE+SFgkEdRAXGVQxBHALyoAp4vYl5VYVl6kY8+lMxhbVfiQZSUlK6yxQOP
+        Tb5rvPSUhdvVZkjHu/n2tPay3dOYnYog4+v5Xt7X6fgSZLv1kPFsTOWGbx/v5f7042W/ugvS3dPv
+        bPfwjYr3qqHCtTFnnbgunMXsKEzd57Oik67Cc6ddiQa06RROG5FPDWqjXfs9HORQAmFoXEpyKUMK
+        wr7QWm1kc/go4S/6zxDfSL/CCb2pO8WSC2tBIjX/s4Ya1GT9qrqWHEEJwnpCc6LwDG34+9EGrSf0
+        A/Vs07jHvam3mHr80Q8THibecs+uDrspMvgfKYxCUnD5s0qVF5cVD6JoycPID+dLLDmPIcrzcFlE
+        hCzLKEDv307baqBZf5abjJGoNRytdZtWGAGNGHFiF2jyvmeCVmwgjWdQ2BrNkudfDntFJSpRgBE0
+        G+r4dkd6DBU0Gh2mELSFWN9qcWwJcZg9gOkVUbV909iSQ9PRW3q/Xq9vAh/L4YQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:09 GMT
+      etag:
+      - W/"4194c61fc10a793ba0c48e905c59bf7d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FFBEA:C7E98D7:5ED66109
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3126'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"125154d508c37f7e1243733ff41a6708380136be","node_id":"MDY6Q29tbWl0MjY4ODIyMzA5OjEyNTE1NGQ1MDhjMzdmN2UxMjQzNzMzZmY0MWE2NzA4MzgwMTM2YmU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/125154d508c37f7e1243733ff41a6708380136be","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:10Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:10Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/14ae3b77ca9fba397aa2cf32b692ff4dd071e1ad"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      etag:
+      - '"6ebebefa8b45ea7cf35f7082c7a94629"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FFC7E:C7E99A6:5ED66109
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3125'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vngpuPEiUbEipQyWJqqrJE5/jcGMVJZB9IAfHfe6hjlw5d3uW9
+        597nJgJaUT0yyg7BROkhEgbxJIbRYOMMt2qjVu++9ur0mR82+1ld1y+H4a0/DuoC27o77tRFf7xe
+        zbaeGTyHnqGOaIqVlDC55Zej7qyX7ehlwGnkESSeGQMueqcXhJGifGTT+NkAd0iSIb7+7TXqE7Yk
+        qpuIHfBQkgNmuihaKK2GrCwA0tZmqV6VqbW5Mc9FggkYNqN5QibYwzv6X9Ofn1H+2eZ+/wbGRtgT
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      etag:
+      - W/"f205494216efec69d50e04f5bbbe9ec8"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:08 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FFDD6:C7E9B29:5ED6610A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3124'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "125154d508c37f7e1243733ff41a6708380136be"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghOcL2VDQqWtZDE1VVkiJ36pjeI4sh9IAfHf+1DHLh263OW+
+        8+65sQADqx8ZuQGlI3cqIgT2xCavobWaWrmTxbtrnDx9Zofd6yKv2/wwvY3HSV7UvjHHF3npPp6v
+        et8sBJ7DSJBBnGPNuZrt+suiOXfr3jseYPY0AkgzPsBqtN0KIWLkj2xbt2hFHSAniK5/e/nuBD2y
+        +saiUTSUbvI0z3SeVL0ohxLSTSZKIYYhS1VRJpWoklQUHZAZLjMQQR7O4v+a/vyM/M829/s3rDnE
+        OX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:11 GMT
+      etag:
+      - W/"dfeb85185bc96e5810e5594a9126f12a"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A7FFE6E:C7E9BE7:5ED6610A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3123'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:11 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80000F:C7E9DE3:5ED6610B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3122'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdKsgcX2kHbRAmmAoofdvQiUREuMJVElKbuOkHfvP6Rk
+        ya43cRwec0lsmvxmOJwZDqedyHQyn13f3MxmH6YfzyaVSkVEY5O721/X98UfRfLl4yP/+tcqqZab
+        Px+yq7uH3x/vbpefJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNew/6+otVxxC9qC
+        F0acTdS6EnoybyeFymQFIQcwEESaXl9Pf57Nbi73lN/cLz9uvs9+a/jXOk+/FKv44dvs7jbZ3D1k
+        /2Iphzyuo0YXoOfW1mbOmB80Hy4yafMmbozQiaqsqOxFokrWsF7Y59WnK0Ay3WGcyTCwh6tlR/LL
+        gTPs8E5yWxZ7yngd3MrDaxaqKNQazP1dHCmWbQF0Zg4mq+xtMABapmwuYFps94mMJHHmp1Ld4pbR
+        P/gl4QyOTYv0VGC3HEqSiz21TItaOW4Tm0TL2kpVnazuDgRQpTNeyUf+JiggBixS9GTF3GJAxArO
+        fDLFr26ZC9dkQ2bTIhFyhfN4G3kPA7Dd1JRd7kcWpFOSVkQ8LSkpuFzxdIbofWXsHEhAqdge/mRe
+        IX9RROjlNiE9G9jOuIeC9IAgor5g/6NxCGDAYJWl2ARjEqtl+NvFW4LEwGOlOZJ4MCE70JaNv5JT
+        WcHLYLIcDNBcqXCWdzBApTGNOMr3jz9VxzSsD7aqKWOfSY8JsePFeBr2wI2RWSVEMItvgS3rL4FY
+        8yrJw4noeS3zn5zX8CzYFogFZFyoOBgTFzpzwJaZnPur0UYhtSYJxNsRoMUi6BaItxVgdUC/ceoT
+        cIvHbW3hQsH073ms7U6g4FXW8CychC2QLiuUKhl/fLFCOz5mByLwVJpqGTdhE/PApB34ogj5J9wR
+        DMhBgKu6ni/pXmGkUSXnzFSW8qWa53h6h9sJscAiKA72xdD3l0u3122DeC0b7hd/mXWSQp1Gd5v1
+        +o/ldW+rYK7V81j7U81tThkWYmuuRajNdDjWxnjqPl1cXLS54O5ZUgodMIt4GrBcJznK61D6tz0P
+        lWPJrXv+LEj9FM+hQvE02FlsgYB7Fwi1B08b+1GNej2Y4g42ppeyQNdCVeHuiIE4llMpKxcyOeat
+        eHyY70Dbz0ZWiTjjeN4gKqxMJOIET3byABT5IpwVPQ3bQ4/IPxMLgZAJdkpaeF7LfFcgFXWhNkEz
+        5AhJiUQLNKjSiFs8SmfT2fR8en0+nf19eTWfXc2n198xp6nRA/vhnMtLmlM3Jn9hCtJ/Fyv4hK7U
+        842g/TcmdZwgx5h8gPwyIOYHekk/QCQFnH4vak/TZbV/t78Og+3kqhQ16rT+cW7kIz5Pd2qsRDUV
+        TgeDa27x2EDNMgz1dVkPyLmJfCaZzK1u0HOkkVqrB5FYMx4bMtlo4lou5c5CqiG33QL/yB+El1Jr
+        1TUbfXOhy8NoG3Ydz1QaHhdiGFC1qDoNx9uQiajM1gy+AUBbHk3fMYH7kooFbwob+bcStVPRk0WD
+        Fe4odAkzUM+L2q1dZ8UbhFy13yNlRf8ZDRcryjry3mHVUlB/FihkFbWOzD8Nh+u5C6xf7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgR+wbxuC303idu4vc+8Xuf+L1P7DvtdP0d6BNXwq7RMB1l0/Hz
+        ts/WT/8BygD70xUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:12 GMT
+      etag:
+      - W/"08a47f2622cdefb9e32342a40f7a16cd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8000AD:C7E9E9B:5ED6610B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3121'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:12 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80014B:C7E9F4D:5ED6610C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3120'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdKsgcX2kHbRAmmAoofdvQiUREuMJVElKbuOkHfvP6Rk
+        ya43cRwec0lsmvxmOJwZDqedyHQyn13f3MxmH6YfzyaVSkVEY5O721/X98UfRfLl4yP/+tcqqZab
+        Px+yq7uH3x/vbpefJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNew/6+otVxxC9qC
+        F0acTdS6EnoybyeFymQFIQcwEESaXl9Pf57Nbi73lN/cLz9uvs9+a/jXOk+/FKv44dvs7jbZ3D1k
+        /2Iphzyuo0YXoOfW1mbOmB80Hy4yafMmbozQiaqsqOxFokrWsF7Y59WnK0Ay3WGcyTCwh6tlR/LL
+        gTPs8E5yWxZ7yngd3MrDaxaqKNQazP1dHCmWbQF0Zg4mq+xtMABapmwuYFps94mMJHHmp1Ld4pbR
+        P/gl4QyOTYv0VGC3HEqSiz21TItaOW4Tm0TL2kpVnazuDgRQpTNeyUf+JiggBixS9GTF3GJAxArO
+        fDLFr26ZC9dkQ2bTIhFyhfN4G3kPA7Dd1JRd7kcWpFOSVkQ8LSkpuFzxdIbofWXsHEhAqdge/mRe
+        IX9RROjlNiE9G9jOuIeC9IAgor5g/6NxCGDAYJWl2ARjEqtl+NvFW4LEwGOlOZJ4MCE70JaNv5JT
+        WcHLYLIcDNBcqXCWdzBApTGNOMr3jz9VxzSsD7aqKWOfSY8JsePFeBr2wI2RWSVEMItvgS3rL4FY
+        8yrJw4noeS3zn5zX8CzYFogFZFyoOBgTFzpzwJaZnPur0UYhtSYJxNsRoMUi6BaItxVgdUC/ceoT
+        cIvHbW3hQsH073ms7U6g4FXW8CychC2QLiuUKhl/fLFCOz5mByLwVJpqGTdhE/PApB34ogj5J9wR
+        DMhBgKu6ni/pXmGkUSXnzFSW8qWa53h6h9sJscAiKA72xdD3l0u3122DeC0b7hd/mXWSQp1Gd5v1
+        +o/ldW+rYK7V81j7U81tThkWYmuuRajNdDjWxnjqPl1cXLS54O5ZUgodMIt4GrBcJznK61D6tz0P
+        lWPJrXv+LEj9FM+hQvE02FlsgYB7Fwi1B08b+1GNej2Y4g42ppeyQNdCVeHuiIE4llMpKxcyOeat
+        eHyY70Dbz0ZWiTjjeN4gKqxMJOIET3byABT5IpwVPQ3bQ4/IPxMLgZAJdkpaeF7LfFcgFXWhNkEz
+        5AhJiUQLNKjSiFs8SmfT2fR8en0+nf19eTWfXc2n198xp6nRA/vhnMtLmlM3Jn9hCtJ/Fyv4hK7U
+        842g/TcmdZwgx5h8gPwyIOYHekk/QCQFnH4vak/TZbV/t78Og+3kqhQ16rT+cW7kIz5Pd2qsRDUV
+        TgeDa27x2EDNMgz1dVkPyLmJfCaZzK1u0HOkkVqrB5FYMx4bMtlo4lou5c5CqiG33QL/yB+El1Jr
+        1TUbfXOhy8NoG3Ydz1QaHhdiGFC1qDoNx9uQiajM1gy+AUBbHk3fMYH7kooFbwob+bcStVPRk0WD
+        Fe4odAkzUM+L2q1dZ8UbhFy13yNlRf8ZDRcryjry3mHVUlB/FihkFbWOzD8Nh+u5C6xf7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgR+wbxuC303idu4vc+8Xuf+L1P7DvtdP0d6BNXwq7RMB1l0/Hz
+        ts/WT/8BygD70xUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:12 GMT
+      etag:
+      - W/"08a47f2622cdefb9e32342a40f7a16cd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:11 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8001CB:C7E9FDE:5ED6610C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3119'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJNbNVmIodCGh7IOzhGZZsqWEsT2OlfoSLHnbeMm/r9S0pX3L
+        QvpipBmNzpwzx3olpgQSE8ZDFso8pLNMqEIh41IoIYpCMogUnYkZZSJKkYxJ0+a407krShbbaM3n
+        Nn2qaHLYyofF/SkZ7sKHw/K02izZ6tOaJYvykAx5veKPP5LDelgNyfBcb2nytOSr4U4mw/57skn4
+        tn784C7vu8pdXFp7NHEQwFFP99qWfTrN2jro8NiaoEYLxrYdTiqdTiwaawL/3e3qUw4uhzZwRYGr
+        qLXLvYNaaetq928Lf8FfA3wBfQ8m9LZsOxK/kgZqdOQ/l1BCN1q+dG3jFMEatNfEzcmFp+jDH/c+
+        6DVxBxxnX8YppxMaTSjfMBlzGTP6TM5jcunI4n+EsB26Dl5/WUkpnEVCFlKkVGRFEc1zqWSY0RQV
+        YiF4ihmkUXjbafseTHA1thOmRmNg76W7b7TVUI28e46QfXPR0UU21+MROmysIfGX3wSZBBSpUhnM
+        ixTEXAHwzPOK5tz9MHlOFUMG+W0J/rHz9ei3s/O1mOevY/KCnS50BlY7/zpXXPboHowCKoNj0iEY
+        nyJ9Y/S+cZkx8QuwfefG0fRV5WU/Va3T8Of2fH4D2lBZdKgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:13 GMT
+      etag:
+      - W/"6ebebefa8b45ea7cf35f7082c7a94629"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800259:C7EA086:5ED6610C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3118'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T3U7jMBCF3yXXUCdNEyeVEKLRLkolQMtekFZIlR1PEhfHjmKXqov67mtDJaBw
+        UX602gtbI48959PM8YMnSQve2GPEkI6Ud6SGwVIr6R15HTHN+xndEJtIACclSwnDKaTDYUj9JI4C
+        HEeMQQw48lM/TWjs21Ka/7EiaXzkrXphnzbGdHqMEOn4oOamWdFBqVrUQ6c0asEQbVQPx4LTYwPa
+        aOT2xaLdOEwNBpVKGpA2sc992kN1EgyjIBqxyE/KEFcYguEoxGFYVaOAxNhPwsQPwpiCJWtMKxav
+        oV4AHYJChaLoUMU3vBbB6u0RfLotthRyPBp9YDhMraVQhO1B9GS9m81KQ79r+OOYDunKVxpiNp2z
+        ZMWFm9BO2R7AWtV5Nl3NbgKRL23cBtH8/Kc/Ky4Fy3Kdnz3mN/Pi8p4V0+W8uOBXfEIzflbfyjyb
+        YBflmVvT9ay4Vk9Vrht2/uOeFuL55e9oWYYz/nR/kt5KFxW/OhtZJJClYlzWlolaO8Yje7YQXN5p
+        b/zgaRDVf+Vx64rv4PmUudz/eiH+b//WdvsXIKHTJuAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:13 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8002D5:C7EA11D:5ED6610D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3117'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "125154d508c37f7e1243733ff41a6708380136be"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMzA5OjQxNmY1NzBlOWEzZTE3NjAyYjk0OTFlZTk1NWFiYThlZTljZGJjY2M=","sha":"416f570e9a3e17602b9491ee955aba8ee9cdbccc","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/416f570e9a3e17602b9491ee955aba8ee9cdbccc","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:13Z"},"object":{"sha":"125154d508c37f7e1243733ff41a6708380136be","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:13 GMT
+      etag:
+      - '"f60b7c29716d8c77c19caed1c1435660"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/416f570e9a3e17602b9491ee955aba8ee9cdbccc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800356:C7EA1AB:5ED6610D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3116'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "416f570e9a3e17602b9491ee955aba8ee9cdbccc", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyMzA5OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"416f570e9a3e17602b9491ee955aba8ee9cdbccc","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/416f570e9a3e17602b9491ee955aba8ee9cdbccc"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      etag:
+      - '"dba6e1f7c17a491c6d3dfff78f19abaa"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800440:C7EA2C8:5ED6610D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3115'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8005B1:C7EA488:5ED6610E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3114'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdKsgcX2kHbRAmmAoofdvQiUREuMJVElKbuOkHfvP6Rk
+        ya43cRwec0lsmvxmOJwZDqedyHQyn13f3MxmH6YfzyaVSkVEY5O721/X98UfRfLl4yP/+tcqqZab
+        Px+yq7uH3x/vbpefJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNew/6+otVxxC9qC
+        F0acTdS6EnoybyeFymQFIQcwEESaXl9Pf57Nbi73lN/cLz9uvs9+a/jXOk+/FKv44dvs7jbZ3D1k
+        /2Iphzyuo0YXoOfW1mbOmB80Hy4yafMmbozQiaqsqOxFokrWsF7Y59WnK0Ay3WGcyTCwh6tlR/LL
+        gTPs8E5yWxZ7yngd3MrDaxaqKNQazP1dHCmWbQF0Zg4mq+xtMABapmwuYFps94mMJHHmp1Ld4pbR
+        P/gl4QyOTYv0VGC3HEqSiz21TItaOW4Tm0TL2kpVnazuDgRQpTNeyUf+JiggBixS9GTF3GJAxArO
+        fDLFr26ZC9dkQ2bTIhFyhfN4G3kPA7Dd1JRd7kcWpFOSVkQ8LSkpuFzxdIbofWXsHEhAqdge/mRe
+        IX9RROjlNiE9G9jOuIeC9IAgor5g/6NxCGDAYJWl2ARjEqtl+NvFW4LEwGOlOZJ4MCE70JaNv5JT
+        WcHLYLIcDNBcqXCWdzBApTGNOMr3jz9VxzSsD7aqKWOfSY8JsePFeBr2wI2RWSVEMItvgS3rL4FY
+        8yrJw4noeS3zn5zX8CzYFogFZFyoOBgTFzpzwJaZnPur0UYhtSYJxNsRoMUi6BaItxVgdUC/ceoT
+        cIvHbW3hQsH073ms7U6g4FXW8CychC2QLiuUKhl/fLFCOz5mByLwVJpqGTdhE/PApB34ogj5J9wR
+        DMhBgKu6ni/pXmGkUSXnzFSW8qWa53h6h9sJscAiKA72xdD3l0u3122DeC0b7hd/mXWSQp1Gd5v1
+        +o/ldW+rYK7V81j7U81tThkWYmuuRajNdDjWxnjqPl1cXLS54O5ZUgodMIt4GrBcJznK61D6tz0P
+        lWPJrXv+LEj9FM+hQvE02FlsgYB7Fwi1B08b+1GNej2Y4g42ppeyQNdCVeHuiIE4llMpKxcyOeat
+        eHyY70Dbz0ZWiTjjeN4gKqxMJOIET3byABT5IpwVPQ3bQ4/IPxMLgZAJdkpaeF7LfFcgFXWhNkEz
+        5AhJiUQLNKjSiFs8SmfT2fR8en0+nf19eTWfXc2n198xp6nRA/vhnMsrmlM3Jn9hCtJ/Fyv4hK7U
+        842g/TcmdZwgx5h8gPwyIOYHekk/QCQFnH4vak/TZbV/t78Og+3kqhQ16rT+cW7kIz5Pd2qsRDUV
+        TgeDa27x2EDNMgz1dVkPyLmJfCaZzK1u0HOkkVqrB5FYMx4bMtlo4lou5c5CqiG33QL/yB+El1Jr
+        1TUbfXOhy8NoG3Ydz1QaHhdiGFC1qDoNx9uQiajM1gy+AUBbHk3fMYH7kooFbwob+bcStVPRk0WD
+        Fe4odAkzUM+L2q1dZ8UbhFy13yNlRf8ZDRcryjry3mHVUlB/FihkFbWOzD8Nh+u5C6xf7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgR+wbxuC303idu4vc+8Xuf+L1P7DvtdP0d6BNXwq7RMB1l0/Hz
+        ts/WT/8BVp0KQhUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:15 GMT
+      etag:
+      - W/"d0dce6267eab13ff289407a4756bd515"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800627:C7EA522:5ED6610E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3113'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghOcL2VDQqWtZDE1VVkiJ36pjeI4sh9IAfHf+1DHLh263OW+
+        8+65sQADqx8ZuQGlI3cqIgT2xCavobWaWrmTxbtrnDx9Zofd6yKv2/wwvY3HSV7UvjHHF3npPp6v
+        et8sBJ7DSJBBnGPNuZrt+suiOXfr3jseYPY0AkgzPsBqtN0KIWLkj2xbt2hFHSAniK5/e/nuBD2y
+        +saiUTSUbvI0z3SeVL0ohxLSTSZKIYYhS1VRJpWoklQUHZAZLjMQQR7O4v+a/vyM/M829/s3rDnE
+        OX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:15 GMT
+      etag:
+      - W/"dfeb85185bc96e5810e5594a9126f12a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8006AD:C7EA5B4:5ED6610F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3112'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJNbNVmIodCGh7IOzhGZZsqWEsT2OlfoSLHnbeMm/r9S0pX3L
+        QvpipBmNzpwzx3olpgQSE8ZDFso8pLNMqEIh41IoIYpCMogUnYkZZSJKkYxJ0+a407krShbbaM3n
+        Nn2qaHLYyofF/SkZ7sKHw/K02izZ6tOaJYvykAx5veKPP5LDelgNyfBcb2nytOSr4U4mw/57skn4
+        tn784C7vu8pdXFp7NHEQwFFP99qWfTrN2jro8NiaoEYLxrYdTiqdTiwaawL/3e3qUw4uhzZwRYGr
+        qLXLvYNaaetq928Lf8FfA3wBfQ8m9LZsOxK/kgZqdOQ/l1BCN1q+dG3jFMEatNfEzcmFp+jDH/c+
+        6DVxBxxnX8YppxMaTSjfMBlzGTP6TM5jcunI4n+EsB26Dl5/WUkpnEVCFlKkVGRFEc1zqWSY0RQV
+        YiF4ihmkUXjbafseTHA1thOmRmNg76W7b7TVUI28e46QfXPR0UU21+MROmysIfGX3wSZBBSpUhnM
+        ixTEXAHwzPOK5tz9MHlOFUMG+W0J/rHz9ei3s/O1mOevY/KCnS50BlY7/zpXXPboHowCKoNj0iEY
+        nyJ9Y/S+cZkx8QuwfefG0fRV5WU/Va3T8Of2fH4D2lBZdKgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:15 GMT
+      etag:
+      - W/"6ebebefa8b45ea7cf35f7082c7a94629"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80078E:C7EA6C7:5ED6610F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3111'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T3U7jMBCF3yXXUCdNEyeVEKLRLkolQMtekFZIlR1PEhfHjmKXqov67mtDJaBw
+        UX602gtbI48959PM8YMnSQve2GPEkI6Ud6SGwVIr6R15HTHN+xndEJtIACclSwnDKaTDYUj9JI4C
+        HEeMQQw48lM/TWjs21Ka/7EiaXzkrXphnzbGdHqMEOn4oOamWdFBqVrUQ6c0asEQbVQPx4LTYwPa
+        aOT2xaLdOEwNBpVKGpA2sc992kN1EgyjIBqxyE/KEFcYguEoxGFYVaOAxNhPwsQPwpiCJWtMKxav
+        oV4AHYJChaLoUMU3vBbB6u0RfLotthRyPBp9YDhMraVQhO1B9GS9m81KQ79r+OOYDunKVxpiNp2z
+        ZMWFm9BO2R7AWtV5Nl3NbgKRL23cBtH8/Kc/Ky4Fy3Kdnz3mN/Pi8p4V0+W8uOBXfEIzflbfyjyb
+        YBflmVvT9ay4Vk9Vrht2/uOeFuL55e9oWYYz/nR/kt5KFxW/OhtZJJClYlzWlolaO8Yje7YQXN5p
+        b/zgaRDVf+Vx64rv4PmUudz/eiH+b//WdvsXIKHTJuAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:15 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800823:C7EA762:5ED6610F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3110'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:16 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800898:C7EA808:5ED6610F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3109'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqHjDdKsgcX2kHbRAmmAoofdvQiUREuMJVElKbuOkHfvP6Rk
+        ya43cRwec0lsmvxmOJwZDqedyHQyn13f3MxmH6YfzyaVSkVEY5O721/X98UfRfLl4yP/+tcqqZab
+        Px+yq7uH3x/vbpefJpjMS4GZVhgbReUm5ZYbYfHDoimKqPu1FBi1SovzQsbnNNew/6+otVxxC9qC
+        F0acTdS6EnoybyeFymQFIQcwEESaXl9Pf57Nbi73lN/cLz9uvs9+a/jXOk+/FKv44dvs7jbZ3D1k
+        /2Iphzyuo0YXoOfW1mbOmB80Hy4yafMmbozQiaqsqOxFokrWsF7Y59WnK0Ay3WGcyTCwh6tlR/LL
+        gTPs8E5yWxZ7yngd3MrDaxaqKNQazP1dHCmWbQF0Zg4mq+xtMABapmwuYFps94mMJHHmp1Ld4pbR
+        P/gl4QyOTYv0VGC3HEqSiz21TItaOW4Tm0TL2kpVnazuDgRQpTNeyUf+JiggBixS9GTF3GJAxArO
+        fDLFr26ZC9dkQ2bTIhFyhfN4G3kPA7Dd1JRd7kcWpFOSVkQ8LSkpuFzxdIbofWXsHEhAqdge/mRe
+        IX9RROjlNiE9G9jOuIeC9IAgor5g/6NxCGDAYJWl2ARjEqtl+NvFW4LEwGOlOZJ4MCE70JaNv5JT
+        WcHLYLIcDNBcqXCWdzBApTGNOMr3jz9VxzSsD7aqKWOfSY8JsePFeBr2wI2RWSVEMItvgS3rL4FY
+        8yrJw4noeS3zn5zX8CzYFogFZFyoOBgTFzpzwJaZnPur0UYhtSYJxNsRoMUi6BaItxVgdUC/ceoT
+        cIvHbW3hQsH073ms7U6g4FXW8CychC2QLiuUKhl/fLFCOz5mByLwVJpqGTdhE/PApB34ogj5J9wR
+        DMhBgKu6ni/pXmGkUSXnzFSW8qWa53h6h9sJscAiKA72xdD3l0u3122DeC0b7hd/mXWSQp1Gd5v1
+        +o/ldW+rYK7V81j7U81tThkWYmuuRajNdDjWxnjqPl1cXLS54O5ZUgodMIt4GrBcJznK61D6tz0P
+        lWPJrXv+LEj9FM+hQvE02FlsgYB7Fwi1B08b+1GNej2Y4g42ppeyQNdCVeHuiIE4llMpKxcyOeat
+        eHyY70Dbz0ZWiTjjeN4gKqxMJOIET3byABT5IpwVPQ3bQ4/IPxMLgZAJdkpaeF7LfFcgFXWhNkEz
+        5AhJiUQLNKjSiFs8SmfT2fR8en0+nf19eTWfXc2n198xp6nRA/vhnMsrmlM3Jn9hCtJ/Fyv4hK7U
+        842g/TcmdZwgx5h8gPwyIOYHekk/QCQFnH4vak/TZbV/t78Og+3kqhQ16rT+cW7kIz5Pd2qsRDUV
+        TgeDa27x2EDNMgz1dVkPyLmJfCaZzK1u0HOkkVqrB5FYMx4bMtlo4lou5c5CqiG33QL/yB+El1Jr
+        1TUbfXOhy8NoG3Ydz1QaHhdiGFC1qDoNx9uQiajM1gy+AUBbHk3fMYH7kooFbwob+bcStVPRk0WD
+        Fe4odAkzUM+L2q1dZ8UbhFy13yNlRf8ZDRcryjry3mHVUlB/FihkFbWOzD8Nh+u5C6xf7H9xQ9gK
+        VWO7v2hB1+numhQBjlaP1zhCcdgR+wbxuC303idu4vc+8Xuf+L1P7DvtdP0d6BNXwq7RMB1l0/Hz
+        ts/WT/8BVp0KQhUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:16 GMT
+      etag:
+      - W/"d0dce6267eab13ff289407a4756bd515"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80090B:C7EA890:5ED66110
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3108'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X227TQBD9lcrPaX2N3URCgNQK8eCgihYICEXr9dje4Bu765Q4yr8z47iX5KHE
+        VXnrS5SsfWbPnLlmY5SsAGNqFExpkMbI4FVRCG1MN4bKGD6wnbE99uKxdc7dIAnAdjw3cN0k8Wzm
+        B9a5e27Zrh8BQssqhoWIERRezP0rZ6Kjr7kVLufep4uP67B9P/60vFzPri/t2YcrO7zIlmEbFzPn
+        5k+4vGpnbdh+L+ZW+PXSmbXvvbBNb8Pr0JkXN2/2eLFGZ5Ukhj33zxnLmDy5XMmqxDehYCJHEsgf
+        j8+Ajt+ldHiGzuELMdPksmM51qnln1rOte1NHW9qW9+N7Z0CpMZ/u6IApVhKJD6WQguWnyAnVjP+
+        C09P+hCMDC0B37mLRBDAue96iedGlsuTxJ/EXuCNuRVBAJC4TgScRf4YPWwkCZBpXaupabJanKVC
+        Z01EApgS6kqZBWgMeSXhNBfRqQallUmfi0WxJjIKtIkgkzgo8+i7Ub8XvHynhDIHJCFBoNQLXjUl
+        prE1MlYgRSI40wLTA9Xc/QbM04TlCkaGBKbokdGUSqQlPhkZ9IXpRqL+ZZPnI6Nm67xiCKKf25dz
+        8xkuZrrIF/sqPwrvMYHdXfoMWdXBvc9OraFum31cFcbmoQHkVSoocCrrqhyfUfvxx2Pf3W9HV/6X
+        b7OcL+f27Hreko0V5rg89KY7VE5fLY0CyatSYzp1hdOYneW3qzceWkhlb6PreP8qOrKlzAeeT8fw
+        4b2kyvPqFrGHVPdres+8eQ9CVrvvokyHG0DQxqx0BqgT0t+S0wL7xBBLHWCDnQQ7i4jJhEKJJcRD
+        jPQQJHNbIo9N18I6W02kuBQ1lfYgWntANFTJlJWi7XrEIEMIpJTseuoQlzoAAmGF2TUIuUNszFqK
+        FeNrkkECB7FCTYdbO4CiMb2uaTDdYMRJYaFhweKCyqxrl4cD8rUE+7H6WoLDKue1BHdDC5vZXvUe
+        VYI1k9Q3jOmP+z3dY+BGQcDZJImYOwkYczgthf7EwWU9jq3ABhsXmBdb0O5H+PE3Pz31hmwux965
+        /YkNa5GL8heKhVpBnrzEZhxJVvIMF+P7/03k2iPLAxcy2rLvbCHhWlYauH60o/Yn/QoLJYvyvQ32
+        dyNoqOKk1I1aIDW+cxjKpJIcupU4x/FAHKskwSzoNps/XQ79pH324Yan59jxfx8ORMKJ1XlFPmz/
+        AjsGlNt5DgAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:16 GMT
+      etag:
+      - W/"0f8e9d37e5b1627870eb7f18792d1f76"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80098F:C7EA929:5ED66110
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3107'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"type\": \"csv\", \n  \"name\":
+      \"mydataset\", \n  \"resources\": [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}",
+      "path": "datapackage.json", "type": "blob", "mode": "100644"}], "base_tree":
+      "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"bb60fd0882502093a750376d766d86a3d7872cf0","size":114,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/bb60fd0882502093a750376d766d86a3d7872cf0"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '678'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      etag:
+      - '"6c3ee073af17698a8dbbb8c91a11f856"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800A2D:C7EA9BC:5ED66110
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3106'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJNbNVmIodCGh7IOzhGZZsqWEsT2OlfoSLHnbeMm/r9S0pX3L
+        QvpipBmNzpwzx3olpgQSE8ZDFso8pLNMqEIh41IoIYpCMogUnYkZZSJKkYxJ0+a407krShbbaM3n
+        Nn2qaHLYyofF/SkZ7sKHw/K02izZ6tOaJYvykAx5veKPP5LDelgNyfBcb2nytOSr4U4mw/57skn4
+        tn784C7vu8pdXFp7NHEQwFFP99qWfTrN2jro8NiaoEYLxrYdTiqdTiwaawL/3e3qUw4uhzZwRYGr
+        qLXLvYNaaetq928Lf8FfA3wBfQ8m9LZsOxK/kgZqdOQ/l1BCN1q+dG3jFMEatNfEzcmFp+jDH/c+
+        6DVxBxxnX8YppxMaTSjfMBlzGTP6TM5jcunI4n+EsB26Dl5/WUkpnEVCFlKkVGRFEc1zqWSY0RQV
+        YiF4ihmkUXjbafseTHA1thOmRmNg76W7b7TVUI28e46QfXPR0UU21+MROmysIfGX3wSZBBSpUhnM
+        ixTEXAHwzPOK5tz9MHlOFUMG+W0J/rHz9ei3s/O1mOevY/KCnS50BlY7/zpXXPboHowCKoNj0iEY
+        nyJ9Y/S+cZkx8QuwfefG0fRV5WU/Va3T8Of2fH4D2lBZdKgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      etag:
+      - W/"6ebebefa8b45ea7cf35f7082c7a94629"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800AF2:C7EAAD4:5ED66111
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3105'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["125154d508c37f7e1243733ff41a6708380136be"],
+      "message": "Datapackage updated", "tree": "1a1cacdbc9d7556771d3205e5ee95857236b0312"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"39a5c0169062ab244e58cea81e312eebbba0c9b8","node_id":"MDY6Q29tbWl0MjY4ODIyMzA5OjM5YTVjMDE2OTA2MmFiMjQ0ZTU4Y2VhODFlMzEyZWViYmJhMGM5Yjg=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/39a5c0169062ab244e58cea81e312eebbba0c9b8","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/39a5c0169062ab244e58cea81e312eebbba0c9b8","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:17Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:17Z"},"tree":{"sha":"1a1cacdbc9d7556771d3205e5ee95857236b0312","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1a1cacdbc9d7556771d3205e5ee95857236b0312"},"message":"Datapackage
+        updated","parents":[{"sha":"125154d508c37f7e1243733ff41a6708380136be","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/125154d508c37f7e1243733ff41a6708380136be"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1185'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      etag:
+      - '"91d20f3c5f8c37396c4e794b8b126b67"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/39a5c0169062ab244e58cea81e312eebbba0c9b8
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800B5A:C7EAB4E:5ED66111
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3104'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBRF/4vnghOcL2VDQqWtZDE1VVkiJ36pjeI4sh9IAfHf+1DHLh263OW+
+        8+65sQADqx8ZuQGlI3cqIgT2xCavobWaWrmTxbtrnDx9Zofd6yKv2/wwvY3HSV7UvjHHF3npPp6v
+        et8sBJ7DSJBBnGPNuZrt+suiOXfr3jseYPY0AkgzPsBqtN0KIWLkj2xbt2hFHSAniK5/e/nuBD2y
+        +saiUTSUbvI0z3SeVL0ohxLSTSZKIYYhS1VRJpWoklQUHZAZLjMQQR7O4v+a/vyM/M829/s3rDnE
+        OX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:18 GMT
+      etag:
+      - W/"dfeb85185bc96e5810e5594a9126f12a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800C2B:C7EAC56:5ED66111
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3103'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "39a5c0169062ab244e58cea81e312eebbba0c9b8"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPU/DMBRF/4tnWidpEiXZkCoKSFYngugS+eOBXcVxZL9WSqv+d17FyMLAcpf7
+        zrvnyiJ8su6eiVuQJnEvE0JkD2wKBgZnqBVbUb/53ovjR7nfvizi8ljtp9fxMImz3PX28CzO6v3p
+        Ynb9QuApjgRZxDl1nMvZrb8c2pNa6+B5hDnQCCDNhAir0akVQsLE7zkMfjGSOkBOEF3/9grqCBpZ
+        d2XJShratLLSWV63WV1IVZQlVI0G2eSwyQsApZTMdKsaMsNlBiLIwzv8X9Ofn4n/2eZ2+wYFe3kD
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:19 GMT
+      etag:
+      - W/"d06c4199910ab5e2600f19eefdc9e277"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800CA3:C7EACD9:5ED66112
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3102'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:19 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800E5F:C7EAEE2:5ED66113
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3101'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkGAqZubk+0N60M5SZTh/u7sUj24otYluuJCcNHr57/yvZ
+        sZMGCKBHXiBRpN+uVrur1bYTmU7ms8urq9ns0/T6ZFKpVEQ0Nrm9+XV9V/xRJF+vH/i3v1ZJtdz8
+        eZ9d3N7//nB7s/w8wWReCsy0wtgoKjcpt9wIix8WTVFE3a+lwKhVWpwWMj6luYb9f0Wt5Ypb0Ba8
+        MOJkotaV0JN5OylUJisIOYCBINL08nL682x2db6n/OZueb35Mfut4d/qPP1arOL777Pbm2Rze5/9
+        i6Uc8riOGl2AnltbmzljftB8OsukzZu4MUInqrKismeJKlnDemFfVp8vAMl0h3Emw8AerpYdyS8H
+        zrDDO8ltWewp43VwKw+vWaiiUGsw93dxpFi2BdCZOZissvfBAGiZsrmAabHdRzKSxJm/leoWt4z+
+        wS8JZ3BsWqRvBXbLoSS52GPLtKiV4zaxSbSsrVTVm9XdgQCqdMYr+cDfBQXEgEWKvlkxtxgQsYIz
+        v5niV7fMhWuyIbNpkQi5wnm8j7yHAdhuasoudyML0ilJKyKelpQUXK54PEH0vjJ2DiSgVGwPfzKv
+        kL8oIvRym5CeDWxn3ENBekAQUV+w/9E4BDBgsMpSbIIxidUy/O3iLUFi4LHSHEk8mJAdaMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGHOX7x5+qYxrWB1vVlLHPpMeE2PFiPA174MbIrBIimMW3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4u0I0GIRdAvE2wqwOqDfOPUJ
+        uMXjtrZwoWD69zzWdidQ8CpreBZOwhZIlxVKlYw/vFihHR+zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdz5d0rzDSqJJzZipL+VLNczy9w+2EWGARFAf7Yuj7y6Xb67ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9qeY2pwwLsTXXItRmOhxrYzx1H8/OztpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/FqR+iudQoXga7Cy2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlQuZHPNW
+        PD7Md6DtFyOrRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQm6AZ
+        coSkRKIFGlRpxC0epbPpbHo6vTydzv4+v5jPLubTyx+Y09TogT055/yC5tSNyZ+eckVTkP67WMEn
+        dKWebwTtvzGp4wSIMfkA+WVAzA/0kp5AJAWcfi9q36bLav9ufx0G28lVKWrUaf3j3MgHfJ7u1FiJ
+        aiqcDgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVb3IrFmPDZkstHEtVzKnYVUQ267Bf6RPwgv
+        pdaqazb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6In
+        iwYr3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxoO13MXWL/Y/+KG
+        sBWqxnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+ijT9zEH33ijz7xR5/Yd9rp+jvQJ66EXaNhOsqm
+        4+dtn60f/wOq/3rkFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:19 GMT
+      etag:
+      - W/"a6ea764c21976facb1f2f1fe52e721f5"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A800F2A:C7EAF7D:5ED66113
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3100'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:20 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801070:C7EB120:5ED66113
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3099'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUVPjNhDHv0teCyjkGAqZubk+0N60M5SZTh/u7sUj24otYluuJCcNHr57/yvZ
+        sZMGCKBHXiBRpN+uVrur1bYTmU7ms8urq9ns0/T6ZFKpVEQ0Nrm9+XV9V/xRJF+vH/i3v1ZJtdz8
+        eZ9d3N7//nB7s/w8wWReCsy0wtgoKjcpt9wIix8WTVFE3a+lwKhVWpwWMj6luYb9f0Wt5Ypb0Ba8
+        MOJkotaV0JN5OylUJisIOYCBINL08nL682x2db6n/OZueb35Mfut4d/qPP1arOL777Pbm2Rze5/9
+        i6Uc8riOGl2AnltbmzljftB8OsukzZu4MUInqrKismeJKlnDemFfVp8vAMl0h3Emw8AerpYdyS8H
+        zrDDO8ltWewp43VwKw+vWaiiUGsw93dxpFi2BdCZOZissvfBAGiZsrmAabHdRzKSxJm/leoWt4z+
+        wS8JZ3BsWqRvBXbLoSS52GPLtKiV4zaxSbSsrVTVm9XdgQCqdMYr+cDfBQXEgEWKvlkxtxgQsYIz
+        v5niV7fMhWuyIbNpkQi5wnm8j7yHAdhuasoudyML0ilJKyKelpQUXK54PEH0vjJ2DiSgVGwPfzKv
+        kL8oIvRym5CeDWxn3ENBekAQUV+w/9E4BDBgsMpSbIIxidUy/O3iLUFi4LHSHEk8mJAdaMvGX8mp
+        rOBlMFkOBmiuVDjLOxig0phGHOX7x5+qYxrWB1vVlLHPpMeE2PFiPA174MbIrBIimMW3wJb1l0Cs
+        eZXk4UT0vJb5T85reBZsC8QCMi5UHIyJC505YMtMzv3VaKOQWpME4u0I0GIRdAvE2wqwOqDfOPUJ
+        uMXjtrZwoWD69zzWdidQ8CpreBZOwhZIlxVKlYw/vFihHR+zAxF4Kk21jJuwiXlg0g58UYT8E+4I
+        BuQgwFVdz5d0rzDSqJJzZipL+VLNczy9w+2EWGARFAf7Yuj7y6Xb67ZBvJYN94u/zDpJoU6ju816
+        /cfyurdVMNfqeaz9qeY2pwwLsTXXItRmOhxrYzx1H8/OztpccPcsKYUOmEU8DViukxzldSj9256H
+        yrHk1j1/FqR+iudQoXga7Cy2QMC9C4Tag6eN/ahGvR5McQcb00tZoGuhqnB3xEAcy6mUlQuZHPNW
+        PD7Md6DtFyOrRJxwPG8QFVYmEnGCJzt5AIp8Ec6KnobtoUfkn4mFQMgEOyUtPK9lviuQirpQm6AZ
+        coSkRKIFGlRpxC0epbPpbHo6vTydzv4+v5jPLubTyx+Y09TogT055/yC5tSNyZ+eckVTkP67WMEn
+        dKWebwTtvzGp4wSIMfkA+WVAzA/0kp5AJAWcfi9q36bLav9ufx0G28lVKWrUaf3j3MgHfJ7u1FiJ
+        aiqcDgbX3OKxgZplGOrrsh6QcxP5TDKZW92g50gjtVb3IrFmPDZkstHEtVzKnYVUQ267Bf6RPwgv
+        pdaqazb65kKXh9E27DqeqTQ8LsQwoGpRdRqOtyETUZmtGXwDgLY8mr5jAvclFQveFDbybyVqp6In
+        iwYr3FHoEmagnhe1W7vOijcIuWq/R8qK/jMaLlaUdeS9w6qloP4sUMgqah2ZfxoO13MXWL/Y/+KG
+        sBWqxnZ/0YKu0901KQIcrR6vcYTisCP2DeJxW+ijT9zEH33ijz7xR5/Yd9rp+jvQJ66EXaNhOsqm
+        4+dtn60f/wOq/3rkFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:20 GMT
+      etag:
+      - W/"a6ea764c21976facb1f2f1fe52e721f5"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:14 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8010F5:C7EB1ED:5ED66114
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3098'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/39a5c0169062ab244e58cea81e312eebbba0c9b8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VS24rbMBD9lUXPSSzJlm9Q6EKypQUTlqZZklLC2J7ESn3DkheyS/69o6Yt7VsW
+        0hehmdHozDlzXpmpgKXMT0AVXIQJDyXkMghQxQVCLNAXEjHPc+BFksdswtquxJ0uqSmbb8JHmdj8
+        qebZcRMs5x9P2cu9Wh4ztVmtj9l8IZere5k1Dzo7PvLt6kuwketqOX+os5fFafu01pvmU5V9oPfH
+        wzv6fBxq+riytjep50GvZwdtqzGfFV3jDdh3xmvQgrHdgNNa51OLxhrPnbtdcyqBamg9avKoo9FU
+        ewO1yjb17t8R/oK/BvgC+hZMGG3VDSx9ZS00SOQ/V1DBcLd4HrqWFMEGtNOE9kTpGbr0+4NLOk3o
+        AXF2bZJLPuXhlMuVCFIZpCLasvOEXSay+B8h7IA0wesvKwkQBRRlXiRlpFQYRaL0JVeoEBMVq0j6
+        Yc7JVbfdtpvBeFdjkzANGgMHJ92cXNND8Z2iu7F3epY0XA8Dttaw9OsfZlIJFZSKx4Uf7SMUMvAj
+        39/vAwFhxGM/5oLI4W2Z/faxuB79Zj6+GvP8bcKecdB7XYDVZFyywyUmLdM91AYnbEAwrsTG1uhD
+        +1NldwE7DrSHdqxrJ/up7oCaXHg+/wAx/Ah1oQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:20 GMT
+      etag:
+      - W/"91d20f3c5f8c37396c4e794b8b126b67"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8011B5:C7EB2C5:5ED66114
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3097'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=39a5c0169062ab244e58cea81e312eebbba0c9b8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft5Fsx0+BMZqwlQSWse7FnBAIejjHSmXJWEpDWvrdKzVmtOle
+        ZN0YeyOJO93dj7v/PQSKNBCMAk4saQm7JRsYbI1WwUXQElv/2mNq4hyUprjiOM+jBEe4iEmW4DhL
+        eZamPE9JzLM8i1iFXSoj7l2RMBxeBLtOutja2taMECKtGGyErXd0wHSDOmi1QQ1YYqzu4FIKemnB
+        WIP8uV43B89pwCKmlQXlHKfgHzuoPsQFSRgO0wKnEaHRcAhJzoDkIcRhBEApJZgVNHdotW3k+jXU
+        C6BzUKjUFJ1b8Q2vQ3D1Tgje3RaXCnkeg35jOlzvldSEn0B0ZN/PZmeg6xv+PKZzuvInDbGH1muy
+        EhJce/rKzgB7vZlOZhjKsZxu3buZ33MxNdOrZ/tu8SPs7WGyvP6MF+Vc8snRv1Lux2FZzu94Odsu
+        yy/iqxjTibhykePsePv3bL8ob/Qx+03Nrz/d0VIeVupn5Pdky+KF6CMLf5ff2mLlVwYU01yojd8O
+        J9N06GxrKdStCUYPgQFZ/Vfad2r5GzzvEp3fuxfF/+3OPT4+AeQNz7r5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80123F:C7EB378:5ED66114
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3096'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My next version tag", "tag": "version-1.1",
+      "type": "commit", "object": "39a5c0169062ab244e58cea81e312eebbba0c9b8"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMzA5OjliMDBiMGI3ZGUxYmFmMWVjZTc0NjYwNzIyMmE4Y2Q2ZGI1NGU0ZDQ=","sha":"9b00b0b7de1baf1ece746607222a8cd6db54e4d4","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/9b00b0b7de1baf1ece746607222a8cd6db54e4d4","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:21Z"},"object":{"sha":"39a5c0169062ab244e58cea81e312eebbba0c9b8","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/39a5c0169062ab244e58cea81e312eebbba0c9b8"},"tag":"version-1.1","message":"My
+        next version tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '698'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      etag:
+      - '"426248d910471c06f6059f6a66742fd5"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/9b00b0b7de1baf1ece746607222a8cd6db54e4d4
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8012C8:C7EB42E:5ED66115
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3095'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "9b00b0b7de1baf1ece746607222a8cd6db54e4d4", "ref":
+      "refs/tags/version-1.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.1","node_id":"MDM6UmVmMjY4ODIyMzA5OnJlZnMvdGFncy92ZXJzaW9uLTEuMQ==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1","object":{"sha":"9b00b0b7de1baf1ece746607222a8cd6db54e4d4","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/9b00b0b7de1baf1ece746607222a8cd6db54e4d4"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:22 GMT
+      etag:
+      - '"78f4c396f6381dfb2eb47215e7d08c79"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.1
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8013BC:C7EB54D:5ED66115
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3094'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:22 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801526:C7EB70B:5ED66116
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3093'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:23 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801598:C7EB7A2:5ED66116
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3092'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:23 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801687:C7EB8BC:5ED66117
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3091'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:24 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80176D:C7EB9D4:5ED66117
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3090'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT2/CMAzFv0vOa9OytiyVOCCxTUOLuOwvlypJDQ1qmqpxkQriu8/svAOHXZ4s
+        +T37Z5/ZADtWXjVwVPvAjzAE67sojRN2xzpfQ2VrcsiVLN7dh5OH72yzepnkaZlvunW77eSxfn7q
+        zCRm26/1SX2K8fXtcZTLxYIGjENL4QaxDyXnqrfx3mIz6th4xwfofeAOUAX0A0St1RFCQEIhrSo3
+        1Yp6gJxC5P6b0esDGGTlmYVG0bIsLXb5PAGh7iGdF8lMi0ykACLPlVYPVJhaG2OIDqceKEGH/y/q
+        7ydv5rhcfgDX8W6NhwEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:24 GMT
+      etag:
+      - W/"dba6e1f7c17a491c6d3dfff78f19abaa"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8017F3:C7EBA76:5ED66118
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3089'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/416f570e9a3e17602b9491ee955aba8ee9cdbccc
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9laBnO5Z8TQKFbtlkacEJpaaL8xLG9tiWV7aDJS91lvz7jsgPtNAX
+        MZqZc+bMYT7YMFZ4kRXbsfQ5jX+/HIa0y8PT8/clvT1Fp+7nn2Ofi+Ptmzq97m/nbB8cu6cl7974
+        KTuoc/Ymjq8HmWctxao7v/zocj/9whymWyDSUMR1lHDcQoAiiblfbMOtQNxGERSwoaCsirIsCTBP
+        igCtMVe98zy4ynUjTTsX63LsvQmvo/Z6NKDNOKGrZOEa1EZ79r1c+qUCqqHxCOQZaLT3D6Opv8GJ
+        7T7YAD2Sil8ttDCt9u/TOJA07EFacbQTpddo018bm7TiqIGGW5jPfe7y2OV+JsKdH+5EcGZ3h41F
+        h6Wx/A9XhB+JKKwivimDpE5Q+GGQBEFdhwLihG+CDRdBXCAxm+VqmWlML83/denBqb2/VkObkFOk
+        5h0nLcfBFWtOknrUGhqrMl1WgyxxpaQxCle22bHNspYlGEJYCx5/pJOrQWl02ISgbYnNg5bNQBW6
+        HgrAzBOxDrNSDrvCokYgkP3e759a7bE1uQIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:24 GMT
+      etag:
+      - W/"f60b7c29716d8c77c19caed1c1435660"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80186D:C7EBB03:5ED66118
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3088'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:24 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8018F7:C7EBB9D:5ED66118
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3087'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:25 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801986:C7EBC59:5ED66118
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3086'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJNbNVmIodCGh7IOzhGZZsqWEsT2OlfoSLHnbeMm/r9S0pX3L
+        QvpipBmNzpwzx3olpgQSE8ZDFso8pLNMqEIh41IoIYpCMogUnYkZZSJKkYxJ0+a407krShbbaM3n
+        Nn2qaHLYyofF/SkZ7sKHw/K02izZ6tOaJYvykAx5veKPP5LDelgNyfBcb2nytOSr4U4mw/57skn4
+        tn784C7vu8pdXFp7NHEQwFFP99qWfTrN2jro8NiaoEYLxrYdTiqdTiwaawL/3e3qUw4uhzZwRYGr
+        qLXLvYNaaetq928Lf8FfA3wBfQ8m9LZsOxK/kgZqdOQ/l1BCN1q+dG3jFMEatNfEzcmFp+jDH/c+
+        6DVxBxxnX8YppxMaTSjfMBlzGTP6TM5jcunI4n+EsB26Dl5/WUkpnEVCFlKkVGRFEc1zqWSY0RQV
+        YiF4ihmkUXjbafseTHA1thOmRmNg76W7b7TVUI28e46QfXPR0UU21+MROmysIfGX3wSZBBSpUhnM
+        ixTEXAHwzPOK5tz9MHlOFUMG+W0J/rHz9ei3s/O1mOevY/KCnS50BlY7/zpXXPboHowCKoNj0iEY
+        nyJ9Y/S+cZkx8QuwfefG0fRV5WU/Va3T8Of2fH4D2lBZdKgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:25 GMT
+      etag:
+      - W/"6ebebefa8b45ea7cf35f7082c7a94629"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801A0D:C7EBD17:5ED66119
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3085'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T3U7jMBCF3yXXUCdNEyeVEKLRLkolQMtekFZIlR1PEhfHjmKXqov67mtDJaBw
+        UX602gtbI48959PM8YMnSQve2GPEkI6Ud6SGwVIr6R15HTHN+xndEJtIACclSwnDKaTDYUj9JI4C
+        HEeMQQw48lM/TWjs21Ka/7EiaXzkrXphnzbGdHqMEOn4oOamWdFBqVrUQ6c0asEQbVQPx4LTYwPa
+        aOT2xaLdOEwNBpVKGpA2sc992kN1EgyjIBqxyE/KEFcYguEoxGFYVaOAxNhPwsQPwpiCJWtMKxav
+        oV4AHYJChaLoUMU3vBbB6u0RfLotthRyPBp9YDhMraVQhO1B9GS9m81KQ79r+OOYDunKVxpiNp2z
+        ZMWFm9BO2R7AWtV5Nl3NbgKRL23cBtH8/Kc/Ky4Fy3Kdnz3mN/Pi8p4V0+W8uOBXfEIzflbfyjyb
+        YBflmVvT9ay4Vk9Vrht2/uOeFuL55e9oWYYz/nR/kt5KFxW/OhtZJJClYlzWlolaO8Yje7YQXN5p
+        b/zgaRDVf+Vx64rv4PmUudz/eiH+b//WdvsXIKHTJuAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:25 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801A81:C7EBD9A:5ED66119
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3084'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.1",
+      "type": "commit", "object": "125154d508c37f7e1243733ff41a6708380136be"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMzA5OmEyYzg5Yjc5ZDQwYjVkNDBkMDNiYzJiYWIyODBlNzZmYzRmMzkyMmI=","sha":"a2c89b79d40b5d40d03bc2bab280e76fc4f3922b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a2c89b79d40b5d40d03bc2bab280e76fc4f3922b","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:25Z"},"object":{"sha":"125154d508c37f7e1243733ff41a6708380136be","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be"},"tag":"version-1.1","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:26 GMT
+      etag:
+      - '"0a69394753c1df1df023d6770167e1b8"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a2c89b79d40b5d40d03bc2bab280e76fc4f3922b
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801AF5:C7EBE22:5ED66119
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3083'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "a2c89b79d40b5d40d03bc2bab280e76fc4f3922b", "ref":
+      "refs/tags/version-1.1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"message":"Reference already exists","documentation_url":"https://developer.github.com/v3/git/refs/#create-a-reference"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '121'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:26 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801BBF:C7EBF22:5ED6611A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3082'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:26 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801CCF:C7EC06A:5ED6611A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3081'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:27 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801D41:C7EC0FA:5ED6611A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3080'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA72RW2vCMBTHv0uf1SRdmpqCD4LbmKzIYFfHKLkctWIvNKlQpd99xz2OMYRdXg4H
+        cv4nv+T3egwaWAXJqTri1dqRPTQur8ohG9FgEJSVhSy3OJHOUvFQPBbp9oUvZjddephGi3K+W5bp
+        3l5flaaT4fJ5flBPsr29v2zT6WSCC9pmh+GN97VLCFF1PlrnftPqkakK0kBdOVKAV85XDQx3uR56
+        cB5RsGZZ0VmFZ+AJhnD6a8ZKb8H4IDkGbqPwMs7EKoopSHUBLBY01JJLBiCjSGk1xsZYbYxBOt/V
+        gAl8+O+ifvzk2Rx9P/jOA/uZh7v/8HBi/OxBako11bEFptWKgYGYC0HjMAzV2FhhdcSBW/7XHs7m
+        6Pu3d86BRpwRAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:27 GMT
+      etag:
+      - W/"52cba76b11f13b882b9423e7640cd754"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801DB9:C7EC17E:5ED6611B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3079'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/416f570e9a3e17602b9491ee955aba8ee9cdbccc
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S24rbMBD9laBnO5Z8TQKFbtlkacEJpaaL8xLG9tiWV7aDJS91lvz7jsgPtNAX
+        MZqZc+bMYT7YMFZ4kRXbsfQ5jX+/HIa0y8PT8/clvT1Fp+7nn2Ofi+Ptmzq97m/nbB8cu6cl7974
+        KTuoc/Ymjq8HmWctxao7v/zocj/9whymWyDSUMR1lHDcQoAiiblfbMOtQNxGERSwoaCsirIsCTBP
+        igCtMVe98zy4ynUjTTsX63LsvQmvo/Z6NKDNOKGrZOEa1EZ79r1c+qUCqqHxCOQZaLT3D6Opv8GJ
+        7T7YAD2Sil8ttDCt9u/TOJA07EFacbQTpddo018bm7TiqIGGW5jPfe7y2OV+JsKdH+5EcGZ3h41F
+        h6Wx/A9XhB+JKKwivimDpE5Q+GGQBEFdhwLihG+CDRdBXCAxm+VqmWlML83/denBqb2/VkObkFOk
+        5h0nLcfBFWtOknrUGhqrMl1WgyxxpaQxCle22bHNspYlGEJYCx5/pJOrQWl02ISgbYnNg5bNQBW6
+        HgrAzBOxDrNSDrvCokYgkP3e759a7bE1uQIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:27 GMT
+      etag:
+      - W/"f60b7c29716d8c77c19caed1c1435660"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801E42:C7EC213:5ED6611B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3078'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:28 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801EB3:C7EC2B8:5ED6611B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3077'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:28 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A801F58:C7EC35F:5ED6611C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3076'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VU24rbMBD9laDnJNbNVmIodCGh7IOzhGZZsqWEsT2OlfoSLHnbeMm/r9S0pX3L
+        QvpipBmNzpwzx3olpgQSE8ZDFso8pLNMqEIh41IoIYpCMogUnYkZZSJKkYxJ0+a407krShbbaM3n
+        Nn2qaHLYyofF/SkZ7sKHw/K02izZ6tOaJYvykAx5veKPP5LDelgNyfBcb2nytOSr4U4mw/57skn4
+        tn784C7vu8pdXFp7NHEQwFFP99qWfTrN2jro8NiaoEYLxrYdTiqdTiwaawL/3e3qUw4uhzZwRYGr
+        qLXLvYNaaetq928Lf8FfA3wBfQ8m9LZsOxK/kgZqdOQ/l1BCN1q+dG3jFMEatNfEzcmFp+jDH/c+
+        6DVxBxxnX8YppxMaTSjfMBlzGTP6TM5jcunI4n+EsB26Dl5/WUkpnEVCFlKkVGRFEc1zqWSY0RQV
+        YiF4ihmkUXjbafseTHA1thOmRmNg76W7b7TVUI28e46QfXPR0UU21+MROmysIfGX3wSZBBSpUhnM
+        ixTEXAHwzPOK5tz9MHlOFUMG+W0J/rHz9ei3s/O1mOevY/KCnS50BlY7/zpXXPboHowCKoNj0iEY
+        nyJ9Y/S+cZkx8QuwfefG0fRV5WU/Va3T8Of2fH4D2lBZdKgEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:28 GMT
+      etag:
+      - W/"6ebebefa8b45ea7cf35f7082c7a94629"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80201C:C7EC419:5ED6611C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3075'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=125154d508c37f7e1243733ff41a6708380136be
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T3U7jMBCF3yXXUCdNEyeVEKLRLkolQMtekFZIlR1PEhfHjmKXqov67mtDJaBw
+        UX602gtbI48959PM8YMnSQve2GPEkI6Ud6SGwVIr6R15HTHN+xndEJtIACclSwnDKaTDYUj9JI4C
+        HEeMQQw48lM/TWjs21Ka/7EiaXzkrXphnzbGdHqMEOn4oOamWdFBqVrUQ6c0asEQbVQPx4LTYwPa
+        aOT2xaLdOEwNBpVKGpA2sc992kN1EgyjIBqxyE/KEFcYguEoxGFYVaOAxNhPwsQPwpiCJWtMKxav
+        oV4AHYJChaLoUMU3vBbB6u0RfLotthRyPBp9YDhMraVQhO1B9GS9m81KQ79r+OOYDunKVxpiNp2z
+        ZMWFm9BO2R7AWtV5Nl3NbgKRL23cBtH8/Kc/Ky4Fy3Kdnz3mN/Pi8p4V0+W8uOBXfEIzflbfyjyb
+        YBflmVvT9ay4Vk9Vrht2/uOeFuL55e9oWYYz/nR/kt5KFxW/OhtZJJClYlzWlolaO8Yje7YQXN5p
+        b/zgaRDVf+Vx64rv4PmUudz/eiH+b//WdvsXIKHTJuAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:28 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:10 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A802088:C7EC4E0:5ED6611C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3074'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/9b00b0b7de1baf1ece746607222a8cd6db54e4d4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S22rjMBD9laDnOJYUx7nAwu6S1uTBKWXbLvFLGNkTW8ayjSV365b8+47IfkAL
+        C0JoZs45c2bQB2u7As+6YDuW7tP4Jblv0/oUPewPU/r+Y/VQNzrd/9RpclhmyfPbydyb9PdLnT3l
+        /Fif/hzfCWfuopN8lFlyEMfkmWf7x29szmwFJLpVnCuu1gUKBReBOa6jOOZrKSVs8iIu1CrCqIiI
+        MA4NESrnersLQ+j1otSuGtUi70w4YN/Z0KAD67oBg0arwKF1NvT3+WymAqiGLiRS6KC04RdaE77E
+        ge0+WAsGycWvCioYZnevQ9eSNTSgvTmaidIL9OnvpU96cwSg5p4mueQBjwMun0S0k3RExq5z1qka
+        c+f1b1tZbmGVcxFveSxBySjC1SZH2AhcComolAKeb9WGlN3Ue2VqY7T7v1u6adrw025oEtoUuXnF
+        wequDcRCkCWD1kLpXabTrMU3N/tXn3n03KP1RefgiOJ3cIuR/twFGotzNiBYX2Jja3XZUoW+Dz3A
+        jQPJtmPTzFkPU9MBkXx4vf4Fg5Y+CroCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:29 GMT
+      etag:
+      - W/"426248d910471c06f6059f6a66742fd5"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A802102:C7EC56F:5ED6611C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3073'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:29 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80218F:C7EC615:5ED6611D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3072'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:29 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A80221B:C7EC6D6:5ED6611D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3071'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/39a5c0169062ab244e58cea81e312eebbba0c9b8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VS24rbMBD9lUXPSSzJlm9Q6EKypQUTlqZZklLC2J7ESn3DkheyS/69o6Yt7VsW
+        0hehmdHozDlzXpmpgKXMT0AVXIQJDyXkMghQxQVCLNAXEjHPc+BFksdswtquxJ0uqSmbb8JHmdj8
+        qebZcRMs5x9P2cu9Wh4ztVmtj9l8IZere5k1Dzo7PvLt6kuwketqOX+os5fFafu01pvmU5V9oPfH
+        wzv6fBxq+riytjep50GvZwdtqzGfFV3jDdh3xmvQgrHdgNNa51OLxhrPnbtdcyqBamg9avKoo9FU
+        ewO1yjb17t8R/oK/BvgC+hZMGG3VDSx9ZS00SOQ/V1DBcLd4HrqWFMEGtNOE9kTpGbr0+4NLOk3o
+        AXF2bZJLPuXhlMuVCFIZpCLasvOEXSay+B8h7IA0wesvKwkQBRRlXiRlpFQYRaL0JVeoEBMVq0j6
+        Yc7JVbfdtpvBeFdjkzANGgMHJ92cXNND8Z2iu7F3epY0XA8Dttaw9OsfZlIJFZSKx4Uf7SMUMvAj
+        39/vAwFhxGM/5oLI4W2Z/faxuB79Zj6+GvP8bcKecdB7XYDVZFyywyUmLdM91AYnbEAwrsTG1uhD
+        +1NldwE7DrSHdqxrJ/up7oCaXHg+/wAx/Ah1oQQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:29 GMT
+      etag:
+      - W/"91d20f3c5f8c37396c4e794b8b126b67"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8022BD:C7EC787:5ED6611D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3070'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=39a5c0169062ab244e58cea81e312eebbba0c9b8
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TbWvbMBDHv4tft5Fsx0+BMZqwlQSWse7FnBAIejjHSmXJWEpDWvrdKzVmtOle
+        ZN0YeyOJO93dj7v/PQSKNBCMAk4saQm7JRsYbI1WwUXQElv/2mNq4hyUprjiOM+jBEe4iEmW4DhL
+        eZamPE9JzLM8i1iFXSoj7l2RMBxeBLtOutja2taMECKtGGyErXd0wHSDOmi1QQ1YYqzu4FIKemnB
+        WIP8uV43B89pwCKmlQXlHKfgHzuoPsQFSRgO0wKnEaHRcAhJzoDkIcRhBEApJZgVNHdotW3k+jXU
+        C6BzUKjUFJ1b8Q2vQ3D1Tgje3RaXCnkeg35jOlzvldSEn0B0ZN/PZmeg6xv+PKZzuvInDbGH1muy
+        EhJce/rKzgB7vZlOZhjKsZxu3buZ33MxNdOrZ/tu8SPs7WGyvP6MF+Vc8snRv1Lux2FZzu94Odsu
+        yy/iqxjTibhykePsePv3bL8ob/Qx+03Nrz/d0VIeVupn5Pdky+KF6CMLf5ff2mLlVwYU01yojd8O
+        J9N06GxrKdStCUYPgQFZ/Vfad2r5GzzvEp3fuxfF/+3OPT4+AeQNz7r5BAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:30 GMT
+      etag:
+      - W/"bb60fd0882502093a750376d766d86a3d7872cf0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:17 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A802331:C7EC821:5ED6611D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3069'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:30 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8023A7:C7EC8A7:5ED6611E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3068'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDdLEwGJ7SLtogTRA0cPuXgRKoiXakqiSlF1HyLv3H1Ky
+        ZNdJHIfHXBKbJr8ZDmeGw2knIp3MwuubmzD8NL09m1Qy5RGNTe7vfl0/FH8UydfbR/btr1VSLTd/
+        LrKr+8Xvj/d3y88TTGYlx0zDtYmicpMywzQ3+GHeFEXU/VpyjBqp+Hkh4nOaq4P/r6iVWDED2pwV
+        mp9N5LriajJrJ4XMRAUhBzAQRJpeX09/DsObyz3lNw/L282P8LeGfavz9Guxihffw/u7ZHO/yP7F
+        UgZ5TEWNKkDPjan1LAjcoP50kQmTN3GjuUpkZXhlLhJZBk3QC/uy+nwFSKY6jDUZBvZwtehIbjlw
+        Oji8k9yUxZ4yTge78vCauSwKuQZzfxdHig22ADozCxNV9j4YAG0gTc5hWmz3iYwkcOanUu3iNqB/
+        8EvCaRyb4umpwG45lCQXe2oDxWtpuU2sEyVqI2R1sro7EEClylglHtm7oIBosEjRkxWziwHhKzjz
+        yRS3ug1suCYbMpviCRcrnMf7yHsYgM2mpuzyMLIgnZIwPGJpSUnB5oqnM0TvG2PnQAJK+fbwJ7MK
+        +YsiQi23CenFwLbGPRSkBwQR9RX7H41DAAMGqyz5xhuTWG2Av128JUgMLJaKIYl7E7IDbYPxV3Iq
+        w1npTZaFAZpL6c/yFgao0LrhR/n+8adqmTrog61qythl0mNC7HgxjoY9MK1FVnHuzeJbYBv0l0Cs
+        WJXk/kT0vDZwn6zXsMzbFogFZFzI2BsTF3pggW2gc+auRhP51JokEG9HgOJzr1sg3laAUR79xqpP
+        wC0et7WBC3nTv+cFbXcCBauyhmX+JGyBdFmhVMnY46sV2vExOxCBp9JUibjxm5gHJu3AFUXIP/6O
+        YEAOAmzV9XJJ9wYjjSo5a6ayFK/VPMfTO9xOiHkWQXGwL4a+v166vW0bxGuD4X5xl1knyddpdLdZ
+        r/9YXve28uZaPS9of6qZySnDQmzNFPe1mQ4XtDGeuk8XFxdtzpl9lpRcecwijgYsU0mO8tqX/m3P
+        Q+VYMmOfP3NSP8VzqJAs9XYWWyDgzgV87cHRxn5Uo173priFjemlKNC1kJW/O2IgjuVU0oi5SI55
+        Kx4f5jvQ9osWVcLPGJ43iAojEoE4wZOdPABFPvdnRUfD9tAjcs/EgiNkvJ2S4o7XBq4rkPK6kBuv
+        GXKEpESiOBpUacQMHqXhNJyeT6/Pp+Hfl1ez8Go2vf6BOU2NHtizc8JLmlM3On9+SkhTkP67WMEn
+        dKVebgTtvzGp4wSI1vkA+WVAzA70kp5BJAWcfi9qT9NltX+3vw2D7eSy5DXqtP5xrsUjPk93aqxE
+        NhVOB4NrZvDYQM0yDPV1WQ/ImY5cJpnMjGrQc6SRWskFT4wejw2ZbDRxLZZiZyHVkNtugXvkD8JL
+        oZTsmo2uudDlYbQNu45nKjSLCz4MyJpXnYbjbYiEV3prBtcAoC2Ppu+YwH5J+Zw1hYncW4naqejJ
+        osEKd+SqhBmo50Xt1q6z4gxCrtrvkbKi+4yGi+FlHTnvMHLJqT8LFLKKXEf6n4bB9ewF1i92v9gh
+        bIWqsd1fFKfrdHdNigBHq8dpHKE47Ih9g3jcFvroEzfxR5/4o0/80Sd2nXa6/g70iStu1miYjrLp
+        +HnbZ+un/wDk/68bFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:30 GMT
+      etag:
+      - W/"a137c0f60766e169d0b56bd8129cf2db"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:21 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A802446:C7EC958:5ED6611E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3067'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:24:31 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C989:33B7B:A8024DD:C7ECA1C:5ED6611E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3066'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_invalid_name.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_invalid_name.yaml
@@ -1,0 +1,2744 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:40 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D53EAB:5B8E568:5ED66128
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3044'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:40 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D53EF3:5B8E5A3:5ED66128
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3043'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822454,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI0NTQ=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:24:41Z","updated_at":"2020-06-02T14:24:41Z","pushed_at":"2020-06-02T14:24:42Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:42 GMT
+      etag:
+      - '"2aca174606b5e004f50c65f55a64f4b6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D53F47:5B8E60B:5ED66128
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3042'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"4c2d29c3e832f8625752f75d04a684e1715d1838","node_id":"MDY6Q29tbWl0MjY4ODIyNDU0OjRjMmQyOWMzZTgzMmY4NjI1NzUyZjc1ZDA0YTY4NGUxNzE1ZDE4Mzg=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/4c2d29c3e832f8625752f75d04a684e1715d1838","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/4c2d29c3e832f8625752f75d04a684e1715d1838","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:42Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:42Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:43 GMT
+      etag:
+      - '"c15b30ece7c998b8b0153c9e4279da0c"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54142:5B8E884:5ED6612A
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3041'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XyW7bMBD9lUBnJ1osW4qBoC2QoMjBDtImbZ2iMGhpJNGlSJWknNpG/r0zsrLY
+        hzYK0lsuhkTqDd+8WTjeOJKV4IyckhkL2uk5iSpLbp3RxjEFw40wCdLgOOlD3A+yeBgMokGQRYPU
+        C9kwDsGP/EHqx/0YoVKlMOMpgsan0+FlcGznX4U3XkzDi9Pz1eT02rtYfFqMy8vVxdfx+uYqX4/L
+        aThZnPuT9fXqZpH4N6cfvOkVrn28/j1Zn+H7WThe5yc7vFhtC6WJYcv9c8EKpg/OllpJ/BJKxgWS
+        QP64fAS0/D6nxSN0Dj9ImSWXAy/wDr3hoRdc+eEoCEdhcOPc3StAavy3I0owhuVE4lxyy5ngazhA
+        WuxAQ6UMt0qvkKjVgN/cR8LPvOM0C/pRFAdh5IeDGNIgOGbRfB7GSYQ7cRr1wUNgrUmAwtrKjFyX
+        Vfwo57ao5ySA2xzhlmAx5ErDoeDzQwvGGpd+Z7NyRUwMWBdBLnEw7rPPRv1e8fBtMhq3QxISBKSd
+        JaqWmMZez1mC5hlPmOWYHqjm9h0wTzMmDPQcDczQllNLw3OJOz2HHpitNeovayF6TsVWQjEE0evd
+        67n5AhcLW4rZrspPwvucwG4PfYGsZu/cF6dWV7fdNq4GY/PYAITKOQXOFE2V4x61n+FgMOzvtqPL
+        4ZdvE5Espv7karomG0vMcb3vTbNogrZaagM6UdJiOjWFU7uN5XfLkxAt5Lq10XS8fxUd2TLuI8+/
+        x/Dxu0wJoW4Ru091t6Z3zLsPIGS1feYy724AQRtX2QJQJ6R/R05z7BNdLDWADXYS7Cw8JRMGJdaQ
+        djHSQpDMrUQem6aFNbbquUk0r6i0O9HaAaIhpXMm+brpEZ0MIZBSsumpXVxqAAiEJWZXJ+QWsXEr
+        zZcsWZEMGhLgS9S0u7U9KBqzq4oupmuMOCnMLcxYWlKZNe1y/4J8K8H2Wn0rwW6V81aC20sLm9lO
+        9T6rBCumqW84o+8/sCBngsuf+IKTIojsNSa/uWYyKXDwe/hfQBfWE8sdBw6aIu9tIeFKKwuJfTKD
+        tSvtiAaSzcXOhPar5nRp4E1gazNDasnWYZCZ0gk0I5/A9kccVZahiM3N/bvV6PFMPOHvffr54/Ge
+        SNiRG6/Ih7s/zUDtyFkNAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:43 GMT
+      etag:
+      - W/"84f40b401dfb5f3fef16a7a4b2d993f1"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54248:5B8E9CB:5ED6612B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3040'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D542AC:5B8EA40:5ED6612B
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3039'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/4c2d29c3e832f8625752f75d04a684e1715d1838
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPJBhjAkGq1EqJqhxItG2iVbKqIgMDGPER2WZViPLfO2566N52
+        pfaCmHnMvDdvhhvRlSAx4RnL2SrzIfJZES1ZEAasCIOccrGMOHihF+Re5EfEIV2fw0XmWJSsT8sn
+        tjLpc0OT+sT36+24Wx/pvv5WJ+3TuH9OpvOhnJL2xHf11ttNx/FcZ955/YWeDpj7evy5mzYYb3gy
+        lZ+w+aAabFwZc9Wx64qrXJTSVEO6yPrWVXDttduCEdr0CuaNTOcGtNGufV4u7ZgLxMC4WORiRSsR
+        +8BolWmby1sJf9G/h/hB+hFOMZiqVyS+kU60gMN/r0Ql1GzzqvoOHYFWSOsJ7gnTC7Dpz6VNWk/w
+        A5zZljHK6Jwu55QdPB4zHnN2JneHPBQZ+I8URgEquP05Ja+gq7xgfhhGjIceDyLIGVuJME15lIWI
+        RHnoA/2327YatPtubjSmBa1Faa3bdtJI0cgJZvaAZr/vTOKJjajxKhR0RpP45YdDXkHJQmbCSNwN
+        TvyIAX+GQjQaHKJAaAuRodOy7BBxiH0RZlBI1Q1NY1uOTS+wyIb3+y/533pahAMAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      etag:
+      - W/"0f0036e19118c4ac4168142caf40a571"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54345:5B8EAF0:5ED6612C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3038'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["4c2d29c3e832f8625752f75d04a684e1715d1838"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f","node_id":"MDY6Q29tbWl0MjY4ODIyNDU0OjZmYTI5ZmY3NzU4MmUzYWQ5ZGFlM2E4YzFjZGI0YjkzMDVlNGFmN2Y=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:44Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:44Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"4c2d29c3e832f8625752f75d04a684e1715d1838","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/4c2d29c3e832f8625752f75d04a684e1715d1838","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/4c2d29c3e832f8625752f75d04a684e1715d1838"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      etag:
+      - '"24d9d84bfcbbf77d1aaffff3713ba047"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54397:5B8EB4E:5ED6612C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3037'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW+DMBRF/4vnJg7my2VGTVLJzRSqZkEGP2oiDMh+iUSj/Pe+qGOXDl3uct95
+        99yYh44VjwzcgjaBOx0QPHti42Sg7g21qlTZ0VVOnT+SQ7lf3srj5jC+DqdRXfW2sqedujbvL19m
+        Wy0EXvxAkEWcQ8G5nvv1Z4/20qzbyXEP80QjgDQzeVgNfbNCCBj4I+vaLUZTB8gJouvfXlNzhhZZ
+        cWPBahpKWmHEcxuDjEUnM5Hmqejy1GwSnckEojxKTSRjSWa4zEAEebge/9f052fgf7a5378BRhiL
+        nX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:45 GMT
+      etag:
+      - W/"70acb3ea4f4bb38b31a11ecc1f23c5cc"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D5441C:5B8EBF1:5ED6612C
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3036'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OsW7CMBCG38VzwRQCIZmj0lZymUhVlugcn2ujOInsAylFvHsPdezSocvd8N93
+        /3cVEa0o7zNJh2CSDJAIo3gQ/WCw8YZTVanNIdRBnT6yffUyvVWHxb5/7Y69usCudsdnddHvT19m
+        V08MnmPHkCMaUykljH7+6cmd9bwdgow4DlyCxDVDxFnn9YwwUZL32TRhMsAZkmSIr397DfqELYny
+        KpIDLtpYWBbW5vl6u8QVmMIAr2372Bqd6WK1WGMGNrdsRtOITLBH8PS/pj8/k/yzze32DdAAQ3V9
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:46 GMT
+      etag:
+      - W/"d8d2df27a1301aca6e14ceaa46bb9890"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D544B8:5B8ECAD:5ED6612D
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3035'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:46 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D545C2:5B8EDFA:5ED6612E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3034'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwXLbNhCG30XX2obMKq6jmUx6SJtpZxxPOzmkuXBAEiJhkQQLgFJljt89/xKk
+        SKmyLcs4+mJLEPDtYrG7WGwzkclkHlxdXwfB7N3sbFKqRIQ0Nrn59Nv6Nv8zjz+/v+ff/l7F5XLz
+        5S6d3dz9Mf3y9a8PE0zmhcBMK4wNw2KTcMuNsPhhUed52P1aCIxapcV5LqNzmmvY/1dUWq64BW3B
+        cyPOJmpdCj2ZN5NcpbKEkAMYCCJNr66mvwTB9eWe8pvb5fvN9+D3mn+rsuRzvoru/gluPsWbm7v0
+        PyzlkMd1WOsc9MzayswZc4Pm54tU2qyOaiN0rEorSnsRq4LVrBf2cfVhBkiqO0xrMgzs4SrZkdxy
+        4Aw7vJPMFvmeMk6HduXhNQuV52oN5v4ujhTLtgA6sxYmy/R1MAAapmwmYFps94GMJHHmp1LbxQ2j
+        f/BLwhkcmxbJqcBuOZQkF3tomBaVarl1ZGItKytVebK6OxBAlU55Ke/5q6CAGLBI0ZMVaxcDIlZw
+        5pMpbnXD2nCNN2Q2LWIhVziP15H3MADbTUXZ5XZkQTolaUXIk4KSQpsrHs4QvS+MnQMJKBHbw5/M
+        S+Qvigi93CakJwO7Ne6hID0giKjP2P9oHAIYMFhlKTbemMRqGP528RYjMfBIaY4k7k3IDrRh46/k
+        VFbwwpusFgZoppQ/y7cwQKUxtTjK948/1ZZpWB9sZV1ELpMeE2LHi3E07IEbI9NSCG8W3wIb1l8C
+        keZlnPkT0fMa5j61XsNTb1sgFpBRriJvTFzorAU2zGTcXY029Kk1SSDejgAtFl63QLytAKs9+k2r
+        PgG3eNzWFi7kTf+ex5ruBHJepjVP/UnYAumyQqmS8vtnK7TjY3YgAk+lqZZR7TcxD0zagSuKkH/8
+        HcGAHAS0VdfTJd0LjDSq5FozFYV8ruY5nt7hdkLMswiKg30x9P350u1l2yBew4b7xV1mnSRfp9Hd
+        Zr3+Y3nd28qba/U81vxUcZtRhoXYimvhazMdjjURnroPFxcXTSZ4+ywphPaYRRwNWK7jDOW1L/2b
+        nofKseC2ff4sSP0Ez6Fc8cTbWWyBgDsX8LUHRxv7UYV63ZviLWxML2SOroUq/d0RA3Esp1RWLmR8
+        zFvx+DDfgTYfjSxjccbxvEFUWBlLxAme7OQBKPKFPys6GraHHpF7JuYCIePtlLRwvIa5rkAiqlxt
+        vGbIEZISiRZoUCUht3iUBtNgej69Op8GXy9n82A2n11+x5y6Qg/s8TnvaE5Vm+zxKVc0Bem/ixV8
+        Qlfq6UbQ/huTOk6AGJMNkF8HxPxAL+kRRJzD6fei9jRdVvt3+8sw2E6mClGhTusf50be4/N0p8aK
+        VV3idDC45haPDdQsw1Bfl/WAjJvQZZLJ3OoaPUcaqbS6E7E147Ehk40mruVS7iykGnLbLXCP/EF4
+        IbVWXbPRNRe6PIy2YdfxTKThUS6GAVWJstNwvA0Zi9JszeAaALTl0fQdE7RfErHgdW5D91aidip6
+        smiwwh2FLmAG6nlRu7XrrDiDkKv2e6Ss6D6j4WJFUYXOO6xaCurPAoWsotah+bfmcL32AusXu1/a
+        IWyFqrHdX7Sg63R3TYIAR6vHaRyiOOyIfYN43BZ66xPX0Vuf+K1P/NYndp12uv4O9IlLYddomI6y
+        6fh522frhx+KZ7ITFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:46 GMT
+      etag:
+      - W/"864721e64c3a2ec54e06b49d4fe38301"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D5461E:5B8EE65:5ED6612E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3033'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:47 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54684:5B8EEEE:5ED6612E
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3032'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwXLbNhCG30XX2obMKq6jmUx6SJtpZxxPOzmkuXBAEiJhkQQLgFJljt89/xKk
+        SKmyLcs4+mJLEPDtYrG7WGwzkclkHlxdXwfB7N3sbFKqRIQ0Nrn59Nv6Nv8zjz+/v+ff/l7F5XLz
+        5S6d3dz9Mf3y9a8PE0zmhcBMK4wNw2KTcMuNsPhhUed52P1aCIxapcV5LqNzmmvY/1dUWq64BW3B
+        cyPOJmpdCj2ZN5NcpbKEkAMYCCJNr66mvwTB9eWe8pvb5fvN9+D3mn+rsuRzvoru/gluPsWbm7v0
+        PyzlkMd1WOsc9MzayswZc4Pm54tU2qyOaiN0rEorSnsRq4LVrBf2cfVhBkiqO0xrMgzs4SrZkdxy
+        4Aw7vJPMFvmeMk6HduXhNQuV52oN5v4ujhTLtgA6sxYmy/R1MAAapmwmYFps94GMJHHmp1LbxQ2j
+        f/BLwhkcmxbJqcBuOZQkF3tomBaVarl1ZGItKytVebK6OxBAlU55Ke/5q6CAGLBI0ZMVaxcDIlZw
+        5pMpbnXD2nCNN2Q2LWIhVziP15H3MADbTUXZ5XZkQTolaUXIk4KSQpsrHs4QvS+MnQMJKBHbw5/M
+        S+Qvigi93CakJwO7Ne6hID0giKjP2P9oHAIYMFhlKTbemMRqGP528RYjMfBIaY4k7k3IDrRh46/k
+        VFbwwpusFgZoppQ/y7cwQKUxtTjK948/1ZZpWB9sZV1ELpMeE2LHi3E07IEbI9NSCG8W3wIb1l8C
+        keZlnPkT0fMa5j61XsNTb1sgFpBRriJvTFzorAU2zGTcXY029Kk1SSDejgAtFl63QLytAKs9+k2r
+        PgG3eNzWFi7kTf+ex5ruBHJepjVP/UnYAumyQqmS8vtnK7TjY3YgAk+lqZZR7TcxD0zagSuKkH/8
+        HcGAHAS0VdfTJd0LjDSq5FozFYV8ruY5nt7hdkLMswiKg30x9P350u1l2yBew4b7xV1mnSRfp9Hd
+        Zr3+Y3nd28qba/U81vxUcZtRhoXYimvhazMdjjURnroPFxcXTSZ4+ywphPaYRRwNWK7jDOW1L/2b
+        nofKseC2ff4sSP0Ez6Fc8cTbWWyBgDsX8LUHRxv7UYV63ZviLWxML2SOroUq/d0RA3Esp1RWLmR8
+        zFvx+DDfgTYfjSxjccbxvEFUWBlLxAme7OQBKPKFPys6GraHHpF7JuYCIePtlLRwvIa5rkAiqlxt
+        vGbIEZISiRZoUCUht3iUBtNgej69Op8GXy9n82A2n11+x5y6Qg/s8TnvaE5Vm+zxKVc0Bem/ixV8
+        Qlfq6UbQ/huTOk6AGJMNkF8HxPxAL+kRRJzD6fei9jRdVvt3+8sw2E6mClGhTusf50be4/N0p8aK
+        VV3idDC45haPDdQsw1Bfl/WAjJvQZZLJ3OoaPUcaqbS6E7E147Ehk40mruVS7iykGnLbLXCP/EF4
+        IbVWXbPRNRe6PIy2YdfxTKThUS6GAVWJstNwvA0Zi9JszeAaALTl0fQdE7RfErHgdW5D91aidip6
+        smiwwh2FLmAG6nlRu7XrrDiDkKv2e6Ss6D6j4WJFUYXOO6xaCurPAoWsotah+bfmcL32AusXu1/a
+        IWyFqrHdX7Sg63R3TYIAR6vHaRyiOOyIfYN43BZ66xPX0Vuf+K1P/NYndp12uv4O9IlLYddomI6y
+        6fh522frhx+KZ7ITFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:47 GMT
+      etag:
+      - W/"864721e64c3a2ec54e06b49d4fe38301"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:45 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D546DE:5B8EF57:5ED6612F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3031'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTY/aMBD9K8hnIMFxPqVKPbAgDrBadekqVBWaJGNiNh8odlYCxH/fsehK7Q0k
+        enHsGT+/mTdPOTNdAktYIIHHUoahH3H0oIgLoE+UT/IiE1nsuT4KkKFkQ9a0BW5VQaDlNA1eeGyy
+        t8pd7lPxPF0cV9O1+7zf1OnrwqfVW53WYlmvT+nbi7+Zz6olfxLpabbfzBduun8/Lac/q9V8Vq94
+        +o0e77uKHi6NOejEceCgxjtlyj4b523tdHhotVOjAW3aDkeVykYGtdGOXbfb+lgA5dA4BHIIUSvK
+        3dFaaepq+28Jf9HfQnwlvYcTelO2HUvOrIEaqfkfJZTQDZ4+urYhRbAGZTWhOVF4jDb8fWeDVhO6
+        QD1bGHe5O3KDkctfJyLhIhFiwy5Ddq3I4H+kMB1SBec/VgpDjAJPSOFlrpdLGcSFCIWfuxmGiNLj
+        GeaQBf5jp21r0M7N3CRMjVrDzkq3aJRRUA2sew6Qv1N0cJWNajxAh43RLPn11aDIecHj3MPI4zIK
+        uB/6XIZ+4QoIIoGTcOIXk8iLHtvgl53vYH+YnW/mvPwesg/slFQ5GEX+JVdcz0g/DAmVxiHrELRN
+        sb7RatdQZsjsBkzf0Tiavqqs7MeqBQLZ4+XyCXWbLu6oBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:47 GMT
+      etag:
+      - W/"24d9d84bfcbbf77d1aaffff3713ba047"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54734:5B8EFC5:5ED6612F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3030'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T207jMBCG3yXXUKeHHFwJIRrtolQCtOwFaYVU2fEkcXHsKHapuqjvvhOoBBQu
+        ykGrvXA88sTzf5r5/eBpVoM39gRzrGH5HSuht7RGe0dew1z1fsZWDBMxRHEuKBMRBToYDLkfh0E/
+        CgMhIIQo8KlPYx76WMrKPyhCwyNv1Sq8WjnX2DEhrJG9UrpqxXu5qUkLjbGkBsesMy0cK8mPHVhn
+        SfddLOpNh2nBkdxoBxoT+9ynLRQnYcEGtCiiKIgHMGSCCoZbnPdzwUecDv0ARqyICiSrXK0Wr6Fe
+        AB2CwpXh5FDFN7yIgHp7BJ9uC5YiHY8lHxiOMGutDBN7EC1b72azstDuGv44pkO68pWGuE3TWbKQ
+        CrA9O2U8gLUp02S6mt30VbrEuO4H8/Of/iy7VCJJbXr2mN/Ms8t7kU2X8+xCXskJT+RZeavTZBJ1
+        UZp0a7qeZdfmqcp1Jc5/3PNMPd/8HSzz4Uw+/T+ht7qLsl8NRogEOjdC6hKZONoxHOHZQkl9Z73x
+        g2dBFf+Vx9EV38HzKXN17+uF+L99W9vtX1VW7HngBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:47 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D5476F:5B8F00A:5ED6612F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3029'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyNDU0OmRjOWJmZWY2MzI1OTJjMWM3MmFmYzQ1OWRjZWUxYjAyODZmYmE1Nzg=","sha":"dc9bfef632592c1c72afc459dcee1b0286fba578","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/dc9bfef632592c1c72afc459dcee1b0286fba578","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:48Z"},"object":{"sha":"6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      etag:
+      - '"458ae9a77ac46417ca9290aa36775a7e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/dc9bfef632592c1c72afc459dcee1b0286fba578
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D547AE:5B8F051:5ED6612F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3028'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "dc9bfef632592c1c72afc459dcee1b0286fba578", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyNDU0OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"dc9bfef632592c1c72afc459dcee1b0286fba578","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/dc9bfef632592c1c72afc459dcee1b0286fba578"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:49 GMT
+      etag:
+      - '"2416311f66a292463f4c73610b725601"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D5482D:5B8F0EE:5ED66130
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3027'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:49 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54907:5B8F1FA:5ED66131
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3026'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjumliYLE9bLtogWzQYg/bvQiUREuMJVElKbuOkHfvP6Jk
+        ya6TOA6PuSQ2TX4zHM4Mh9NMZDKZB1fX10Ew+2l2NilVIkIam9x++nV9l/+Rx59vHvi3v1Zxudx8
+        uU9nt/e/T798/fPDBJN5ITDTCmPDsNgk3HIjLH5Y1Hkedr8WAqNWaXGey+ic5hr2/xWVlituQVvw
+        3IiziVqXQk/mzSRXqSwh5AAGgkjTq6vpz0Fwfbmn/OZuebP5HvxW829VlnzOV9H938Htp3hze5/+
+        i6Uc8rgOa52DnllbmTljbtD8eJFKm9VRbYSOVWlFaS9iVbCa9cI+rj7MAEl1h2lNhoE9XCU7klsO
+        nGGHd5LZIt9TxunQrjy8ZqHyXK3B3N/FkWLZFkBn1sJkmb4NBkDDlM0ETIvtPpKRJM78VGq7uGH0
+        D35JOINj0yI5Fdgth5LkYo8N06JSLbeOTKxlZaUqT1Z3BwKo0ikv5QN/ExQQAxYperJi7WJAxArO
+        fDLFrW5YG67xhsymRSzkCufxNvIeBmC7qSi73I0sSKckrQh5UlBSaHPF4xmi95WxcyABJWJ7+JN5
+        ifxFEaGX24T0bGC3xj0UpAcEEfUF+x+NQwADBqssxcYbk1gNw98u3mIkBh4pzZHEvQnZgTZs/JWc
+        ygpeeJPVwgDNlPJn+RYGqDSmFkf5/vGn2jIN64OtrIvIZdJjQux4MY6GPXBjZFoK4c3iW2DD+ksg
+        0ryMM38iel7D3KfWa3jqbQvEAjLKVeSNiQudtcCGmYy7q9GGPrUmCcTbEaDFwusWiLcVYLVHv2nV
+        J+AWj9vawoW86d/zWNOdQM7LtOapPwlbIF1WKFVS/vBihXZ8zA5E4Kk01TKq/SbmgUk7cEUR8o+/
+        IxiQg4C26nq+pHuFkUaVXGumopAv1TzH0zvcToh5FkFxsC+Gvr9cur1uG8Rr2HC/uMusk+TrNLrb
+        rNd/LK97W3lzrZ7Hmh8qbjPKsBBbcS18babDsSbCU/fx4uKiyQRvnyWF0B6ziKMBy3Wcobz2pX/T
+        81A5Fty2z58FqZ/gOZQrnng7iy0QcOcCvvbgaGM/qlCve1O8hY3phczRtVClvztiII7llMrKhYyP
+        eSseH+Y70OajkWUszjieN4gKK2OJOMGTnTwARb7wZ0VHw/bQI3LPxFwgZLydkhaO1zDXFUhElauN
+        1ww5QlIi0QINqiTkFo/SYBpMz6dX59Pg6+VsHszms8vvmFNX6IE9Peea5lS1yZ6eckNTkP67WMEn
+        dKWebwTtvzGp4wSIMdkA+WVAzA/0kp5AxDmcfi9qT9NltX+3vw6D7WSqEBXqtP5xbuQDPk93aqxY
+        1SVOB4NrbvHYQM0yDPV1WQ/IuAldJpnMra7Rc6SRSqt7EVszHhsy2WjiWi7lzkKqIbfdAvfIH4QX
+        UmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3WDK4BQFseTd8xQfslEQte5zZ0byVqp6In
+        iwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qloP4sUMgqah2af2oO12svsH6x+6Ud
+        wlaoGtv9RQu6TnfXJAhwtHqcxiGKw47YN4jHbaH3PnEdvfeJ3/vE731i12mn6+9An7gUdo2G6Sib
+        jp+3fbZ+/A83JpPPFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:49 GMT
+      etag:
+      - W/"837659f4fb3ab4e26ab69cf78aee6ef0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54948:5B8F24D:5ED66131
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3025'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:50 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54984:5B8F297:5ED66131
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3024'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjumliYLE9bLtogWzQYg/bvQiUREuMJVElKbuOkHfvP6Jk
+        ya6TOA6PuSQ2TX4zHM4Mh9NMZDKZB1fX10Ew+2l2NilVIkIam9x++nV9l/+Rx59vHvi3v1Zxudx8
+        uU9nt/e/T798/fPDBJN5ITDTCmPDsNgk3HIjLH5Y1Hkedr8WAqNWaXGey+ic5hr2/xWVlituQVvw
+        3IiziVqXQk/mzSRXqSwh5AAGgkjTq6vpz0Fwfbmn/OZuebP5HvxW829VlnzOV9H938Htp3hze5/+
+        i6Uc8rgOa52DnllbmTljbtD8eJFKm9VRbYSOVWlFaS9iVbCa9cI+rj7MAEl1h2lNhoE9XCU7klsO
+        nGGHd5LZIt9TxunQrjy8ZqHyXK3B3N/FkWLZFkBn1sJkmb4NBkDDlM0ETIvtPpKRJM78VGq7uGH0
+        D35JOINj0yI5Fdgth5LkYo8N06JSLbeOTKxlZaUqT1Z3BwKo0ikv5QN/ExQQAxYperJi7WJAxArO
+        fDLFrW5YG67xhsymRSzkCufxNvIeBmC7qSi73I0sSKckrQh5UlBSaHPF4xmi95WxcyABJWJ7+JN5
+        ifxFEaGX24T0bGC3xj0UpAcEEfUF+x+NQwADBqssxcYbk1gNw98u3mIkBh4pzZHEvQnZgTZs/JWc
+        ygpeeJPVwgDNlPJn+RYGqDSmFkf5/vGn2jIN64OtrIvIZdJjQux4MY6GPXBjZFoK4c3iW2DD+ksg
+        0ryMM38iel7D3KfWa3jqbQvEAjLKVeSNiQudtcCGmYy7q9GGPrUmCcTbEaDFwusWiLcVYLVHv2nV
+        J+AWj9vawoW86d/zWNOdQM7LtOapPwlbIF1WKFVS/vBihXZ8zA5E4Kk01TKq/SbmgUk7cEUR8o+/
+        IxiQg4C26nq+pHuFkUaVXGumopAv1TzH0zvcToh5FkFxsC+Gvr9cur1uG8Rr2HC/uMusk+TrNLrb
+        rNd/LK97W3lzrZ7Hmh8qbjPKsBBbcS18babDsSbCU/fx4uKiyQRvnyWF0B6ziKMBy3Wcobz2pX/T
+        81A5Fty2z58FqZ/gOZQrnng7iy0QcOcCvvbgaGM/qlCve1O8hY3phczRtVClvztiII7llMrKhYyP
+        eSseH+Y70OajkWUszjieN4gKK2OJOMGTnTwARb7wZ0VHw/bQI3LPxFwgZLydkhaO1zDXFUhElauN
+        1ww5QlIi0QINqiTkFo/SYBpMz6dX59Pg6+VsHszms8vvmFNX6IE9Peea5lS1yZ6eckNTkP67WMEn
+        dKWebwTtvzGp4wSIMdkA+WVAzA/0kp5AxDmcfi9qT9NltX+3vw6D7WSqEBXqtP5xbuQDPk93aqxY
+        1SVOB4NrbvHYQM0yDPV1WQ/IuAldJpnMra7Rc6SRSqt7EVszHhsy2WjiWi7lzkKqIbfdAvfIH4QX
+        UmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3WDK4BQFseTd8xQfslEQte5zZ0byVqp6In
+        iwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qloP4sUMgqah2af2oO12svsH6x+6Ud
+        wlaoGtv9RQu6TnfXJAhwtHqcxiGKw47YN4jHbaH3PnEdvfeJ3/vE731i12mn6+9An7gUdo2G6Sib
+        jp+3fbZ+/A83JpPPFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:50 GMT
+      etag:
+      - W/"837659f4fb3ab4e26ab69cf78aee6ef0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D549EA:5B8F313:5ED66132
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3023'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QT0+DQBDFv8uehQUstJD0YIIaG7EXa7UXsn+Gsg3sEnZogk2/u6NnDx68vMu8
+        N/N7c2EjNKz4Vs9RHD0/w+iNs0EcRuyGWaehNpocVVllu/6tr04fi235NL+Uu2hrN93BVmf9+GDV
+        nCeH982n2OfT8+v9VN2t17RgGjsKt4iDLzgXgwmPBttJhsr1fITBed4DCo9uhKAzMkDwSCikdd3P
+        WtAMkFOI3L8zOnkChay4MN8KOqZVLhtostskzRMVq2UiGrVIc60AYhklq6yRIl2uiA7nAShBxf8X
+        9eeTf+a4Xr8AgB9Dm4cBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:50 GMT
+      etag:
+      - W/"2416311f66a292463f4c73610b725601"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54A3F:5B8F371:5ED66132
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3022'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/dc9bfef632592c1c72afc459dcee1b0286fba578
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S246bMBD9lcjPIYADJCBVaqXsVrsSi7rdLSIv0QBjMMKAsFmVrPLvHSs/0Ep9
+        sT2Xc+bMkT/ZMNZ4kTVLWHpKo1/fH4e0K4Ls9LS+nN69TL12Wf6sznnB0+uTn709d2me7lP1qIrr
+        Dz/LX7tz/v676L6t2emsCvXgv1ybL2zLdAtEWldxKVBEex7GvPKrAwdRBWFcV4h+6fFjJEoID0cC
+        LHNPgNaYSSeuC5PcNdK0S7mrRuXOOI3aVWhAm3FGp5elY1Ab7drzclFrDVRD4xLINdBo9x9GU3+D
+        M0s+2QAKScXPFlqYNw8f8ziQNFQgrTjaidI7tOmvjU1acdRAwy2Me9xzvMjx+JsfJDxIguOZ3bZs
+        LDusjOW/uxIJ4LEQh0N45LiHOq6BriP5U5dBGe+9EAMQB0HMZp0sM41R0vxfl+6c2v1rNbQJOUVq
+        PnDWchwcf+eRJIVaQ2NVputmkBVuemlMjxvbvLXNUsgKDCGsBfcY6csJ6DVu2YygbYktg5bNQBX6
+        PfQAs8zEOix9v2UTrP0IBLLh7fYHovtgbLkCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:50 GMT
+      etag:
+      - W/"458ae9a77ac46417ca9290aa36775a7e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54AA5:5B8F3E0:5ED66132
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3021'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:51 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54AEA:5B8F442:5ED66132
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3020'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjumliYLE9bLtogWzQYg/bvQiUREuMJVElKbuOkHfvP6Jk
+        ya6TOA6PuSQ2TX4zHM4Mh9NMZDKZB1fX10Ew+2l2NilVIkIam9x++nV9l/+Rx59vHvi3v1Zxudx8
+        uU9nt/e/T798/fPDBJN5ITDTCmPDsNgk3HIjLH5Y1Hkedr8WAqNWaXGey+ic5hr2/xWVlituQVvw
+        3IiziVqXQk/mzSRXqSwh5AAGgkjTq6vpz0Fwfbmn/OZuebP5HvxW829VlnzOV9H938Htp3hze5/+
+        i6Uc8rgOa52DnllbmTljbtD8eJFKm9VRbYSOVWlFaS9iVbCa9cI+rj7MAEl1h2lNhoE9XCU7klsO
+        nGGHd5LZIt9TxunQrjy8ZqHyXK3B3N/FkWLZFkBn1sJkmb4NBkDDlM0ETIvtPpKRJM78VGq7uGH0
+        D35JOINj0yI5Fdgth5LkYo8N06JSLbeOTKxlZaUqT1Z3BwKo0ikv5QN/ExQQAxYperJi7WJAxArO
+        fDLFrW5YG67xhsymRSzkCufxNvIeBmC7qSi73I0sSKckrQh5UlBSaHPF4xmi95WxcyABJWJ7+JN5
+        ifxFEaGX24T0bGC3xj0UpAcEEfUF+x+NQwADBqssxcYbk1gNw98u3mIkBh4pzZHEvQnZgTZs/JWc
+        ygpeeJPVwgDNlPJn+RYGqDSmFkf5/vGn2jIN64OtrIvIZdJjQux4MY6GPXBjZFoK4c3iW2DD+ksg
+        0ryMM38iel7D3KfWa3jqbQvEAjLKVeSNiQudtcCGmYy7q9GGPrUmCcTbEaDFwusWiLcVYLVHv2nV
+        J+AWj9vawoW86d/zWNOdQM7LtOapPwlbIF1WKFVS/vBihXZ8zA5E4Kk01TKq/SbmgUk7cEUR8o+/
+        IxiQg4C26nq+pHuFkUaVXGumopAv1TzH0zvcToh5FkFxsC+Gvr9cur1uG8Rr2HC/uMusk+TrNLrb
+        rNd/LK97W3lzrZ7Hmh8qbjPKsBBbcS18babDsSbCU/fx4uKiyQRvnyWF0B6ziKMBy3Wcobz2pX/T
+        81A5Fty2z58FqZ/gOZQrnng7iy0QcOcCvvbgaGM/qlCve1O8hY3phczRtVClvztiII7llMrKhYyP
+        eSseH+Y70OajkWUszjieN4gKK2OJOMGTnTwARb7wZ0VHw/bQI3LPxFwgZLydkhaO1zDXFUhElauN
+        1ww5QlIi0QINqiTkFo/SYBpMz6dX59Pg6+VsHszms8vvmFNX6IE9Peea5lS1yZ6eckNTkP67WMEn
+        dKWebwTtvzGp4wSIMdkA+WVAzA/0kp5AxDmcfi9qT9NltX+3vw6D7WSqEBXqtP5xbuQDPk93aqxY
+        1SVOB4NrbvHYQM0yDPV1WQ/IuAldJpnMra7Rc6SRSqt7EVszHhsy2WjiWi7lzkKqIbfdAvfIH4QX
+        UmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3WDK4BQFseTd8xQfslEQte5zZ0byVqp6In
+        iwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qloP4sUMgqah2af2oO12svsH6x+6Ud
+        wlaoGtv9RQu6TnfXJAhwtHqcxiGKw47YN4jHbaH3PnEdvfeJ3/vE731i12mn6+9An7gUdo2G6Sib
+        jp+3fbZ+/A83JpPPFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:51 GMT
+      etag:
+      - W/"837659f4fb3ab4e26ab69cf78aee6ef0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54B34:5B8F498:5ED66133
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3019'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTY/aMBD9K8hnIMFxPqVKPbAgDrBadekqVBWaJGNiNh8odlYCxH/fsehK7Q0k
+        enHsGT+/mTdPOTNdAktYIIHHUoahH3H0oIgLoE+UT/IiE1nsuT4KkKFkQ9a0BW5VQaDlNA1eeGyy
+        t8pd7lPxPF0cV9O1+7zf1OnrwqfVW53WYlmvT+nbi7+Zz6olfxLpabbfzBduun8/Lac/q9V8Vq94
+        +o0e77uKHi6NOejEceCgxjtlyj4b523tdHhotVOjAW3aDkeVykYGtdGOXbfb+lgA5dA4BHIIUSvK
+        3dFaaepq+28Jf9HfQnwlvYcTelO2HUvOrIEaqfkfJZTQDZ4+urYhRbAGZTWhOVF4jDb8fWeDVhO6
+        QD1bGHe5O3KDkctfJyLhIhFiwy5Ddq3I4H+kMB1SBec/VgpDjAJPSOFlrpdLGcSFCIWfuxmGiNLj
+        GeaQBf5jp21r0M7N3CRMjVrDzkq3aJRRUA2sew6Qv1N0cJWNajxAh43RLPn11aDIecHj3MPI4zIK
+        uB/6XIZ+4QoIIoGTcOIXk8iLHtvgl53vYH+YnW/mvPwesg/slFQ5GEX+JVdcz0g/DAmVxiHrELRN
+        sb7RatdQZsjsBkzf0Tiavqqs7MeqBQLZ4+XyCXWbLu6oBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:51 GMT
+      etag:
+      - W/"24d9d84bfcbbf77d1aaffff3713ba047"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54B7C:5B8F4F9:5ED66133
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3018'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82T207jMBCG3yXXUKeHHFwJIRrtolQCtOwFaYVU2fEkcXHsKHapuqjvvhOoBBQu
+        ykGrvXA88sTzf5r5/eBpVoM39gRzrGH5HSuht7RGe0dew1z1fsZWDBMxRHEuKBMRBToYDLkfh0E/
+        CgMhIIQo8KlPYx76WMrKPyhCwyNv1Sq8WjnX2DEhrJG9UrpqxXu5qUkLjbGkBsesMy0cK8mPHVhn
+        SfddLOpNh2nBkdxoBxoT+9ynLRQnYcEGtCiiKIgHMGSCCoZbnPdzwUecDv0ARqyICiSrXK0Wr6Fe
+        AB2CwpXh5FDFN7yIgHp7BJ9uC5YiHY8lHxiOMGutDBN7EC1b72azstDuGv44pkO68pWGuE3TWbKQ
+        CrA9O2U8gLUp02S6mt30VbrEuO4H8/Of/iy7VCJJbXr2mN/Ms8t7kU2X8+xCXskJT+RZeavTZBJ1
+        UZp0a7qeZdfmqcp1Jc5/3PNMPd/8HSzz4Uw+/T+ht7qLsl8NRogEOjdC6hKZONoxHOHZQkl9Z73x
+        g2dBFf+Vx9EV38HzKXN17+uF+L99W9vtX1VW7HngBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:51 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:44 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54BCA:5B8F54A:5ED66133
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3017'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "ver 1.0", "type":
+      "commit", "object": "6fa29ff77582e3ad9dae3a8c1cdb4b9305e4af7f"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"message":"Could not verify tag name","documentation_url":"https://developer.github.com/v3/git/tags/#create-a-tag-object"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-length:
+      - '123'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:52 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 422 Unprocessable Entity
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54C11:5B8F59B:5ED66133
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3016'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:52 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54C61:5B8F604:5ED66134
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3015'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjumliYLE9bLtogWzQYg/bvQiUREuMJVElKbuOkHfvP6Jk
+        ya6TOA6PuSQ2TX4zHM4Mh9NMZDKZB1fX10Ew+2l2NilVIkIam9x++nV9l/+Rx59vHvi3v1Zxudx8
+        uU9nt/e/T798/fPDBJN5ITDTCmPDsNgk3HIjLH5Y1Hkedr8WAqNWaXGey+ic5hr2/xWVlituQVvw
+        3IiziVqXQk/mzSRXqSwh5AAGgkjTq6vpz0Fwfbmn/OZuebP5HvxW829VlnzOV9H938Htp3hze5/+
+        i6Uc8rgOa52DnllbmTljbtD8eJFKm9VRbYSOVWlFaS9iVbCa9cI+rj7MAEl1h2lNhoE9XCU7klsO
+        nGGHd5LZIt9TxunQrjy8ZqHyXK3B3N/FkWLZFkBn1sJkmb4NBkDDlM0ETIvtPpKRJM78VGq7uGH0
+        D35JOINj0yI5Fdgth5LkYo8N06JSLbeOTKxlZaUqT1Z3BwKo0ikv5QN/ExQQAxYperJi7WJAxArO
+        fDLFrW5YG67xhsymRSzkCufxNvIeBmC7qSi73I0sSKckrQh5UlBSaHPF4xmi95WxcyABJWJ7+JN5
+        ifxFEaGX24T0bGC3xj0UpAcEEfUF+x+NQwADBqssxcYbk1gNw98u3mIkBh4pzZHEvQnZgTZs/JWc
+        ygpeeJPVwgDNlPJn+RYGqDSmFkf5/vGn2jIN64OtrIvIZdJjQux4MY6GPXBjZFoK4c3iW2DD+ksg
+        0ryMM38iel7D3KfWa3jqbQvEAjLKVeSNiQudtcCGmYy7q9GGPrUmCcTbEaDFwusWiLcVYLVHv2nV
+        J+AWj9vawoW86d/zWNOdQM7LtOapPwlbIF1WKFVS/vBihXZ8zA5E4Kk01TKq/SbmgUk7cEUR8o+/
+        IxiQg4C26nq+pHuFkUaVXGumopAv1TzH0zvcToh5FkFxsC+Gvr9cur1uG8Rr2HC/uMusk+TrNLrb
+        rNd/LK97W3lzrZ7Hmh8qbjPKsBBbcS18babDsSbCU/fx4uKiyQRvnyWF0B6ziKMBy3Wcobz2pX/T
+        81A5Fty2z58FqZ/gOZQrnng7iy0QcOcCvvbgaGM/qlCve1O8hY3phczRtVClvztiII7llMrKhYyP
+        eSseH+Y70OajkWUszjieN4gKK2OJOMGTnTwARb7wZ0VHw/bQI3LPxFwgZLydkhaO1zDXFUhElauN
+        1ww5QlIi0QINqiTkFo/SYBpMz6dX59Pg6+VsHszms8vvmFNX6IE9Peea5lS1yZ6eckNTkP67WMEn
+        dKWebwTtvzGp4wSIMdkA+WVAzA/0kp5AxDmcfi9qT9NltX+3vw6D7WSqEBXqtP5xbuQDPk93aqxY
+        1SVOB4NrbvHYQM0yDPV1WQ/IuAldJpnMra7Rc6SRSqt7EVszHhsy2WjiWi7lzkKqIbfdAvfIH4QX
+        UmvVNRtdc6HLw2gbdh3PRBoe5WIYUJUoOw3H25CxKM3WDK4BQFseTd8xQfslEQte5zZ0byVqp6In
+        iwYr3FHoAmagnhe1W7vOijMIuWq/R8qK7jMaLlYUVei8w6qloP4sUMgqah2af2oO12svsH6x+6Ud
+        wlaoGtv9RQu6TnfXJAhwtHqcxiGKw47YN4jHbaH3PnEdvfeJ3/vE731i12mn6+9An7gUdo2G6Sib
+        jp+3fbZ+/A83JpPPFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:52 GMT
+      etag:
+      - W/"837659f4fb3ab4e26ab69cf78aee6ef0"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:48 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54C9F:5B8F656:5ED66134
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3014'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:24:53 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C990:2668E:4D54CF0:5B8F6BA:5ED66134
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3013'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_name_only.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_name_only.yaml
@@ -1,0 +1,5189 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:34 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571D5AA:677AD61:5ED660E6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3213'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:34 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571D602:677ADAD:5ED660E6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3212'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822169,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjIxNjk=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:23:34Z","updated_at":"2020-06-02T14:23:34Z","pushed_at":"2020-06-02T14:23:35Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:36 GMT
+      etag:
+      - '"aa36511b0f1198160d5a5f6f182e7a97"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571D65E:677AE24:5ED660E6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3211'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"248f571e0ebe789d8c8239c72627d761f033f51b","node_id":"MDY6Q29tbWl0MjY4ODIyMTY5OjI0OGY1NzFlMGViZTc4OWQ4YzgyMzljNzI2MjdkNzYxZjAzM2Y1MWI=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/248f571e0ebe789d8c8239c72627d761f033f51b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/248f571e0ebe789d8c8239c72627d761f033f51b","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:36Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:36Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:37 GMT
+      etag:
+      - '"ea5d6e65c6add632f7f1be3bd3592fd9"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571D876:677B08E:5ED660E8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3210'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X32+bMBD+Vyqe00IICUmkaZvUbcpDWlXr1qXTFBk4wJmxmW3Shaj/++4IXZs8
+        dKXq3voSgc13/u67H75sHckKcKZOwYwF7fScWBUFt85065ic4YYfjNNh2AcPIgjHk2Qcj/3BJA79
+        kR8m4aifeoNBOuxHCJUqgSVPEDQ/XYwu/ImNroQ3Xy2C89PZZn65GJ6vZt75p0X/rP4o5p++8uvL
+        ODi/uggWdbaZ12J1Vs/8+Sr5eVYvfl+v3tdzf9GfX83e7PFilc2VJoYt9885y5k++rDWSuKXUDAu
+        kATyx+UToOV3GS2eoHP4QcIsuex7vnfsjY49/7IfTP3BdDC6dm7vFCA1/tsRBRjDMiIxk9xyJngN
+        R0iLHWkoleFW6Q0StRrwm7tIoNSTJPUHYTj2g7AfDMeQ+P6EhVEUjOMQd8ZJOAAPgZUmAXJrSzN1
+        XVbyk4zbvIpIALc5wi3AYsiVhmPBo2MLxhqXfpfLYkNMDFgXQS5xMO6Tz0b9XvDwXTIat0MSEgSk
+        XcaqkpjGXs9Zg+Ypj5nlmB6o5u4dME9TJgz0HA3M0JZTScMziTs9hx6YrTTqLyshek7JNkIxBNHr
+        7cu5+QwXc1uI5b7KD8L7lMDuDn2GrObg3GenVle33TauBmNz3wCEyjgFzuRNleMetZ/RcDga7Lej
+        i9HXb2ciXmHruVzUZGONOa4PvWkWjd9WS2VAx0paTKemcCq3sfx2/SZAC5lubTQd719FR7aMe8/z
+        8Rjef5cqIdQNYg+p7tf0nnn3LwhZ7Z65zLobQNDWVTYH1Anp35LTHPtEF0sNYIudBDsLT8iEQYk1
+        JF2MtBAkcyORx7ZpYY2tKjKx5iWVdidae0A0pHTGJK+bHtHJEAIpJZue2sWlBoBAWGN2dULuEFu3
+        1HzN4g3JoCEGvkZNu1s7gKIxuynpYvqCESeFuYUlSwoqs6ZdHl6QryXYXquvJditcl5LcHdpYTPb
+        q94nlWDJNPUNZ/r9BxbkUnD5E19wUgSRvsTkF2km4xwHv7//C+jCemC548BBU+SdLSRcamUhtg9m
+        sHalHdFAskjsTWi/Kk6XBt4EtjJLpBbvHAaZKh1DM/IJbH/EUaUpitjc3L9bje7PxBMe79NPH48P
+        RMKO3HhFPtz+ASKrBApZDQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:37 GMT
+      etag:
+      - W/"8bbaeb185e73a7366d9bbf47a60f8775"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DA02:677B262:5ED660E9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3209'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:37 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DA66:677B2D6:5ED660E9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3208'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/248f571e0ebe789d8c8239c72627d761f033f51b
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTwY6bMBD9lchnEsCQGJAqtdK2qxxItGrUiFRVZGAAUwORbVaFKP/ecdPD7m1X
+        ai8WnsfMezPzfCW64SQhNIyqNfPBgxxYFJdREdEgLhjdUFayjV95QVCt/Zw4pB9KOIsSk9KHbPNE
+        Y5MfpZe2Wbh/2E7pIVvv2623f8z83fxFpo/fxOlQhPvjU5jN9ZTOst3NW5q25c/dnP06tZ/mlGZ+
+        etx+wOKjkli4MeaiE9flF7GqhWnGfFUMnavgMmi3A8O1GRQspciXBrTRrj3P524qOWJgXExyMaMT
+        iL2jtcZ08vxawgv6txDfSd/DyUfTDIokV9LzDrD5rw1vuFp8flZDjxOBjgs7E9wThldgwx9rG7Qz
+        wR+wZ5tGPeotvc3Sowc/TGiQBJsTuTnkrsjAf6QwClDB9a+V0CtxWdGAsYiGzA/XEZSUxpzleRgV
+        DJGoZAF4/3bbVoN238yNg+lAa17b0W17YQSXYoaFNdDij88EWmxCjReuoDeaJN9/OOQZlKhEwY3A
+        3WDH9zvgY6i41OAQBVxbiIy9FnWPiEPsBzejQqp+lNKWnOTAMcleb7ffUx376oQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      etag:
+      - W/"1d2c00c3de60444daad3b342f431a96e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DB03:677B391:5ED660E9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3207'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["248f571e0ebe789d8c8239c72627d761f033f51b"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"b9c59d7d26679f868b94d97b564b9b7f41185bec","node_id":"MDY6Q29tbWl0MjY4ODIyMTY5OmI5YzU5ZDdkMjY2NzlmODY4Yjk0ZDk3YjU2NGI5YjdmNDExODViZWM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b9c59d7d26679f868b94d97b564b9b7f41185bec","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:38Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:38Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"248f571e0ebe789d8c8239c72627d761f033f51b","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/248f571e0ebe789d8c8239c72627d761f033f51b","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/248f571e0ebe789d8c8239c72627d761f033f51b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      etag:
+      - '"792004ff155c9ccf31e9dad7f52446c9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DB59:677B3F2:5ED660EA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3206'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngklC4pAZQVvJYmlTwRLZ8aU2iuMoPpBSxH/voY5dOnR5y7vv
+        3ndjE3SsemTkFpSJ3KuIMLEnNgQDjTPUyq0s3n3t5fm4PmxfZvl2zA/Da38a5FXta3t6llf9sfsy
+        +3om8DL1BFnEMVacq9EtPx3ai162wfMJxkAjgDQTJlj0Ti8QIkb+yKbxs1HUAXKC6Pq3V9BnaJFV
+        NxatoqF0XXa5SGAFGkS5MWVbptmmFWmRCiOKpFtlWZcnmsxwHoEI8vAO/9f052fkf7a5378Bx6+9
+        GX0BAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:39 GMT
+      etag:
+      - W/"dd4f3aeba807806ceaae0ed85fd52813"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DC2C:677B4C7:5ED660EA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3205'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "b9c59d7d26679f868b94d97b564b9b7f41185bec"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWqsoceLMFQUkqwsEtUtkxxfsKo4j+1opVP3vXMXIwsDylnff
+        ve/KEgysuWfmDrTNPOiMkNgDm6KFzltq1VaJ99AGdToU++3Lot4O5X56HY+Tuuhd647P6mI+nr7s
+        rl0IPKeRIIc454ZzPfv1p0d3Nus+Bp5gjjQCSDMxwWr0ZoWQMfN7dl1YrKYOkBNE17+9ojlBj6y5
+        suw0DRnZl9JW9lGISg61qI0srKxMKQojTTUUm01dGujJDJcZiCCP4PF/TX9+Zv5nm9vtG7CgU799
+        AQAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:39 GMT
+      etag:
+      - W/"47c5510fe26b7f1f481103f543ac0da3"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DC7F:677B551:5ED660EB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3204'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:40 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DD55:677B649:5ED660EB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3203'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjBGliYLE9bLtogWyAoofdvQiUREu0JVElKXsdIe/ef0jJ
+        kl1v4jg85pLYNPnNcDgzHE47EelkFt7c3obh5c3d2aSSKY9obHL/6ff1Q/FXkXy+e2Rf/14l1XLz
+        ZZFd3y/+/PFlsfwwwWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTpzc301zC8vdxTfvOwvNt8D/9o2Nc6Tz8Xq3jxLbz/lGzuF9kP
+        LGWQx1TUqAL03Jhaz4LADeqri0yYvIkbzVUiK8Mrc5HIMmiCXtjH1YdrQDLVYazJMLCHq0VHcsuB
+        08HhneSmLPaUcTrYlYfXzGVRyDWY+7s4UmywBdCZWZiosrfBAGgDaXIO02K7T2QkgTM/lWoXtwH9
+        g18STuPYFE9PBXbLoSS52FMbKF5Ly21inShRGyGrk9XdgQAqVcYq8cjeBAVEg0WKnqyYXQwIX8GZ
+        T6a41W1gwzXZkNkUT7hY4TzeRt7DAGw2NWWXh5EF6ZSE4RFLS0oKNlc8nSF6Xxk7BxJQyreHP5lV
+        yF8UEWq5TUjPBrY17qEgPSCIqC/Y/2gcAhgwWGXJN96YxGoD/O3iLUFiYLFUDEncm5AdaBuMv5JT
+        Gc5Kb7IsDNBcSn+WtzBAhdYNP8r3jz9Vy9RBH2xVU8Yukx4TYseLcTTsgWktsopzbxbfAtugvwRi
+        xaok9yei57WB+2S9hmXetkAsIONCxt6YuNADC2wDnTN3NZrIp9YkgXg7AhSfe90C8bYCjPLoN1Z9
+        Am7xuK0NXMib/j0vaLsTKFiVNSzzJ2ELpMsKpUrGHl+s0I6P2YEIPJWmSsSN38Q8MGkHrihC/vF3
+        BANyEGCrrudLulcYaVTJWTOVpXip5jme3uF2QsyzCIqDfTH0/eXS7XXbIF4bDPeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nlB+0vNTE4ZFmJrprivzXS4oI3x1H26uLhoc87ss6TkymMWcTRgmUpylNe+9G97
+        HirHkhn7/JmT+imeQ4Vkqbez2AIBdy7gaw+ONvajGvW6N8UtbEwvRYGuhaz83REDcSynkkbMRXLM
+        W/H4MN+Bth+1qBJ+xvC8QVQYkQjECZ7s5AEo8rk/KzoatocekXsmFhwh4+2UFHe8NnBdgZTXhdx4
+        zZAjJCUSxdGgSiNm8CgNp+H0fHpzPg3/ubyehVezq+vvmNPU6IH9fM4dzakbnb8wBem/ixV8Qlfq
+        +UbQ/huTOk6Qo3U+QH4bELMDvaSfIJICTr8Xtafpstq/21+HwXZyWfIadVr/ONfiEZ+nOzVWIpsK
+        p4PBNTN4bKBmGYb6uqwH5ExHLpNMZkY16DnSSK3kgidGj8eGTDaauBZLsbOQashtt8A98gfhpVBK
+        ds1G11zo8jDahl3HMxWaxQUfBmTNq07D8TZEwiu9NYNrANCWR9N3TGC/pHzOmsJE7q1E7VT0ZNFg
+        hTtyVcIM1POidmvXWXEGIVft90hZ0X1Gw8Xwso6cdxi55NSfBQpZRa4j/W/D4Hr2AusXu1/sELZC
+        1djuL4rTdbq7JkWAo9XjNI5QHHbEvkE8bgu994mb+L1P/N4nfu8Tu047XX8H+sQVN2s0TEfZdPy8
+        7bP1038q9gMsFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:40 GMT
+      etag:
+      - W/"9ad2afe2cc30bd6ba885bf3bf292576d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:39 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DD9D:677B698:5ED660EC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3202'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:40 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DDE9:677B6F1:5ED660EC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3201'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjBGliYLE9bLtogWyAoofdvQiUREu0JVElKXsdIe/ef0jJ
+        kl1v4jg85pLYNPnNcDgzHE47EelkFt7c3obh5c3d2aSSKY9obHL/6ff1Q/FXkXy+e2Rf/14l1XLz
+        ZZFd3y/+/PFlsfwwwWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTpzc301zC8vdxTfvOwvNt8D/9o2Nc6Tz8Xq3jxLbz/lGzuF9kP
+        LGWQx1TUqAL03Jhaz4LADeqri0yYvIkbzVUiK8Mrc5HIMmiCXtjH1YdrQDLVYazJMLCHq0VHcsuB
+        08HhneSmLPaUcTrYlYfXzGVRyDWY+7s4UmywBdCZWZiosrfBAGgDaXIO02K7T2QkgTM/lWoXtwH9
+        g18STuPYFE9PBXbLoSS52FMbKF5Ly21inShRGyGrk9XdgQAqVcYq8cjeBAVEg0WKnqyYXQwIX8GZ
+        T6a41W1gwzXZkNkUT7hY4TzeRt7DAGw2NWWXh5EF6ZSE4RFLS0oKNlc8nSF6Xxk7BxJQyreHP5lV
+        yF8UEWq5TUjPBrY17qEgPSCIqC/Y/2gcAhgwWGXJN96YxGoD/O3iLUFiYLFUDEncm5AdaBuMv5JT
+        Gc5Kb7IsDNBcSn+WtzBAhdYNP8r3jz9Vy9RBH2xVU8Yukx4TYseLcTTsgWktsopzbxbfAtugvwRi
+        xaok9yei57WB+2S9hmXetkAsIONCxt6YuNADC2wDnTN3NZrIp9YkgXg7AhSfe90C8bYCjPLoN1Z9
+        Am7xuK0NXMib/j0vaLsTKFiVNSzzJ2ELpMsKpUrGHl+s0I6P2YEIPJWmSsSN38Q8MGkHrihC/vF3
+        BANyEGCrrudLulcYaVTJWTOVpXip5jme3uF2QsyzCIqDfTH0/eXS7XXbIF4bDPeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nlB+0vNTE4ZFmJrprivzXS4oI3x1H26uLhoc87ss6TkymMWcTRgmUpylNe+9G97
+        HirHkhn7/JmT+imeQ4Vkqbez2AIBdy7gaw+ONvajGvW6N8UtbEwvRYGuhaz83REDcSynkkbMRXLM
+        W/H4MN+Bth+1qBJ+xvC8QVQYkQjECZ7s5AEo8rk/KzoatocekXsmFhwh4+2UFHe8NnBdgZTXhdx4
+        zZAjJCUSxdGgSiNm8CgNp+H0fHpzPg3/ubyehVezq+vvmNPU6IH9fM4dzakbnb8wBem/ixV8Qlfq
+        +UbQ/huTOk6Qo3U+QH4bELMDvaSfIJICTr8Xtafpstq/21+HwXZyWfIadVr/ONfiEZ+nOzVWIpsK
+        p4PBNTN4bKBmGYb6uqwH5ExHLpNMZkY16DnSSK3kgidGj8eGTDaauBZLsbOQashtt8A98gfhpVBK
+        ds1G11zo8jDahl3HMxWaxQUfBmTNq07D8TZEwiu9NYNrANCWR9N3TGC/pHzOmsJE7q1E7VT0ZNFg
+        hTtyVcIM1POidmvXWXEGIVft90hZ0X1Gw8Xwso6cdxi55NSfBQpZRa4j/W/D4Hr2AusXu1/sELZC
+        1djuL4rTdbq7JkWAo9XjNI5QHHbEvkE8bgu994mb+L1P/N4nfu8Tu047XX8H+sQVN2s0TEfZdPy8
+        7bP1038q9gMsFRsAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:40 GMT
+      etag:
+      - W/"9ad2afe2cc30bd6ba885bf3bf292576d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:39 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DE44:677B75A:5ED660EC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3200'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZlW7INhR68lBySULrbxSklSPYoVuKPYMlLsyH/vSPShfaW
+        QHoR0oxGb96bh87E1IJkRKZlnFa8oozxVCUskWlUpVzGLJKp5CoKgiSWUJIp6foKtrrComVesK80
+        tfK18Zf7Ilrni9PyuYjX7SIu3l/iTV4dME5X7027zouo2B/8TX4Ii/0LXX3BO/uqXeVPv9b5d715
+        XX7Cx8ehwYdra48m8zxx1POdtvUo52XfegMce+O1YIWx/QCzRsuZBWON59bttj1VAnNgPSzysKLV
+        mLuDWm3bZvtvC3/B3wJ8Bb0HU4y27geSnUknWkDy32pRi2Hy9Db0HSoCrdBOE5wThufgwp93Lug0
+        wQvI2ZVRn/ozn818+hxEGQ2zMNmQy5RcO7LwHyHsANjB+Y+VOIeEhZGKQumHpVIsrSIexaUvgQOo
+        kKKNhGTxY6ftejDezdgoTAvGiJ2TbtFpq0Uzce45ivKA0clVNuzxKAborCHZjw+CNEpUzAPwARkl
+        aZWUCQ3TklNGecVZoPwwVHEgH0vww853oD/MzjdjXn5OyRsMWulSWI3+RVdcz4AfhhKNgSkZQBiX
+        ImNn9K7DzJS4jbDjgOPoxqZxsp+aXmCRO14uvwEhLyk8qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:41 GMT
+      etag:
+      - W/"792004ff155c9ccf31e9dad7f52446c9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DEA0:677B7C8:5ED660EC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3199'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hOY9kKjNGYtjjQlnUPc0IhSNbZVipLxlIastLvvnMbWJf1
+        IStj7EHi0En3//G/01NgeAvBNJDc846XD7yG0dpZE5wEHffN+xnXcEykkKSlZFwmDNh4fCbClMZR
+        QmMpgUIShyxkqaAhlnLqO4owehJseo1PG+87NyWEd2pUK99sxKi0Lemhs4604LnztodTrcSpB+cd
+        GfbVqt0NmA48Ka3xYDBxyP25h+qTYGXMZCLHlCasSmkq2ESyRMR0IphIqkkUpbGAEska3+rVr1Bv
+        gI5BEdoKcqzib7yIgHoHBB+2BUuRgceRP2iOtFujLZcHED3f7nuzcdDvDX9p01GuHNmC9wzxu24Y
+        yUppQHv2yngAW1vn2Xyz+BbpfI1xG8XLq8twUdxomeUuP3/J75bFzaMs5utlca1u1Uxk6ry+N3k2
+        S4Yoz4Y13y6KO/ta5a6RVxePotA/X36N1+XZQr3en7F7M0TFlw4jRAJTWqlMjUwCx5FO8GyllXlw
+        wfQpcKCr/2rGcSr+Bs+Hhmv4X2/E/+3fen7+AUwlbB7gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:41 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DF1D:677B859:5ED660ED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3198'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "b9c59d7d26679f868b94d97b564b9b7f41185bec"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMTY5OjYzZjJkOGZmMDUwZDkxYzUzMDIwZjhhZmIyZDVhNjdkNTQ1ZWMyN2E=","sha":"63f2d8ff050d91c53020f8afb2d5a67d545ec27a","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/63f2d8ff050d91c53020f8afb2d5a67d545ec27a","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:41Z"},"object":{"sha":"b9c59d7d26679f868b94d97b564b9b7f41185bec","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:41 GMT
+      etag:
+      - '"9cd25aeec6531574eeade777b57b2b53"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/63f2d8ff050d91c53020f8afb2d5a67d545ec27a
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571DF7C:677B8B9:5ED660ED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3197'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "63f2d8ff050d91c53020f8afb2d5a67d545ec27a", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyMTY5OnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"63f2d8ff050d91c53020f8afb2d5a67d545ec27a","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/63f2d8ff050d91c53020f8afb2d5a67d545ec27a"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      etag:
+      - '"64461fb7d2685ee221289337cfa82414"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E027:677B98C:5ED660ED
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3196'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:43 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E19E:677BB13:5ED660EE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3195'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjBGliYLE9bLtogWyAoofdvQiUREu0JVElKXsdIe/ef0jJ
+        kl1v4jg85pLYNPnNcDgzHE47EelkFt7c3obh5c3d2aSSKY9obHL/6ff1Q/FXkXy+e2Rf/14l1XLz
+        ZZFd3y/+/PFlsfwwwWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTpzc301zC8vdxTfvOwvNt8D/9o2Nc6Tz8Xq3jxLbz/lGzuF9kP
+        LGWQx1TUqAL03Jhaz4LADeqri0yYvIkbzVUiK8Mrc5HIMmiCXtjH1YdrQDLVYazJMLCHq0VHcsuB
+        08HhneSmLPaUcTrYlYfXzGVRyDWY+7s4UmywBdCZWZiosrfBAGgDaXIO02K7T2QkgTM/lWoXtwH9
+        g18STuPYFE9PBXbLoSS52FMbKF5Ly21inShRGyGrk9XdgQAqVcYq8cjeBAVEg0WKnqyYXQwIX8GZ
+        T6a41W1gwzXZkNkUT7hY4TzeRt7DAGw2NWWXh5EF6ZSE4RFLS0oKNlc8nSF6Xxk7BxJQyreHP5lV
+        yF8UEWq5TUjPBrY17qEgPSCIqC/Y/2gcAhgwWGXJN96YxGoD/O3iLUFiYLFUDEncm5AdaBuMv5JT
+        Gc5Kb7IsDNBcSn+WtzBAhdYNP8r3jz9Vy9RBH2xVU8Yukx4TYseLcTTsgWktsopzbxbfAtugvwRi
+        xaok9yei57WB+2S9hmXetkAsIONCxt6YuNADC2wDnTN3NZrIp9YkgXg7AhSfe90C8bYCjPLoN1Z9
+        Am7xuK0NXMib/j0vaLsTKFiVNSzzJ2ELpMsKpUrGHl+s0I6P2YEIPJWmSsSN38Q8MGkHrihC/vF3
+        BANyEGCrrudLulcYaVTJWTOVpXip5jme3uF2QsyzCIqDfTH0/eXS7XXbIF4bDPeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nlB+0vNTE4ZFmJrprivzXS4oI3x1H26uLhoc87ss6TkymMWcTRgmUpylNe+9G97
+        HirHkhn7/JmT+imeQ4Vkqbez2AIBdy7gaw+ONvajGvW6N8UtbEwvRYGuhaz83REDcSynkkbMRXLM
+        W/H4MN+Bth+1qBJ+xvC8QVQYkQjECZ7s5AEo8rk/KzoatocekXsmFhwh4+2UFHe8NnBdgZTXhdx4
+        zZAjJCUSxdGgSiNm8CgNp+H0fHpzPg3/ubyehVezq+vvmNPU6IH9dM51SHPqRucvTEH672IFn9CV
+        er4RtP/GpI4T5GidD5DfBsTsQC/pJ4ikgNPvRe1puqz27/bXYbCdXJa8Rp3WP861eMTn6U6Nlcim
+        wulgcM0MHhuoWYahvi7rATnTkcskk5lRDXqONFIrueCJ0eOxIZONJq7FUuwspBpy2y1wj/xBeCmU
+        kl2z0TUXujyMtmHX8UyFZnHBhwFZ86rTcLwNkfBKb83gGgC05dH0HRPYLymfs6YwkXsrUTsVPVk0
+        WOGOXJUwA/W8qN3adVacQchV+z1SVnSf0XAxvKwj5x1GLjn1Z4FCVpHrSP/bMLievcD6xe4XO4St
+        UDW2+4vidJ3urkkR4Gj1OI0jFIcdsW8Qj9tC733iJn7vE7/3id/7xK7TTtffgT5xxc0aDdNRNh0/
+        b/ts/fQfhicc0RUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:43 GMT
+      etag:
+      - W/"676e56ef4903a8e9557873d121012099"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E1F9:677BBB6:5ED660EF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3194'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:43 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E260:677BC22:5ED660EF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3193'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjBGliYLE9bLtogWyAoofdvQiUREu0JVElKXsdIe/ef0jJ
+        kl1v4jg85pLYNPnNcDgzHE47EelkFt7c3obh5c3d2aSSKY9obHL/6ff1Q/FXkXy+e2Rf/14l1XLz
+        ZZFd3y/+/PFlsfwwwWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTpzc301zC8vdxTfvOwvNt8D/9o2Nc6Tz8Xq3jxLbz/lGzuF9kP
+        LGWQx1TUqAL03Jhaz4LADeqri0yYvIkbzVUiK8Mrc5HIMmiCXtjH1YdrQDLVYazJMLCHq0VHcsuB
+        08HhneSmLPaUcTrYlYfXzGVRyDWY+7s4UmywBdCZWZiosrfBAGgDaXIO02K7T2QkgTM/lWoXtwH9
+        g18STuPYFE9PBXbLoSS52FMbKF5Ly21inShRGyGrk9XdgQAqVcYq8cjeBAVEg0WKnqyYXQwIX8GZ
+        T6a41W1gwzXZkNkUT7hY4TzeRt7DAGw2NWWXh5EF6ZSE4RFLS0oKNlc8nSF6Xxk7BxJQyreHP5lV
+        yF8UEWq5TUjPBrY17qEgPSCIqC/Y/2gcAhgwWGXJN96YxGoD/O3iLUFiYLFUDEncm5AdaBuMv5JT
+        Gc5Kb7IsDNBcSn+WtzBAhdYNP8r3jz9Vy9RBH2xVU8Yukx4TYseLcTTsgWktsopzbxbfAtugvwRi
+        xaok9yei57WB+2S9hmXetkAsIONCxt6YuNADC2wDnTN3NZrIp9YkgXg7AhSfe90C8bYCjPLoN1Z9
+        Am7xuK0NXMib/j0vaLsTKFiVNSzzJ2ELpMsKpUrGHl+s0I6P2YEIPJWmSsSN38Q8MGkHrihC/vF3
+        BANyEGCrrudLulcYaVTJWTOVpXip5jme3uF2QsyzCIqDfTH0/eXS7XXbIF4bDPeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nlB+0vNTE4ZFmJrprivzXS4oI3x1H26uLhoc87ss6TkymMWcTRgmUpylNe+9G97
+        HirHkhn7/JmT+imeQ4Vkqbez2AIBdy7gaw+ONvajGvW6N8UtbEwvRYGuhaz83REDcSynkkbMRXLM
+        W/H4MN+Bth+1qBJ+xvC8QVQYkQjECZ7s5AEo8rk/KzoatocekXsmFhwh4+2UFHe8NnBdgZTXhdx4
+        zZAjJCUSxdGgSiNm8CgNp+H0fHpzPg3/ubyehVezq+vvmNPU6IH9dM51SHPqRucvTEH672IFn9CV
+        er4RtP/GpI4T5GidD5DfBsTsQC/pJ4ikgNPvRe1puqz27/bXYbCdXJa8Rp3WP861eMTn6U6Nlcim
+        wulgcM0MHhuoWYahvi7rATnTkcskk5lRDXqONFIrueCJ0eOxIZONJq7FUuwspBpy2y1wj/xBeCmU
+        kl2z0TUXujyMtmHX8UyFZnHBhwFZ86rTcLwNkfBKb83gGgC05dH0HRPYLymfs6YwkXsrUTsVPVk0
+        WOGOXJUwA/W8qN3adVacQchV+z1SVnSf0XAxvKwj5x1GLjn1Z4FCVpHrSP/bMLievcD6xe4XO4St
+        UDW2+4vidJ3urkkR4Gj1OI0jFIcdsW8Qj9tC733iJn7vE7/3id/7xK7TTtffgT5xxc0aDdNRNh0/
+        b/ts/fQfhicc0RUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:43 GMT
+      etag:
+      - W/"676e56ef4903a8e9557873d121012099"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E2BA:677BC91:5ED660EF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3192'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QP2/CMBDFv4vnJjYBBxKJoRJtVVSLhf6BJXLiMwmK4yi+IKWI795r5w4durzl
+        3rv7vbuyASzLvzVw1KfALzCExnfRLBbsjnXeQNEYcqiNSl/dm1Pnw2K3eZ7U/iB33bY9dupinh67
+        asqS48f2U79n48v+YVT36zUtGIeWwjViH3LOdd/EpwbrsYwr7/gAvQ/cAeqAfoCobcoIISChkBaF
+        m4ymGSCnELl/Z/TlGSpk+ZWFWtOxdG4Ts7JWSGGyWSXnIhF2pW2ZGKnTpZELCVWy1ESHUw+UoOL/
+        i/rzyT9z3G5fTjTbLocBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:44 GMT
+      etag:
+      - W/"64461fb7d2685ee221289337cfa82414"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E32E:677BD0A:5ED660EF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3191'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/63f2d8ff050d91c53020f8afb2d5a67d545ec27a
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S246bMBD9lcjPEC7hLq20D2xXqUSiqtmtwktk4wFMMCBsdktW+feOlR9opb5Y
+        nplzzpwZzRcZRg4XwUlGiryI3l+/DUV3Do75fi1O5/DYnW9l9/16fC1lkb99lvn19/n2divy/WfZ
+        tW0p92uZv7eHjl8Ppx9e+atYD/7LE7GIaimKRrva50ldu6HLU68Kd67v1gmtmc9DGsU8DEKo/Jgi
+        YZl7JLRaTypzHDqJbSN0u7BtNUpnhmlUjgRNlR5nsHvBbA1KK8e8l4tcOcUaaAdJjqaNcv6hNeIb
+        mEn2RQYqAV38bGlL583LxzwOaA0kFcYczoTpLZj0c2OSxhwCsLmh+Tid7Ua265+8IPN3WeCV5G6R
+        kXVQaaP/2ApLqzDlMfejKE7rJEpYGvA0ZmEUsJTFdeB5ScigQmW9TkYZ20ih/++WHprK+Ws3OAlu
+        Ct18wKzEONje1kVLEpSijXFZrJtBVLDphdY9bAzYMmBRi4pqZJgVPGLAk6tpr8AiM1BlSmQZlGgG
+        rOD14IfqZUbVYel7i0x07UeKJBPe738ATlwOArkCAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:44 GMT
+      etag:
+      - W/"9cd25aeec6531574eeade777b57b2b53"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E379:677BD5C:5ED660F0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3190'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:44 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E3C5:677BDC4:5ED660F0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3189'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjBGliYLE9bLtogWyAoofdvQiUREu0JVElKXsdIe/ef0jJ
+        kl1v4jg85pLYNPnNcDgzHE47EelkFt7c3obh5c3d2aSSKY9obHL/6ff1Q/FXkXy+e2Rf/14l1XLz
+        ZZFd3y/+/PFlsfwwwWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTpzc301zC8vdxTfvOwvNt8D/9o2Nc6Tz8Xq3jxLbz/lGzuF9kP
+        LGWQx1TUqAL03Jhaz4LADeqri0yYvIkbzVUiK8Mrc5HIMmiCXtjH1YdrQDLVYazJMLCHq0VHcsuB
+        08HhneSmLPaUcTrYlYfXzGVRyDWY+7s4UmywBdCZWZiosrfBAGgDaXIO02K7T2QkgTM/lWoXtwH9
+        g18STuPYFE9PBXbLoSS52FMbKF5Ly21inShRGyGrk9XdgQAqVcYq8cjeBAVEg0WKnqyYXQwIX8GZ
+        T6a41W1gwzXZkNkUT7hY4TzeRt7DAGw2NWWXh5EF6ZSE4RFLS0oKNlc8nSF6Xxk7BxJQyreHP5lV
+        yF8UEWq5TUjPBrY17qEgPSCIqC/Y/2gcAhgwWGXJN96YxGoD/O3iLUFiYLFUDEncm5AdaBuMv5JT
+        Gc5Kb7IsDNBcSn+WtzBAhdYNP8r3jz9Vy9RBH2xVU8Yukx4TYseLcTTsgWktsopzbxbfAtugvwRi
+        xaok9yei57WB+2S9hmXetkAsIONCxt6YuNADC2wDnTN3NZrIp9YkgXg7AhSfe90C8bYCjPLoN1Z9
+        Am7xuK0NXMib/j0vaLsTKFiVNSzzJ2ELpMsKpUrGHl+s0I6P2YEIPJWmSsSN38Q8MGkHrihC/vF3
+        BANyEGCrrudLulcYaVTJWTOVpXip5jme3uF2QsyzCIqDfTH0/eXS7XXbIF4bDPeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nlB+0vNTE4ZFmJrprivzXS4oI3x1H26uLhoc87ss6TkymMWcTRgmUpylNe+9G97
+        HirHkhn7/JmT+imeQ4Vkqbez2AIBdy7gaw+ONvajGvW6N8UtbEwvRYGuhaz83REDcSynkkbMRXLM
+        W/H4MN+Bth+1qBJ+xvC8QVQYkQjECZ7s5AEo8rk/KzoatocekXsmFhwh4+2UFHe8NnBdgZTXhdx4
+        zZAjJCUSxdGgSiNm8CgNp+H0fHpzPg3/ubyehVezq+vvmNPU6IH9dM51SHPqRucvTEH672IFn9CV
+        er4RtP/GpI4T5GidD5DfBsTsQC/pJ4ikgNPvRe1puqz27/bXYbCdXJa8Rp3WP861eMTn6U6Nlcim
+        wulgcM0MHhuoWYahvi7rATnTkcskk5lRDXqONFIrueCJ0eOxIZONJq7FUuwspBpy2y1wj/xBeCmU
+        kl2z0TUXujyMtmHX8UyFZnHBhwFZ86rTcLwNkfBKb83gGgC05dH0HRPYLymfs6YwkXsrUTsVPVk0
+        WOGOXJUwA/W8qN3adVacQchV+z1SVnSf0XAxvKwj5x1GLjn1Z4FCVpHrSP/bMLievcD6xe4XO4St
+        UDW2+4vidJ3urkkR4Gj1OI0jFIcdsW8Qj9tC733iJn7vE7/3id/7xK7TTtffgT5xxc0aDdNRNh0/
+        b/ts/fQfhicc0RUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:45 GMT
+      etag:
+      - W/"676e56ef4903a8e9557873d121012099"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E42E:677BE3B:5ED660F0
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3188'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZlW7INhR68lBySULrbxSklSPYoVuKPYMlLsyH/vSPShfaW
+        QHoR0oxGb96bh87E1IJkRKZlnFa8oozxVCUskWlUpVzGLJKp5CoKgiSWUJIp6foKtrrComVesK80
+        tfK18Zf7Ilrni9PyuYjX7SIu3l/iTV4dME5X7027zouo2B/8TX4Ii/0LXX3BO/uqXeVPv9b5d715
+        XX7Cx8ehwYdra48m8zxx1POdtvUo52XfegMce+O1YIWx/QCzRsuZBWON59bttj1VAnNgPSzysKLV
+        mLuDWm3bZvtvC3/B3wJ8Bb0HU4y27geSnUknWkDy32pRi2Hy9Db0HSoCrdBOE5wThufgwp93Lug0
+        wQvI2ZVRn/ozn818+hxEGQ2zMNmQy5RcO7LwHyHsANjB+Y+VOIeEhZGKQumHpVIsrSIexaUvgQOo
+        kKKNhGTxY6ftejDezdgoTAvGiJ2TbtFpq0Uzce45ivKA0clVNuzxKAborCHZjw+CNEpUzAPwARkl
+        aZWUCQ3TklNGecVZoPwwVHEgH0vww853oD/MzjdjXn5OyRsMWulSWI3+RVdcz4AfhhKNgSkZQBiX
+        ImNn9K7DzJS4jbDjgOPoxqZxsp+aXmCRO14uvwEhLyk8qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:45 GMT
+      etag:
+      - W/"792004ff155c9ccf31e9dad7f52446c9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E48E:677BEAB:5ED660F1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3187'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hOY9kKjNGYtjjQlnUPc0IhSNbZVipLxlIastLvvnMbWJf1
+        IStj7EHi0En3//G/01NgeAvBNJDc846XD7yG0dpZE5wEHffN+xnXcEykkKSlZFwmDNh4fCbClMZR
+        QmMpgUIShyxkqaAhlnLqO4owehJseo1PG+87NyWEd2pUK99sxKi0Lemhs4604LnztodTrcSpB+cd
+        GfbVqt0NmA48Ka3xYDBxyP25h+qTYGXMZCLHlCasSmkq2ESyRMR0IphIqkkUpbGAEska3+rVr1Bv
+        gI5BEdoKcqzib7yIgHoHBB+2BUuRgceRP2iOtFujLZcHED3f7nuzcdDvDX9p01GuHNmC9wzxu24Y
+        yUppQHv2yngAW1vn2Xyz+BbpfI1xG8XLq8twUdxomeUuP3/J75bFzaMs5utlca1u1Uxk6ry+N3k2
+        S4Yoz4Y13y6KO/ta5a6RVxePotA/X36N1+XZQr3en7F7M0TFlw4jRAJTWqlMjUwCx5FO8GyllXlw
+        wfQpcKCr/2rGcSr+Bs+Hhmv4X2/E/+3fen7+AUwlbB7gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:45 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E4D6:677BEF3:5ED660F1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3186'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "v-1.0", "type":
+      "commit", "object": "b9c59d7d26679f868b94d97b564b9b7f41185bec"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMTY5OmExZWU5YTI5NTM3ZjZiMzE3MGRhYzNkZDMwNjQ2NmZmYzg5Y2Y1NjA=","sha":"a1ee9a29537f6b3170dac3dd306466ffc89cf560","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a1ee9a29537f6b3170dac3dd306466ffc89cf560","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:45Z"},"object":{"sha":"b9c59d7d26679f868b94d97b564b9b7f41185bec","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec"},"tag":"v-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '691'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:46 GMT
+      etag:
+      - '"529deee90c6641888f74c83624f9e02e"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a1ee9a29537f6b3170dac3dd306466ffc89cf560
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E523:677BF66:5ED660F1
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3185'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "a1ee9a29537f6b3170dac3dd306466ffc89cf560", "ref":
+      "refs/tags/v-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '77'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/v-1.0","node_id":"MDM6UmVmMjY4ODIyMTY5OnJlZnMvdGFncy92LTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/v-1.0","object":{"sha":"a1ee9a29537f6b3170dac3dd306466ffc89cf560","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a1ee9a29537f6b3170dac3dd306466ffc89cf560"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '371'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:46 GMT
+      etag:
+      - '"a771a005640b9432107a2999ff2c4123"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/v-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E5ED:677C04D:5ED660F2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3184'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QP2/CMBDFv4vnJjYBBxKJoRJtVVSLhf6BJXLiMwmK4yi+IKWI795r5w4durzl
+        3rv7vbuyASzLvzVw1KfALzCExnfRLBbsjnXeQNEYcqiNSl/dm1Pnw2K3eZ7U/iB33bY9dupinh67
+        asqS48f2U79n48v+YVT36zUtGIeWwjViH3LOdd/EpwbrsYwr7/gAvQ/cAeqAfoCobcoIISChkBaF
+        m4ymGSCnELl/Z/TlGSpk+ZWFWtOxdG4Ts7JWSGGyWSXnIhF2pW2ZGKnTpZELCVWy1ESHUw+UoOL/
+        i/rzyT9z3G5fTjTbLocBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:47 GMT
+      etag:
+      - W/"64461fb7d2685ee221289337cfa82414"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E72C:677C1C5:5ED660F2
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3183'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:23:47 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E784:677C22A:5ED660F3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3182'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:48 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E879:677C33A:5ED660F3
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3181'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:48 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E8BF:677C399:5ED660F4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3180'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:48 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E91B:677C3F6:5ED660F4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3179'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:49 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E978:677C46D:5ED660F4
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3178'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIBAF0auYtVW3sPMAll7BIHzRRFgDi43x7tLNy7wUkLPxoIkW0WaWEh11
+        5MSWgKhGT4lrSVf9h+qdJ2aHB5fcSIM/9SjbYCXwM3IVJ+yZWw/tTV8bCdGCvh8u9SX+ZwAAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:49 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571E9D7:677C4E4:5ED660F5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3177'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:49 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EA2C:677C546:5ED660F5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3176'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:49 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EA88:677C5AD:5ED660F5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3175'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:50 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EAE7:677C616:5ED660F5
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3174'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:50 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EB44:677C681:5ED660F6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3173'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/v-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QMW+DMBCF/4vngiEEpyBlqJQmalUrS1opWZCxz4EIY4SPSCjKf++lY6cOXd7y
+        7tN7725sBMvKhwaO6hz4NUrjhD2x3huoWkOe3Ejx6b6cvByX+83bLA/HfN+/d6deXs1u2+u5WHwc
+        Xif5sl4TOI0dQQ3iEErO1dDG5xabqY61d3yEwQfuAFVAP0LUtXWEEJDCSavKzUaRB8gJouvfrXx9
+        AY2svLHQKIpRKUChFkWerayos3SVGKUzY7JELIWwVj8X2ubiMQjnAYigkf9b8udrf+5xv38D+iWM
+        yXMBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:50 GMT
+      etag:
+      - W/"a771a005640b9432107a2999ff2c4123"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EB9E:677C6FA:5ED660F6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3172'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a1ee9a29537f6b3170dac3dd306466ffc89cf560
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S246bMBD9lcjPEO4mIFVqpaSrfYBV27QreIlsGMAUA8ImLVnl33es/EAr7Yvl
+        uZwzZ479RsaphouoSUqyY0Z/PX0ds74IX47PW3Yuohd5+lu+/oyK83OUn7Og7EuR3U5B9vS9K275
+        7/KY/cn7b34uS1nc2qjwCy/vv3wiFlEdQ1LmASTMT6IgbigPvNitWRXUdeDSkNKmqQ5J1UTURcC6
+        DAjotJ5V6jhsFvtW6G7l+2qSzgLzpBwJmik9LWAPgtsalFaOOS8XudUMa6AdBDmatcr5j9HY38JC
+        0jcyMgmo4kfHOrbsTtdlGlEaSCaMONwJ03sw6c+tSRpx2IDDDcx3fdd2qe36Zy9M/SANo5LcLTLx
+        Hipt+B+u8KSKkjqufUrjpDnQA0/COol5REOe8LgJPe8QcaiQWW+zYcYxUuiPdenBqZx/VoOboFOo
+        5mp7e/NkEpRirdGXbbtRVLAbhNYD7EybRa6wiEZUTAt0EZd/xICfrWGDAosswJQpkXVUoh2xgv8G
+        L0yvC7KO6zBYZGbbMDEEmfB+fwcMORw5swIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:50 GMT
+      etag:
+      - W/"529deee90c6641888f74c83624f9e02e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EC03:677C76D:5ED660F6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3171'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:51 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EC5E:677C7D0:5ED660F6
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3170'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:51 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571ECC0:677C854:5ED660F7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3169'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZlW7INhR68lBySULrbxSklSPYoVuKPYMlLsyH/vSPShfaW
+        QHoR0oxGb96bh87E1IJkRKZlnFa8oozxVCUskWlUpVzGLJKp5CoKgiSWUJIp6foKtrrComVesK80
+        tfK18Zf7Ilrni9PyuYjX7SIu3l/iTV4dME5X7027zouo2B/8TX4Ii/0LXX3BO/uqXeVPv9b5d715
+        XX7Cx8ehwYdra48m8zxx1POdtvUo52XfegMce+O1YIWx/QCzRsuZBWON59bttj1VAnNgPSzysKLV
+        mLuDWm3bZvtvC3/B3wJ8Bb0HU4y27geSnUknWkDy32pRi2Hy9Db0HSoCrdBOE5wThufgwp93Lug0
+        wQvI2ZVRn/ozn818+hxEGQ2zMNmQy5RcO7LwHyHsANjB+Y+VOIeEhZGKQumHpVIsrSIexaUvgQOo
+        kKKNhGTxY6ftejDezdgoTAvGiJ2TbtFpq0Uzce45ivKA0clVNuzxKAborCHZjw+CNEpUzAPwARkl
+        aZWUCQ3TklNGecVZoPwwVHEgH0vww853oD/MzjdjXn5OyRsMWulSWI3+RVdcz4AfhhKNgSkZQBiX
+        ImNn9K7DzJS4jbDjgOPoxqZxsp+aXmCRO14uvwEhLyk8qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:51 GMT
+      etag:
+      - W/"792004ff155c9ccf31e9dad7f52446c9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571ED22:677C8C8:5ED660F7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3168'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hOY9kKjNGYtjjQlnUPc0IhSNbZVipLxlIastLvvnMbWJf1
+        IStj7EHi0En3//G/01NgeAvBNJDc846XD7yG0dpZE5wEHffN+xnXcEykkKSlZFwmDNh4fCbClMZR
+        QmMpgUIShyxkqaAhlnLqO4owehJseo1PG+87NyWEd2pUK99sxKi0Lemhs4604LnztodTrcSpB+cd
+        GfbVqt0NmA48Ka3xYDBxyP25h+qTYGXMZCLHlCasSmkq2ESyRMR0IphIqkkUpbGAEska3+rVr1Bv
+        gI5BEdoKcqzib7yIgHoHBB+2BUuRgceRP2iOtFujLZcHED3f7nuzcdDvDX9p01GuHNmC9wzxu24Y
+        yUppQHv2yngAW1vn2Xyz+BbpfI1xG8XLq8twUdxomeUuP3/J75bFzaMs5utlca1u1Uxk6ry+N3k2
+        S4Yoz4Y13y6KO/ta5a6RVxePotA/X36N1+XZQr3en7F7M0TFlw4jRAJTWqlMjUwCx5FO8GyllXlw
+        wfQpcKCr/2rGcSr+Bs+Hhmv4X2/E/+3fen7+AUwlbB7gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:51 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571ED7E:677C933:5ED660F7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3167'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZlW7INhR68lBySULrbxSklSPYoVuKPYMlLsyH/vSPShfaW
+        QHoR0oxGb96bh87E1IJkRKZlnFa8oozxVCUskWlUpVzGLJKp5CoKgiSWUJIp6foKtrrComVesK80
+        tfK18Zf7Ilrni9PyuYjX7SIu3l/iTV4dME5X7027zouo2B/8TX4Ii/0LXX3BO/uqXeVPv9b5d715
+        XX7Cx8ehwYdra48m8zxx1POdtvUo52XfegMce+O1YIWx/QCzRsuZBWON59bttj1VAnNgPSzysKLV
+        mLuDWm3bZvtvC3/B3wJ8Bb0HU4y27geSnUknWkDy32pRi2Hy9Db0HSoCrdBOE5wThufgwp93Lug0
+        wQvI2ZVRn/ozn818+hxEGQ2zMNmQy5RcO7LwHyHsANjB+Y+VOIeEhZGKQumHpVIsrSIexaUvgQOo
+        kKKNhGTxY6ftejDezdgoTAvGiJ2TbtFpq0Uzce45ivKA0clVNuzxKAborCHZjw+CNEpUzAPwARkl
+        aZWUCQ3TklNGecVZoPwwVHEgH0vww853oD/MzjdjXn5OyRsMWulSWI3+RVdcz4AfhhKNgSkZQBiX
+        ImNn9K7DzJS4jbDjgOPoxqZxsp+aXmCRO14uvwEhLyk8qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:52 GMT
+      etag:
+      - W/"792004ff155c9ccf31e9dad7f52446c9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EDF9:677C9BD:5ED660F7
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3166'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hOY9kKjNGYtjjQlnUPc0IhSNbZVipLxlIastLvvnMbWJf1
+        IStj7EHi0En3//G/01NgeAvBNJDc846XD7yG0dpZE5wEHffN+xnXcEykkKSlZFwmDNh4fCbClMZR
+        QmMpgUIShyxkqaAhlnLqO4owehJseo1PG+87NyWEd2pUK99sxKi0Lemhs4604LnztodTrcSpB+cd
+        GfbVqt0NmA48Ka3xYDBxyP25h+qTYGXMZCLHlCasSmkq2ESyRMR0IphIqkkUpbGAEska3+rVr1Bv
+        gI5BEdoKcqzib7yIgHoHBB+2BUuRgceRP2iOtFujLZcHED3f7nuzcdDvDX9p01GuHNmC9wzxu24Y
+        yUppQHv2yngAW1vn2Xyz+BbpfI1xG8XLq8twUdxomeUuP3/J75bFzaMs5utlca1u1Uxk6ry+N3k2
+        S4Yoz4Y13y6KO/ta5a6RVxePotA/X36N1+XZQr3en7F7M0TFlw4jRAJTWqlMjUwCx5FO8GyllXlw
+        wfQpcKCr/2rGcSr+Bs+Hhmv4X2/E/+3fen7+AUwlbB7gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:52 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EE53:677CA1F:5ED660F8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3165'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:52 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EE9F:677CA8A:5ED660F8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3164'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:53 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EEF1:677CAE4:5ED660F8
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3163'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/matching-refs/tags/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62QwWrDMBBE/0Xn2rLjWKkNORTSlpaKXNJCUoqRpVXsYFnGWgdMyL9302NPPfQy
+        l9nHzOznhY1gWXnTwFEdAz9HaZywO9Z7A1VryJMbKd7dh5On/XK7eZnlbp9v+9fu0MuzeX7q9Vws
+        3naPk3xYrwmcxo6gBnEIJedqaONji81Ux9o7PsLgA3eAKqAfIeraOkIISOGkVeVmo8gD5ATR9e9W
+        vj6BRlZeWGgUxagUoFCLIs9WVtRZukqM0pkxWSKWQlir7wttc3EbhPMARNDI/y3587U/97hev74B
+        QqdvFHUBAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:53 GMT
+      etag:
+      - W/"b8d2e57a37f5b2f4a3fef3dc9c4069e5"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EF55:677CB50:5ED660F9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3162'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/a1ee9a29537f6b3170dac3dd306466ffc89cf560
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA61S246bMBD9lcjPEO4mIFVqpaSrfYBV27QreIlsGMAUA8ImLVnl33es/EAr7Yvl
+        uZwzZ479RsaphouoSUqyY0Z/PX0ds74IX47PW3Yuohd5+lu+/oyK83OUn7Og7EuR3U5B9vS9K275
+        7/KY/cn7b34uS1nc2qjwCy/vv3wiFlEdQ1LmASTMT6IgbigPvNitWRXUdeDSkNKmqQ5J1UTURcC6
+        DAjotJ5V6jhsFvtW6G7l+2qSzgLzpBwJmik9LWAPgtsalFaOOS8XudUMa6AdBDmatcr5j9HY38JC
+        0jcyMgmo4kfHOrbsTtdlGlEaSCaMONwJ03sw6c+tSRpx2IDDDcx3fdd2qe36Zy9M/SANo5LcLTLx
+        Hipt+B+u8KSKkjqufUrjpDnQA0/COol5REOe8LgJPe8QcaiQWW+zYcYxUuiPdenBqZx/VoOboFOo
+        5mp7e/NkEpRirdGXbbtRVLAbhNYD7EybRa6wiEZUTAt0EZd/xICfrWGDAosswJQpkXVUoh2xgv8G
+        L0yvC7KO6zBYZGbbMDEEmfB+fwcMORw5swIAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:53 GMT
+      etag:
+      - W/"529deee90c6641888f74c83624f9e02e"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EFA6:677CBB4:5ED660F9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3161'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:53 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571EFFB:677CC19:5ED660F9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3160'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:54 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571F047:677CC7B:5ED660F9
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3159'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUTYvbMBD9K0HnJLZlW7INhR68lBySULrbxSklSPYoVuKPYMlLsyH/vSPShfaW
+        QHoR0oxGb96bh87E1IJkRKZlnFa8oozxVCUskWlUpVzGLJKp5CoKgiSWUJIp6foKtrrComVesK80
+        tfK18Zf7Ilrni9PyuYjX7SIu3l/iTV4dME5X7027zouo2B/8TX4Ii/0LXX3BO/uqXeVPv9b5d715
+        XX7Cx8ehwYdra48m8zxx1POdtvUo52XfegMce+O1YIWx/QCzRsuZBWON59bttj1VAnNgPSzysKLV
+        mLuDWm3bZvtvC3/B3wJ8Bb0HU4y27geSnUknWkDy32pRi2Hy9Db0HSoCrdBOE5wThufgwp93Lug0
+        wQvI2ZVRn/ozn818+hxEGQ2zMNmQy5RcO7LwHyHsANjB+Y+VOIeEhZGKQumHpVIsrSIexaUvgQOo
+        kKKNhGTxY6ftejDezdgoTAvGiJ2TbtFpq0Uzce45ivKA0clVNuzxKAborCHZjw+CNEpUzAPwARkl
+        aZWUCQ3TklNGecVZoPwwVHEgH0vww853oD/MzjdjXn5OyRsMWulSWI3+RVdcz4AfhhKNgSkZQBiX
+        ImNn9K7DzJS4jbDjgOPoxqZxsp+aXmCRO14uvwEhLyk8qAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:54 GMT
+      etag:
+      - W/"792004ff155c9ccf31e9dad7f52446c9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571F09A:677CCD9:5ED660FA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3158'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b9c59d7d26679f868b94d97b564b9b7f41185bec
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82TUWvbMBDHv4uf28hOY9kKjNGYtjjQlnUPc0IhSNbZVipLxlIastLvvnMbWJf1
+        IStj7EHi0En3//G/01NgeAvBNJDc846XD7yG0dpZE5wEHffN+xnXcEykkKSlZFwmDNh4fCbClMZR
+        QmMpgUIShyxkqaAhlnLqO4owehJseo1PG+87NyWEd2pUK99sxKi0Lemhs4604LnztodTrcSpB+cd
+        GfbVqt0NmA48Ka3xYDBxyP25h+qTYGXMZCLHlCasSmkq2ESyRMR0IphIqkkUpbGAEska3+rVr1Bv
+        gI5BEdoKcqzib7yIgHoHBB+2BUuRgceRP2iOtFujLZcHED3f7nuzcdDvDX9p01GuHNmC9wzxu24Y
+        yUppQHv2yngAW1vn2Xyz+BbpfI1xG8XLq8twUdxomeUuP3/J75bFzaMs5utlca1u1Uxk6ry+N3k2
+        S4Yoz4Y13y6KO/ta5a6RVxePotA/X36N1+XZQr3en7F7M0TFlw4jRAJTWqlMjUwCx5FO8GyllXlw
+        wfQpcKCr/2rGcSr+Bs+Hhmv4X2/E/+3fen7+AUwlbB7gBAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:54 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571F0D8:677CD2E:5ED660FA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3157'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:54 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571F126:677CD7B:5ED660FA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3156'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJqGjBNmsgcX2sO2iBbIBih62exEoiZZoS6JKUvY6Qt69/4iS
+        JbtO4jg85pLYNPnNcDgzHE4zkclkFtzc3gbB5c3Hs0mpEhHS2OTuy2/r+/zPPP768YF//2sVl8vN
+        t0V6fbf44+e3xfLTBJN5ITDTCmPDsNgk3HIjLH6Y13kedr8WAqNWaXGey+ic5hr2/xWVlituQZvz
+        3IiziVqXQk9mzSRXqSwh5AAGgkjTm5vphyC4vdxTfnO//Lj5Efxe8+9VlnzNV9Hin+DuS7y5W6Q/
+        sZRDHtdhrXPQM2srM2PMDZqri1TarI5qI3SsSitKexGrgtWsF/Z59ekakFR3mNZkGNjDVbIjueXA
+        GXZ4J5kt8j1lnA7tysNr5irP1RrM/V0cKZZtAXRmLUyW6dtgADRM2UzAtNjuIxlJ4sxPpbaLG0b/
+        4JeEMzg2LZJTgd1yKEku9tgwLSrVcuvIxFpWVqryZHV3IIAqnfJSPvA3QQExYJGiJyvWLgZErODM
+        J1Pc6oa14RpvyGxaxEKucB5vI+9hALabirLL/ciCdErSipAnBSWFNlc8niF6Xxk7BxJQIraHP5mV
+        yF8UEXq5TUjPBnZr3ENBekAQUV+w/9E4BDBgsMpSbLwxidUw/O3iLUZi4JHSHEncm5AdaMPGX8mp
+        rOCFN1ktDNBMKX+Wb2GASmNqcZTvH3+qLdOwPtjKuohcJj0mxI4X42jYAzdGpqUQ3iy+BTasvwQi
+        zcs48yei5zXMfWq9hqfetkAsIKNcRd6YuNBZC2yYybi7Gm3oU2uSQLwdAVrMvW6BeFsBVnv0m1Z9
+        Am7xuK0tXMib/j2PNd0J5LxMa576k7AF0mWFUiXlDy9WaMfH7EAEnkpTLaPab2IemLQDVxQh//g7
+        ggE5CGirrudLulcYaVTJtWYqCvlSzXM8vcPthJhnERQH+2Lo+8ul2+u2QbyGDfeLu8w6Sb5Oo7vN
+        ev3H8rq3lTfX6nms+aXiNqMMC7EV18LXZjocayI8dR8vLi6aTPD2WVII7TGLOBqwXMcZymtf+jc9
+        D5VjwW37/JmT+gmeQ7niibez2AIBdy7gaw+ONvajCvW6N8Vb2JheyBxdC1X6uyMG4lhOqaycy/iY
+        t+LxYb4DbT4bWcbijON5g6iwMpaIEzzZyQNQ5At/VnQ0bA89IvdMzAVCxtspaeF4DXNdgURUudp4
+        zZAjJCUSLdCgSkJu8SgNpsH0fHpzPg3+vryeBVezq+sfmFNX6IE9Oec6oDlVbbKnp3ygKUj/Xazg
+        E7pSzzeC9t+Y1HECxJhsgPw6IGYHeklPIOIcTr8Xtafpstq/21+HwXYyVYgKdVr/ODfyAZ+nOzVW
+        rOoSp4PBNbd4bKBmGYb6uqwHZNyELpNMZlbX6DnSSKXVQsTWjMeGTDaauJZLubOQashtt8A98gfh
+        hdRadc1G11zo8jDahl3HM5GGR7kYBlQlyk7D8TZkLEqzNYNrANCWR9N3TNB+ScSc17kN3VuJ2qno
+        yaLBCncUuoAZqOdF7daus+IMQq7a75GyovuMhosVRRU677BqKag/CxSyilqH5t+aw/XaC6xf7H5p
+        h7AVqsZ2f9GCrtPdNQkCHK0ep3GI4rAj9g3icVvovU9cR+994vc+8Xuf2HXa6fo70CcuhV2jYTrK
+        puPnbZ+tH/8DRw64qxUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:55 GMT
+      etag:
+      - W/"cc085f6d1b838ce7db7547336026224c"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:42 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571F16A:677CDCD:5ED660FA
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3155'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:23:55 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C983:204BE:571F1AF:677CE22:5ED660FB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3154'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_no_chance.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_no_chance.yaml
@@ -1,0 +1,1782 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:56 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:83366AE:9C17BF8:5ED660FB
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3153'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:56 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336703:9C17C44:5ED660FC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3152'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822262,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjIyNjI=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:23:56Z","updated_at":"2020-06-02T14:23:56Z","pushed_at":"2020-06-02T14:23:57Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:57 GMT
+      etag:
+      - '"f77803f2b5405826cce5162288c361e9"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:833676A:9C17CB5:5ED660FC
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3151'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"17aa41485de647e9eeebc50bc8812d1921faa6dc","node_id":"MDY6Q29tbWl0MjY4ODIyMjYyOjE3YWE0MTQ4NWRlNjQ3ZTllZWViYzUwYmM4ODEyZDE5MjFmYWE2ZGM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/17aa41485de647e9eeebc50bc8812d1921faa6dc","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/17aa41485de647e9eeebc50bc8812d1921faa6dc","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:58Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:58Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:58 GMT
+      etag:
+      - '"8d43c7f53fb841e69bb411438d30b679"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336A10:9C17FD8:5ED660FD
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3150'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1XS3PaMBD+KxmfSfzAPGcy7SG0kwPppCVJodNhZHuNRWXJlWRSwuS/d9c4Dzik
+        OJPecgFb0rf77VPrjSNZDs7QyZmxoJ2WE6s859YZbhyTMdzwe4yFftjvJNANezAAgCjueFHc7/tB
+        4g8CP2Wsm8QIlSqBOU8QND6bdi+DgY1uhDdeTsMvZ+dr/F9/WY7a05uRN55chhc3X8XF8rI9mwgx
+        u7nm07ur22k+xrOj9exs1BkvP+V4Nph9Hp/u8GKlzZQmhjX3bxnLmD4arbSSeBJyxgWSQP64fAK0
+        /HFBiydoHB5ImCWTAy/wjr3usRdM/HAYtIed/sy5f/AAeeO/qcjBGLYgEueSW84Ev4MjpMWONBTK
+        cKv0GolaDXjmMRKpN0jSoN3r9YOw54edPiRBMGC9KAr7cQ93+kmvDR4CS00OyKwtzNB1WcFPFtxm
+        ZUQOcCsVbg4WQ640HAseHVsw1rj0O5/na2JiwLoIcomDcf1DdaP/3lD5NhlR/eFJSBCQdh6rUmIa
+        ey1nBZqnPGaWY3qgN7fvgHmaMmGg5WhghracUhq+kLjTcuiB2VKj/2UpRMsp2FoohiB6vX87M19h
+        YmZzMd/18rPwHhLYrdJXuNXs6X11ajU1263jajA2Tw1AqAWnwJmsqnLco/bT7XS67d12dNm9/n4h
+        4uXUv5hM70jGCnNc71tTLZqgrpbSgI6VtJhOVeGUbiX5w+o0RAkLXcuoOt6/io5kGfeJ58sxfDqX
+        KiHULWL3qe7W9I549xGErLbPXC6aC0DQxlU2A/QT0r8nozn2iSaSKsAGOwl2Fp6QCIMu1pA0EVJD
+        kMytRB6bqoVVssrIxJoXVNqNaO0AUZDSCyb5XdUjGglCIKVk1VObmFQBEAgrzK5GyC1i4xaar1i8
+        JjdoiIGv0KfNpe1BUZhdF3QxXWHEycPcwpwlOZVZ1S73L8j3Eqyv1fcSbFY57yW4vbSwme1U70El
+        WDBNfcMZ/viJBTkXXP7CF5wUQaRvMflFmsk4w8Hv8buALqxnkhsOHDRFPshCwoVWFmL7bAarV+oR
+        DSSLxM6E9rvkdGngTWBLM0dq8dZgkKnSMVQjn8D2RxxVmqITq5v7T+2jJ52o4eU+ffh4vOck7MiV
+        VWTD/V/+NqoCWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:59 GMT
+      etag:
+      - W/"cbf8e07597145b3ff54639097e2ef1db"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336BAC:9C181BB:5ED660FE
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3149'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:59 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336C27:9C18245:5ED660FF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3148'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/17aa41485de647e9eeebc50bc8812d1921faa6dc
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPJIAh4UOq1ENotQd2lTZtBFUVDTAERwYi22zFRvnvHTeq1N52
+        pfZi7Hnz5s0XV6Y7YCnzI4DQD+N1g5swwgQRq3rtVXUc+7zxE+63AJumZg4bxgaPoiFSvi02O56Y
+        6iC9/FyET9uHmb7z0zkLikPm5ftd+Hj4JB/Pu6DcS1kevori5cuPos/JN5vLbbbOzx968uXlx/wd
+        BZ+UpMCdMRedui5cxOokTDdVq3rsXYWXUbs9GtBmVLiUoloa1Ea79jwe+7kBwtC4RHKJ0QvC3lBa
+        Z3p5/DuFP+RfI3wXfYsmTKYbFUuvbIAeqfjPHXSgFtmzGgfqCPYgbE9oTmReoTW/P1mj7Qk5UM2W
+        xj3uLb3N0uN7P0x5kK7jkt0cds/I4H+UMAopg+vvVWq9pGl5EEUxDyM/XMfYcJ5AVFVhXEeExE0U
+        oPdvp21zoFm/Vpsa06PWcLKtexiEESDFCy7sAi1+7ZmgFZspxwsoHIxm6bfvDntGJVpRgxE0G6r4
+        /kb6GVqQGh2mELSF2DRocRoIcZi9gJkUSQ2TlDbkLEcgkn3ebj8BB/d8qYQDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:23:59 GMT
+      etag:
+      - W/"4b135a92e4d5b9c5fb39e2fe55a162fd"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336CD3:9C18321:5ED660FF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3147'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["17aa41485de647e9eeebc50bc8812d1921faa6dc"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3","node_id":"MDY6Q29tbWl0MjY4ODIyMjYyOmIzNTVkNWUyYmJjNTJmMjdkYmYxZTA1YjMxNjNhMDdkZjBiNWYxZTM=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:59Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:23:59Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"17aa41485de647e9eeebc50bc8812d1921faa6dc","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/17aa41485de647e9eeebc50bc8812d1921faa6dc","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/17aa41485de647e9eeebc50bc8812d1921faa6dc"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:00 GMT
+      etag:
+      - '"7f97cc3f835b0bfad3942b3f0910f52d"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336D38:9C183A1:5ED660FF
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3146'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OPW/CMBCG/4vngmsUQsiMClSymJqqLJE/jtoojiP7QHIR/72HOnbp0OVueO+5
+        97mxBCfWPmbmDpTNPKiMkNgTG6OF3ltK5UbWb6EL8vxRHTb7QrscxtfhOMqr2nbuuJNX/f7yZbdd
+        IfCSBoIc4pRbztXk558e3UXPTQw8wRSpBJBqYoLZ4PUMIWPmj9n3oVhFGSAniK5/e0V9BoOsvbHs
+        FBWJlVKVqJqlhbpawRoAtFk+a9M0YmHFeiFOStXWkBmWCYggj+Dxf01/fmb+Z5v7/RuBQb/NfQEA
+        AA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:00 GMT
+      etag:
+      - W/"52f8c7a585c8ab819c865448ad3ab592"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:58 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336E08:9C18493:5ED66100
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3145'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMW/CMBCF/4vngkOCQcqMSotkMTVVWSJffKmN4jiyD6QU8d97qGOXDl3eSffu
+        3ftuImEv6odm6dDYLIPJhEk8iTFabL1lV+/05i00QZ8/1sfd68xzPo6H4TTqq9k37vSir/D+/GX3
+        zczBSxo45IimXEtpJr/89OQusOxikAmnyCVIXBMTLgYPC8JMWT60bcNsDXtIkkN8/Zsrwhk7EvVN
+        ZGe4CCqlrMISoFNlX24t9CssFFSrTWWKre0LULypmIzmCTnBHMHT/5L+/MzyzzT3+zdh++ppfQEA
+        AA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:01 GMT
+      etag:
+      - W/"e4ee1bc8d8d2abe980f549da13509019"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8336E76:9C1851C:5ED66100
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3144'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:01 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:833705C:9C1873C:5ED66101
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3143'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOmnmpgaJ76FZ0QBZg2EPXF4GSaImxJGokZc8R8t37P1Gy
+        ZM+NHYePeUlsmvzd8Xh3PF4zkclkHsxub4MgmAUXk1IlIqSxyd2n39b3+R95/Pn9I//61youl5s/
+        H9Kbu4cv+P/lwwSTeSEw0wpjw7DYJNxyIyx+WNR5Hna/FgKjVmlxmcvokuYa9v8VlZYrbkFb8NyI
+        i4lal0JP5s0kV6ksIeQABoJI09ls+ksQ3F7vKb+5X77ffAt+r/nXKks+56vo4Z/g7lO8uXtI/8NS
+        Dnlch7XOQc+srcycMTdo3l2l0mZ1VBuhY1VaUdqrWBWsZr2wj6sPN4CkusO0JsPAHq6SHcktB86w
+        wzvJbJHvKeN0aFceXrNQea7WYO7v4kSxbAugM2thskxfBwOgYcpmAqbFdp/ISBJnfi61Xdww+ge/
+        JJzBsWmRnAvslkNJcrGnhmlRqZZbRybWsrJSlWeruwMBVOmUl/KRvwoKiAGLFD1bsXYxIGIFZz6b
+        4lY3rA3XeENm0yIWcoXzeB15DwOw3VSUXe5HFqRTklaEPCkoKbS54ukC0fvC2DmQgBKxPfzJvET+
+        oojQy21CejawW+MeCtIDgoh6xP4n4xDAgMEqS7HxxiRWw/C3i7cYiYFHSnMkcW9CdqANG38lp7KC
+        F95ktTBAM6X8Wb6FASqNqcVJvn/6qbZMw/pgK+sicpn0lBA7XYyjYQ/cGJmWQniz+BbYsP4SiDQv
+        48yfiJ7XMPep9RqeetsCsYCMchV5Y+JCZy2wYSbj7mq0oU+tSQLxdgRosfC6BeJtBVjt0W9a9Qm4
+        xeO2tnAhb/r3PNZ0J5DzMq156k/CFkiXFUqVlD8erdBOj9mBCDyVplpGtd/EPDBpB64oQv7xdwQD
+        chDQVl3Pl3QvMNKokmvNVBTyWM1zOr3D7YSYZxEUB/ti6Pvx0u1l2yBew4b7xV1mnSRfp9HdZr3+
+        Y3nd28qba/U81vxUcZtRhoXYimvhazMdjjURnrpPV1dXTSZ4+ywphPaYRRwNWK7jDOW1L/2bnofK
+        seC2ff4sSP0Ez6Fc8cTbWWyBgDsX8LUHRxv7UYV63ZviLWxML2SOroUq/d0RA3Esp1RWLmR8ylvx
+        9DDfgTYfjSxjccHxvEFUWBlLxAme7OQBKPKFPys6GraHHpF7JuYCIePtlLRwvIa5rkAiqlxtvGbI
+        EZISiRZoUCUht3iUBtNgejmdXU6Dv69v5sG7+c+zb5hTV+iB/WDOzXx6TXOq2mRHpiD9d7GCT+hK
+        Pd8I2n9jUscJcozJBsivA2J+oJf0A0Scw+n3ovY8XVb7d/vLMNhOpgpRoU7rH+dGPuLzdKfGilVd
+        4nQwuOYWjw3ULMNQX5f1gIyb0GWSydzqGj1HGqm0ehCxNeOxIZONJq7lUu4spBpy2y1wj/xBeCG1
+        Vl2z0TUXujyMtmHX8Uyk4VEuhgFVibLTcLwNGYvSbM3gGgC05dH0HRO0XxKx4HVuQ/dWonYqerJo
+        sMIdhS5gBup5Ubu166w4g5Cr9nukrOg+o+FiRVGFzjusWgrqzwKFrKLWofm35nC99gLrF7tf2iFs
+        haqx3V+0oOt0d02CAEerx2kcojjsiH2DeNwWeusT19Fbn/itT/zWJ3addrr+DvSJS2HXaJiOsun4
+        edtn66fv79ZlERUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:01 GMT
+      etag:
+      - W/"1d646cedf9d59690a37b74469a94206a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:833710D:9C18828:5ED66101
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3142'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:02 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8337207:9C18908:5ED66101
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3141'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl4SOmnmpgaJ76FZ0QBZg2EPXF4GSaImxJGokZc8R8t37P1Gy
+        ZM+NHYePeUlsmvzd8Xh3PF4zkclkHsxub4MgmAUXk1IlIqSxyd2n39b3+R95/Pn9I//61youl5s/
+        H9Kbu4cv+P/lwwSTeSEw0wpjw7DYJNxyIyx+WNR5Hna/FgKjVmlxmcvokuYa9v8VlZYrbkFb8NyI
+        i4lal0JP5s0kV6ksIeQABoJI09ls+ksQ3F7vKb+5X77ffAt+r/nXKks+56vo4Z/g7lO8uXtI/8NS
+        Dnlch7XOQc+srcycMTdo3l2l0mZ1VBuhY1VaUdqrWBWsZr2wj6sPN4CkusO0JsPAHq6SHcktB86w
+        wzvJbJHvKeN0aFceXrNQea7WYO7v4kSxbAugM2thskxfBwOgYcpmAqbFdp/ISBJnfi61Xdww+ge/
+        JJzBsWmRnAvslkNJcrGnhmlRqZZbRybWsrJSlWeruwMBVOmUl/KRvwoKiAGLFD1bsXYxIGIFZz6b
+        4lY3rA3XeENm0yIWcoXzeB15DwOw3VSUXe5HFqRTklaEPCkoKbS54ukC0fvC2DmQgBKxPfzJvET+
+        oojQy21CejawW+MeCtIDgoh6xP4n4xDAgMEqS7HxxiRWw/C3i7cYiYFHSnMkcW9CdqANG38lp7KC
+        F95ktTBAM6X8Wb6FASqNqcVJvn/6qbZMw/pgK+sicpn0lBA7XYyjYQ/cGJmWQniz+BbYsP4SiDQv
+        48yfiJ7XMPep9RqeetsCsYCMchV5Y+JCZy2wYSbj7mq0oU+tSQLxdgRosfC6BeJtBVjt0W9a9Qm4
+        xeO2tnAhb/r3PNZ0J5DzMq156k/CFkiXFUqVlD8erdBOj9mBCDyVplpGtd/EPDBpB64oQv7xdwQD
+        chDQVl3Pl3QvMNKokmvNVBTyWM1zOr3D7YSYZxEUB/ti6Pvx0u1l2yBew4b7xV1mnSRfp9HdZr3+
+        Y3nd28qba/U81vxUcZtRhoXYimvhazMdjjURnrpPV1dXTSZ4+ywphPaYRRwNWK7jDOW1L/2bnofK
+        seC2ff4sSP0Ez6Fc8cTbWWyBgDsX8LUHRxv7UYV63ZviLWxML2SOroUq/d0RA3Esp1RWLmR8ylvx
+        9DDfgTYfjSxjccHxvEFUWBlLxAme7OQBKPKFPys6GraHHpF7JuYCIePtlLRwvIa5rkAiqlxtvGbI
+        EZISiRZoUCUht3iUBtNgejmdXU6Dv69v5sG7+c+zb5hTV+iB/WDOzXx6TXOq2mRHpiD9d7GCT+hK
+        Pd8I2n9jUscJcozJBsivA2J+oJf0A0Scw+n3ovY8XVb7d/vLMNhOpgpRoU7rH+dGPuLzdKfGilVd
+        4nQwuOYWjw3ULMNQX5f1gIyb0GWSydzqGj1HGqm0ehCxNeOxIZONJq7lUu4spBpy2y1wj/xBeCG1
+        Vl2z0TUXujyMtmHX8Uyk4VEuhgFVibLTcLwNGYvSbM3gGgC05dH0HRO0XxKx4HVuQ/dWonYqerJo
+        sMIdhS5gBup5Ubu166w4g5Cr9nukrOg+o+FiRVGFzjusWgrqzwKFrKLWofm35nC99gLrF7tf2iFs
+        haqx3V+0oOt0d02CAEerx2kcojjsiH2DeNwWeusT19Fbn/itT/zWJ3addrr+DvSJS2HXaJiOsun4
+        edtn66fv79ZlERUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:02 GMT
+      etag:
+      - W/"1d646cedf9d59690a37b74469a94206a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:83372AB:9C18A0D:5ED66102
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3140'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VUXY/aMBD8K8jPQL4TiFSpregDJyWnqlxRqCq0jjfEIU5QbE5HEf+9a9GT2jeQ
+        6Escz3o9u7OTnJmugaWMB1EkIvQ5LyO/8hPBKw/diAdeHICbiMrlESEBG7OuF7iVgpKyRRF/9eeG
+        r1s3a4rwebE80Xp6Vstf+er7Pl+/nAr11OSrJ5U1Yl+o4m2z+uQVTfaWN3mdLcR+03yW+dri2Qe6
+        /Di0dHFtzEGnjgMHOd1JUx/5tOyVM+Ch145CA9r0A05ayScGtdGOfW636iSAYmgcSnIoQ0mK3dFa
+        bVS7/beEv+hvIb6S3sMJR1P3A0vPrAOF1Py3GmoYRl9eh74jRVCBtJrQnAieooU/7ixoNaED1LNN
+        813fnbjxxPVXXpj6QRrNN+wyZteKDP5HCjMgVXD+Y6UkwVkchFUYcDcoqyqeizAJo9LlmCBWgc+x
+        BB5Hj522rUE7N3OTMAq1hp2VbtlJI6EdWfccoNwTOrrKRjUeYMDOaJb+eG/QSwBCL5xFAuMwwTki
+        0lfj8nI283zhzX2vAohF+dgG3+18B/vD7Hwz5+XnmL3iICtZgpHkX3LFdY/0w6ig1ThmA4K2IXbs
+        tNx1FBkz+wLmONA4umPbWtlPbQ+UZLeXy28hx/YRqAQAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:02 GMT
+      etag:
+      - W/"7f97cc3f835b0bfad3942b3f0910f52d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8337343:9C18AC5:5ED66102
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3139'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/datapackage.json?ref=b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA82Tb2vbMBDGv4tft5H/VHYcGKMxW3FgHWtf1AmFIFlnW6ksGUtpyEq/e89tYF2W
+        F1kYoy8sjjvrnh/PnZ48zVrwJp5gjnWsfGA1jFbWaO/M65hrDldsw7AwhmRcipSJJIU0DCPuj2Ma
+        JDEVAmJIqJ/66ZjHPray8ieKpPGZt+4VXm2c6+yEENbJUS1ds+aj0rSkh85Y0oJj1pkezpXk5w6s
+        s2Q4l8t2O2BacKQ02oHGwj735x6qTzyiVFAIOS9pWIWJ4FUAPuVREEfMT0Tlc4qZCMka16rl71Dv
+        gI5B4cpwcqziH7yIgHp7BCfbgq3IwGPJXwxHmI1Whok9iJ5tdrNZW+h3hr+O6ShXjhzBIUPcthtW
+        spIK0J6dMiZgY+o8m63nd4HKVxi3AV1cffXnxbUSWW7zy9f6dlFcP4pitloU3+R3OeWZvKzvdZ5N
+        kyHKs+GbbebFjXnrctOIqy+PvFC/bt7SVRnN5dv/0/ReD1Hxo8MIkUCXRkhdIxPHdYwvMLdUUj9Y
+        b/LkWVDVh9px3Ip/wXPScg3v6534/31bz88v2OIkoeAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:02 GMT
+      etag:
+      - W/"8e78cd9ad79e9223b08651765dde6e7509098b60"
+      last-modified:
+      - Tue, 02 Jun 2020 14:23:59 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:83373DA:9C18B76:5ED66102
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3138'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"message": "My nice little tag", "tag": "version-1.0",
+      "type": "commit", "object": "b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags
+  response:
+    body:
+      string: !!python/unicode '{"node_id":"MDM6VGFnMjY4ODIyMjYyOjYwZmMyYmM0ZDVkNGI0N2ZkOTFkNGMyMzI0MGEwOTVhYTg5MDUxYmM=","sha":"60fc2bc4d5d4b47fd91d4c23240a095aa89051bc","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/60fc2bc4d5d4b47fd91d4c23240a095aa89051bc","tagger":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:03Z"},"object":{"sha":"b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3","type":"commit","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/b355d5e2bbc52f27dbf1e05b3163a07df0b5f1e3"},"tag":"version-1.0","message":"My
+        nice little tag","verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '697'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:03 GMT
+      etag:
+      - '"daf073275fd3fe7c1e1bd706a7230b66"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/60fc2bc4d5d4b47fd91d4c23240a095aa89051bc
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8337464:9C18C11:5ED66102
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3137'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"sha": "60fc2bc4d5d4b47fd91d4c23240a095aa89051bc", "ref":
+      "refs/tags/version-1.0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs
+  response:
+    body:
+      string: !!python/unicode '{"ref":"refs/tags/version-1.0","node_id":"MDM6UmVmMjY4ODIyMjYyOnJlZnMvdGFncy92ZXJzaW9uLTEuMA==","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0","object":{"sha":"60fc2bc4d5d4b47fd91d4c23240a095aa89051bc","type":"tag","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags/60fc2bc4d5d4b47fd91d4c23240a095aa89051bc"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '391'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:04 GMT
+      etag:
+      - '"78701f2a5a557d52974fcec48cd82bc6"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:833756A:9C18D1A:5ED66103
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3136'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:04 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:833773A:9C18F57:5ED66104
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3135'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YUW/bNhDHv4tfl0SuknmpgaJ9aFd0QBZg2EPXF4GSaImxJGokZc8R8t37P1Ky
+        ZM9JHIePeUlsmvzd8Xh3PF47EelkHs6ur8MwnIVnk0qmPKKxyc3nL+vb4o8i+fr+nn3/a5VUy82f
+        d9nVzd03/P/2YYLJrOSYabg2UVRuUmaY5gY/LJqiiLpfS45RIxU/L0R8TnN18P8VtRIrZkBbsELz
+        s4lcV1xN5u2kkJmoIOQABoJI09ls+lsYXr/bU35zu3y/+RH+3rDvdZ5+LVbx3T/hzedkc3OX/Yel
+        DPKYihpVgJ4bU+t5ELhBfXmRCZM3caO5SmRleGUuElkGTdAL+7j6cAVIpjqMNRkG9nC16EhuOXA6
+        OLyT3JTFnjJOB7vy8JqFLAq5BnN/F0eKDbYAOjMLE1X2OhgAbSBNzmFabPeBjCRw5qdS7eI2oH/w
+        S8JpHJvi6anAbjmUJBd7aAPFa2m5TawTJWojZHWyujsQQKXKWCXu2auggGiwSNGTFbOLAeErOPPJ
+        FLe6DWy4Jhsym+IJFyucx+vIexiAzaam7HI7siCdkjA8YmlJScHmioczRO8LY+dAAkr59vAn8wr5
+        iyJCLbcJ6cnAtsY9FKQHBBH1GfsfjUMAAwarLPnGG5NYbYC/XbwlSAwsloohiXsTsgNtg/FXcirD
+        WelNloUBmkvpz/IWBqjQuuFH+f7xp2qZOuiDrWrK2GXSY0LseDGOhj0wrUVWce7N4ltgG/SXQKxY
+        leT+RPS8NnCfrNewzNsWiAVkXMjYGxMXemCBbaBz5q5GE/nUmiQQb0eA4guvWyDeVoBRHv3Gqk/A
+        LR63tYELedO/5wVtdwIFq7KGZf4kbIF0WaFUydj9sxXa8TE7EIGn0lSJuPGbmAcm7cAVRcg//o5g
+        QA4CbNX1dEn3AiONKjlrprIUz9U8x9M73E6IeRZBcbAvhr4/X7q9bBvEa4PhfnGXWSfJ12l0t1mv
+        /1he97by5lo9L2h/qZnJKcNCbM0U97WZDhe0MZ66DxcXF23OmX2WlFx5zCKOBixTSY7y2pf+bc9D
+        5VgyY58/C1I/xXOokCz1dhZbIODOBXztwdHGflSjXvemuIWN6aUo0LWQlb87YiCO5VTSiIVIjnkr
+        Hh/mO9D2oxZVws8YnjeICiMSgTjBk508AEU+92dFR8P20CNyz8SCI2S8nZLijtcGriuQ8rqQG68Z
+        coSkRKI4GlRpxAwepeE0nJ5PZ+fT8O93V/Pwcv7r7AfmNDV6YI/MuZpPL2lO3ej88SlXNAXpv4sV
+        fEJX6ulG0P4bkzpOgGidD5BPA2J+oJf0CCIp4PR7UXuaLqv9u/1lGGwnlyWvUaf1j3Mt7vF5ulNj
+        JbKpcDoYXDODxwZqlmGor8t6QM505DLJZG5Ug54jjdRK3vHE6PHYkMlGE9diKXYWUg257Ra4R/4g
+        vBRKya7Z6JoLXR5G27DreKZCs7jgw4CsedVpON6GSHilt2ZwDQDa8mj6jgnsl5QvWFOYyL2VqJ2K
+        niwarHBHrkqYgXpe1G7tOivOIOSq/R4pK7rPaLgYXtaR8w4jl5z6s0Ahq8h1pP9tGFzPXmD9YveL
+        HcJWqBrb/UVxuk5316QIcLR6nMYRisOO2DeIx22htz5xE7/1id/6xG99Ytdpp+vvQJ+44maNhuko
+        m46ft322fvgJdh6D3hUbAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:04 GMT
+      etag:
+      - W/"5a02d33c8609ea38835eddca14c87cae"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:03 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:83377FF:9C19046:5ED66104
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3134'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:24:05 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C988:2668C:8337891:9C190E3:5ED66104
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3133'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_no_package.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_no_package.yaml
@@ -1,0 +1,243 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:39 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98F:160FE:5CDE107:6DC1A7C:5ED66127
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3047'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:39 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98F:160FE:5CDE14B:6DC1AB0:5ED66127
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3046'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIAwAwK+Yuho6uPEAR79gEBogAUqgsBj/rrfeA5l6N55Aw8myHDyKgw0c
+        25GpiJHI5Rot/R9EateIjiYlrtSUjxLGrSxnnDs2qtxx9STwfutuZdhYAAAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:40 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98F:160FE:5CDE1A5:6DC1B1B:5ED66127
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3045'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/backend/cassettes/TestGitHubBackend.test_tag_update_no_tag.yaml
+++ b/tests/backend/cassettes/TestGitHubBackend.test_tag_update_no_tag.yaml
@@ -1,0 +1,1525 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VTTW+cMBT8K5XPu2tgF9oiVcmhPfTQSFXTqsllZcABV8a2bMNqg/LfOzbko3uo
+        xAnzPDNveLyZiNStUKQkruOj1YpsiGhIWeR5sd8QpRt+DO/k2+fvxa/fN7L+c5fe3N49AsdG5pk9
+        DlbivvPeuJLSueiyXSt8N1SD47bWynPld7Xu6UCj8tX46QCF1i4asQUKF1pGLDIzF1qOvvrsfC8v
+        us9NI/oV96Cl1CdwL63+R56+kOBqPgvVrhcAaaLadxxzgv2n8NHC+VVWImGi4YF/ESQc5m55s8bO
+        QoGZk4KPiVpudNQaKldbYbzQapWtf4gQ0rZlSjyy1UIgOvCDoVUGIgFEPmK7VjFnxkSNFSOrz2EM
+        ltdcjJjperULKsT82XAs9E/88TBh4fmRNX2I2QOTjiNXrA+AHx3rmH33ZQke1tYwdY4X2hjRxzhW
+        SOgSsJAva3etpaFIcSl1HQcOwFdnGZdhHj0TIZIuqu9irK/bUAzBAKATlrNKwoEapEQHoZ+P/iS8
+        X5Z1NjlDzFBJUR/nkZeHYkOWSlxOUqbpc0yQM1LmhzepweuG1GjpMV7m4SxLko/bZL/N0tu0KLP3
+        Zf7hHr4G07zFZMk2ybf7JGD2B8DuydNf1BG5+bAEAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:31 GMT
+      etag:
+      - W/"3c5910f000ba8e3776b6f7f77774b03f"
+      last-modified:
+      - Sat, 30 May 2020 16:34:27 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425C73C:4EDB18B:5ED6611F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3065'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VTy27bMBD8F51t65HEiQUU7SFtT0YuPbS5ECtqJdGmSJYPua7hf+/qkUZ5AAVc
+        n8wVZ3Z3ZniKpK6FivKoRQ/Oa4tLKYqlR+ddtIhEGeXrdXKbZXfpIlK6RNaXou395+PDfnN8zL4E
+        +G6a8qvsit2PbHvPj9td/YugwUq62HhvXB7HYMSqFr4JxYrrNta2dvH7LS0a7dhF6HjAUm/sUPlL
+        SUYwsTRa7y8lGbC9gM4FvJRkBBNLi22B9lKaCX0iwXuaMxGaUEjB2f/xviSZ00MHHuxrE4eiu5py
+        EBxarpUnp4ZIhPgpaB+7D9c0Y4mOW2G80JRPFaTs1WQdWlEJpBBWIB2SS+AYxQmU+A39XWas3iGn
+        +ObehunCEAxB8T6++TxtMUYnp5RPhVr0TyBPFlGlpdQH0n92EqoeTo1v5as9ZzF/P+HcIngsGXh6
+        IFmSJcvkZpndfUuv8jTNk/Sxfz2m/OcdfzRIDA+z5QnptQdJWwqSG9m0Fk2qD4p6vq0/VZ73LYXb
+        s+CgJnYCclofCm2B5BslKISUJADDFkT/yF0DDdgVdlarTzS3NgJUb+rgYgVB+nGQyQG0LUV78DUi
+        LcpZwjkoNurzjBD410t/0KwCTpPQ559BWGwpPwwVFHKWCSOBuE+RgrZXqLKI1MMZ4HTc3K5v1tn1
+        ZkNWv1QpTehHftN6JJUjl6gxJWL6l5zPfwAvks/YMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:32 GMT
+      etag:
+      - W/"7be9b7007def9be9ee27bc58f77ffe24"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425C77C:4EDB1CC:5ED6611F
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3064'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "test__mydataset"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/orgs/metastore-lib-tests/repos
+  response:
+    body:
+      string: !!python/unicode '{"id":268822417,"node_id":"MDEwOlJlcG9zaXRvcnkyNjg4MjI0MTc=","name":"test__mydataset","full_name":"metastore-lib-tests/test__mydataset","private":false,"owner":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/metastore-lib-tests/test__mydataset","description":null,"fork":false,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset","forks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/forks","keys_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/keys{/key_id}","collaborators_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/teams","hooks_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/hooks","issue_events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/events{/number}","events_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/events","assignees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/assignees{/user}","branches_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches{/branch}","tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/tags","blobs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs{/sha}","trees_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees{/sha}","statuses_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/statuses/{sha}","languages_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/languages","stargazers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/stargazers","contributors_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contributors","subscribers_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscribers","subscription_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/subscription","commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/commits{/sha}","git_commits_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits{/sha}","comments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/comments{/number}","issue_comment_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues/comments{/number}","contents_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/{+path}","compare_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/compare/{base}...{head}","merges_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/merges","archive_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/downloads","issues_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/issues{/number}","pulls_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/pulls{/number}","milestones_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/milestones{/number}","notifications_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/labels{/name}","releases_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/releases{/id}","deployments_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/deployments","created_at":"2020-06-02T14:24:32Z","updated_at":"2020-06-02T14:24:32Z","pushed_at":"2020-06-02T14:24:33Z","git_url":"git://github.com/metastore-lib-tests/test__mydataset.git","ssh_url":"git@github.com:metastore-lib-tests/test__mydataset.git","clone_url":"https://github.com/metastore-lib-tests/test__mydataset.git","svn_url":"https://github.com/metastore-lib-tests/test__mydataset","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true},"allow_squash_merge":true,"allow_merge_commit":true,"allow_rebase_merge":true,"delete_branch_on_merge":false,"organization":{"login":"metastore-lib-tests","id":66072281,"node_id":"MDEyOk9yZ2FuaXphdGlvbjY2MDcyMjgx","avatar_url":"https://avatars3.githubusercontent.com/u/66072281?v=4","gravatar_id":"","url":"https://api.github.com/users/metastore-lib-tests","html_url":"https://github.com/metastore-lib-tests","followers_url":"https://api.github.com/users/metastore-lib-tests/followers","following_url":"https://api.github.com/users/metastore-lib-tests/following{/other_user}","gists_url":"https://api.github.com/users/metastore-lib-tests/gists{/gist_id}","starred_url":"https://api.github.com/users/metastore-lib-tests/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/metastore-lib-tests/subscriptions","organizations_url":"https://api.github.com/users/metastore-lib-tests/orgs","repos_url":"https://api.github.com/users/metastore-lib-tests/repos","events_url":"https://api.github.com/users/metastore-lib-tests/events{/privacy}","received_events_url":"https://api.github.com/users/metastore-lib-tests/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":0}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '6911'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:33 GMT
+      etag:
+      - '"e1263956da9ffd18e6662b592e59659c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - public_repo, repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425C7C7:4EDB21F:5ED66120
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3063'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: !!python/unicode '{"content": "IyDCr1xfKOODhClfL8KvClRoaXMgaXMgYSBkYXRhcGFja2FnZSByZXBvc2l0b3J5IGNyZWF0ZWQgYnkgW2BtZXRhc3RvcmUtbGliYF0oaHR0cHM6Ly9naXRodWIuY29tL2RhdG9waWFuL21ldGFzdG9yZS1saWIp",
+      "message": "Initialize data repository"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PUT
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md
+  response:
+    body:
+      string: !!python/unicode '{"content":{"name":"README.md","path":"README.md","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","html_url":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md","git_url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","download_url":"https://raw.githubusercontent.com/metastore-lib-tests/test__mydataset/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/contents/README.md?ref=master","git":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e","html":"https://github.com/metastore-lib-tests/test__mydataset/blob/master/README.md"}},"commit":{"sha":"65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff","node_id":"MDY6Q29tbWl0MjY4ODIyNDE3OjY1YjFkMmI3YWVmY2FmM2U2MWViN2RmNjNmZDNkZDY4YmYxMzJjZmY=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:33Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:33Z"},"tree":{"sha":"1f09df237782471458ed229a7bb48c7f238d73e0","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/1f09df237782471458ed229a7bb48c7f238d73e0"},"message":"Initialize
+        data repository","parents":[],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1785'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:34 GMT
+      etag:
+      - '"097aff91967dd4831d43bd8589cc3571"'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425C96A:4EDB40A:5ED66121
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3062'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/branches/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1X207bQBD9FeTngBM7OCFS1T4EJColVVsKNVUVre1xvGEv7u46ECL+vTOOuSQP
+        FCP6xksU7/rMnrmdHa89xSR4I08y68B4HS/VUnLnjdaeLRhuRIdJLwuSAYM8ZXkIUQ+SQZZHYZ6F
+        WRYNk7wXBmmeI1TpDGY8Q9BkHEdfgyOXXIjuZBH3v4xPV9PxcfhlEffixcnVRJ6G8cW5jIMTOQl+
+        BJOLcz4NvsnpYiovx9Ory3Hcj2V8M7n9vLiU8YctXqxyhTbEsOH+vWAFM3vHS6MVvgmScYEkkD8u
+        HwAtf5rT4gE6hy9kzJHLQTfo7nej/W5w1uuPgv4oDC+9u/sIUDT+2xESrGVzInGquONM8FvYQ1ps
+        z0CpLXfarJCoM4Dv3Geil3ePsjwIB4Nh0B/0+odDyILgiA2SpD9MB7gzzAYhdBFYGQpA4VxpR77P
+        Sn4w566oEgqAXx/hS3CYcm1gX/Bk34F11qff2UyuiIkF5yPIJw7Wf/HZGL83PHxTjNZvUYQEAeVm
+        qa4UlnG34y3B8JynzHEsD4zm5hmwTnMmLHQ8A8zSllcpy+cKdzoe/WGuMhh/VQnR8Uq2EpohiB7v
+        3s7NV7hYOClm21F+kt6XJHZz6CvCanfOfXVptXXbb/JqMTePAiD0nFPibFF3Oe6R/ESHh1G4LUdf
+        o/OfU5Gi/EzP4luyscQaN7ve1Is2aLqlsmBSrRyWU904FQYMLX9cfuijhblpbNSK96+mI1vWf+T5
+        fA4f38u1EPoasbtUt3t6y7z/AEJWm/9czdsbQNDa164AjBPSvyOnOepEG0s1YI1KgsrCMzJhMcQG
+        sjZGGgiSuVbIY11LWG2rSmxqeEmt3YrWFhANaTNnit/WGtHKEAKpJGtNbeNSDUAgLLG6WiE3iLVf
+        Gr5k6YrCYCAFvsSYtre2A0VjblXSxfQDM04R5g5mLJPUZrVc7l6Q7y3YXKvvLdiuc95bcHNpoZht
+        de+LWrBkhnTDG/36jQ05E1xd4QNOiiDyt5j8EsNUWuDg9/BdQBfWE8stBw6aIu9tIeHSaAepezKD
+        NSvNiAaKJWJrQvtTcbo08CZwlZ0htXTjMKhcmxTqkU+g/BFHXX+N1Df3TROjxzPxhOd1+uXj8U6Q
+        UJFrr8iHu7+6C5QjWQ0AAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:34 GMT
+      etag:
+      - W/"f42a7f644a96326e2f7e2d94278ef0ea"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CAC9:4EDB585:5ED66122
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3061'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"tree": [{"content": "{\n  \"name\": \"mydataset\", \n  \"resources\":
+      [\n    {\n      \"path\": \"data/myresource.csv\"\n    }\n  ]\n}", "path": "datapackage.json",
+      "type": "blob", "mode": "100644"}], "base_tree": "1f09df237782471458ed229a7bb48c7f238d73e0"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees
+  response:
+    body:
+      string: !!python/unicode '{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"699248ebc0140bc7bccffef45504128c2e00c96e","size":120,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/699248ebc0140bc7bccffef45504128c2e00c96e"},{"path":"datapackage.json","mode":"100644","type":"blob","sha":"8e78cd9ad79e9223b08651765dde6e7509098b60","size":96,"url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/blobs/8e78cd9ad79e9223b08651765dde6e7509098b60"}],"truncated":false}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '677'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:35 GMT
+      etag:
+      - '"83e389f7548749b55e3e791146579e48"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CB1B:4EDB607:5ED66122
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3060'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7VTTY+bMBD9K5HPJIBhgSBV6oFdKZVg1a+NSFVFBo+DWQyRbVbNRvnvHTc97N52
+        pfZi4XnMvDdvxmdiOkZyktw0IadNykC0TESQhNCkXCSR4BHnSdaIMKKtEMQj48RhLzkmlUWdfKZr
+        22yHoOzr+L7YnKriNrrv67Du7x5LtYnq7YOq6Z0q6Xdabh9kRb+oqq/Urqged0Ud16r+VT5/6neq
+        /oDFZz1g4c7ao8l9nx3l6iBtNzerdlK+huNkfAWWGTtpWA6yWVow1vju3O/ViTPEwPqY5GOGkoi9
+        o7XOqmH/WsIL+rcQX0nfw8lm202a5GcyMgXY/NeOdUwvbp/0NKIjoJh0nuCcMLwCF/54cEHnCf6A
+        Pbs0GtBgGSTLgH4L45zGeRTtyMUjV0UW/iOF1YAKzn9XKRTBmgsapWlG4zSMbzLglK5Z2jRx1qaI
+        ZDyNIPi303YajP9mbjRGgTHs4KzbjNJKNshnWLgFWvzZM4krdkKNR6ZhtIbkP3565Am0FLJlVuJs
+        sOPrHfAxCDYY8IgGZhxE5tHIw4iIR9wHs7NGqnEeBlfyNEwMk9z1cvkNfZV9f4QDAAA=
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:35 GMT
+      etag:
+      - W/"713c0297c672102b36bc9023d9442d7d"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CBC1:4EDB6BB:5ED66123
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3059'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"parents": ["65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff"],
+      "message": "Initial datapackage commit", "tree": "77e8634f43b03cff69d4745c0be7eef32becab65"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: POST
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits
+  response:
+    body:
+      string: !!python/unicode '{"sha":"0f42abe88409e287274087ae359144dd055dd235","node_id":"MDY6Q29tbWl0MjY4ODIyNDE3OjBmNDJhYmU4ODQwOWUyODcyNzQwODdhZTM1OTE0NGRkMDU1ZGQyMzU=","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0f42abe88409e287274087ae359144dd055dd235","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/0f42abe88409e287274087ae359144dd055dd235","author":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:35Z"},"committer":{"name":"Shahar
+        Evron","email":"shahar.evron@gmail.com","date":"2020-06-02T14:24:35Z"},"tree":{"sha":"77e8634f43b03cff69d4745c0be7eef32becab65","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/trees/77e8634f43b03cff69d4745c0be7eef32becab65"},"message":"Initial
+        datapackage commit","parents":[{"sha":"65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff","url":"https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff","html_url":"https://github.com/metastore-lib-tests/test__mydataset/commit/65b1d2b7aefcaf3e61eb7df63fd3dd68bf132cff"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-length:
+      - '1192'
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:36 GMT
+      etag:
+      - '"094c8843c9304df3d09627594ce7466c"'
+      location:
+      - https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/commits/0f42abe88409e287274087ae359144dd055dd235
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 201 Created
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CC0F:4EDB734:5ED66123
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3058'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWit1cVHmQCmS6UQQXSI7PmNXcRzZ10qh6n/nKkYWBpa3vPvu
+        fReWwbH6loV70LbwqAtCZndsTBa6YKlVjZJvsY3q+LHeN7v5tXkU+/FlOIzqrLetPzyrs3l/+rLb
+        dibwlAeCPOJUas71FJafAf3JLPsUeYYp0QggzaQMiyGYBULBwm/ZdXG2mjpAThBd//ZK5gg9svrC
+        itc0JO9NZVdmo8H12gmQFZiNdVI4K6yVD8ZVYtU7R2Y4T0AEecSA/2v687PwP9tcr9+LvLeOfQEA
+        AA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:36 GMT
+      etag:
+      - W/"10c69d73cea1276f7dd32b40775711e9"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:33 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CC9C:4EDB7D3:5ED66124
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3057'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"sha": "0f42abe88409e287274087ae359144dd055dd235"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: PATCH
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/heads/master
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA62OMU/DMBCF/4tnWofEIWnmlAKS6UQQXSK7vmJXcRzZ10qh6n/nKkYWBpa3vPvu
+        fRcW4cCaWyZuQZnEvUoIkd2xMRjonaFWtvLhzXdeHj/Etn2eX9t1sR1fht0oz2rT2d2TPOv3xy+z
+        6WYCT3EgyCJOqeFcTW756dCe9HIfPI8wBRoBpJkQYTE4vUBImPgt+97PRlEHyAmi699eQR9hj6y5
+        sGQVDWUHkSsNdS2yFeR1lVciqysFRbm6F8KYrCyNyYuSzHCegAjy8A7/1/TnZ+J/trlevwGORlCe
+        fQEAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:37 GMT
+      etag:
+      - W/"1c5e9b21e4e01c5104bb9d171099f296"
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CCE4:4EDB81F:5ED66124
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3056'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:37 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CDAD:4EDB91C:5ED66125
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3055'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDZKsgcX2sO2iBdIAxR529yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFl7f3obh1eXN2aSSKY9obHL35bf1ffFnkXz9+MC+/71KquXm
+        r0V2dbf4Y3r3Lfk0wWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTp9fX0JgxvL/eU39wvP25+hr837Hudp1+LVbz4Ed59STZ3i+xf
+        LGWQx1TUqAL03Jhaz4LADeoPF5kweRM3mqtEVoZX5iKRZdAEvbDPq09XgGSqw1iTYWAPV4uO5JYD
+        p4PDO8lNWewp43SwKw+vmcuikGsw93dxpNhgC6AzszBRZW+DAdAG0uQcpsV2H8lIAmd+KtUubgP6
+        B78knMaxKZ6eCuyWQ0lyscc2ULyWltvEOlGiNkJWJ6u7AwFUqoxV4oG9CQqIBosUPVkxuxgQvoIz
+        n0xxq9vAhmuyIbMpnnCxwnm8jbyHAdhsasou9yML0ikJwyOWlpQUbK54PEP0vjJ2DiSglG8PfzKr
+        kL8oItRym5CeDWxr3ENBekAQUV+w/9E4BDBgsMqSb7wxidUG+NvFW4LEwGKpGJK4NyE70DYYfyWn
+        MpyV3mRZGKC5lP4sb2GACq0bfpTvH3+qlqmDPtiqpoxdJj0mxI4X42jYA9NaZBXn3iy+BbZBfwnE
+        ilVJ7k9Ez2sD98l6Dcu8bYFYQMaFjL0xcaEHFtgGOmfuajSRT61JAvF2BCg+97oF4m0FGOXRb6z6
+        BNzicVsbuJA3/Xte0HYnULAqa1jmT8IWSJcVSpWMPbxYoR0fswMReCpNlYgbv4l5YNIOXFGE/OPv
+        CAbkIMBWXc+XdK8w0qiSs2YqS/FSzXM8vcPthJhnERQH+2Lo+8ul2+u2Qbw2GO4Xd5l1knydRneb
+        9fqP5XVvK2+u1fOC9peamZwyLMTWTHFfm+lwQRvjqft4cXHR5pzZZ0nJlccs4mjAMpXkKK996d/2
+        PFSOJTP2+TMn9VM8hwrJUm9nsQUC7lzA1x4cbexHNep1b4pb2JheigJdC1n5uyMG4lhOJY2Yi+SY
+        t+LxYb4DbT9rUSX8jOF5g6gwIhGIEzzZyQNQ5HN/VnQ0bA89IvdMLDhCxtspKe54beC6AimvC7nx
+        miFHSEokiqNBlUbM4FEaTsPp+fT6fBp+u7yahVezD+FPzGlq9MCennNNc+pG509PuaEpSP9drOAT
+        ulLPN4L235jUcQJE63yA/DogZgd6SU8gkgJOvxe1p+my2r/bX4fBdnJZ8hp1Wv841+IBn6c7NVYi
+        mwqng8E1M3hsoGYZhvq6rAfkTEcuk0xmRjXoOdJIreSCJ0aPx4ZMNpq4Fkuxs5BqyG23wD3yB+Gl
+        UEp2zUbXXOjyMNqGXcczFZrFBR8GZM2rTsPxNkTCK701g2sA0JZH03dMYL+kfM6awkTurUTtVPRk
+        0WCFO3JVwgzU86J2a9dZcQYhV+33SFnRfUbDxfCyjpx3GLnk1J8FCllFriP9T8PgevYC6xe7X+wQ
+        tkLV2O4vitN1ursmRYCj1eM0jlAcdsS+QTxuC733iZv4vU/83id+7xO7Tjtdfwf6xBU3azRMR9l0
+        /Lzts/Xjfyd1lh8VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:37 GMT
+      etag:
+      - W/"a2a44fd20d905c023e373fd0fa702e2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CDFF:4EDB969:5ED66125
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3054'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:37 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CE44:4EDB9CB:5ED66125
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3053'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDZKsgcX2sO2iBdIAxR529yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFl7f3obh1eXN2aSSKY9obHL35bf1ffFnkXz9+MC+/71KquXm
+        r0V2dbf4Y3r3Lfk0wWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTp9fX0JgxvL/eU39wvP25+hr837Hudp1+LVbz4Ed59STZ3i+xf
+        LGWQx1TUqAL03Jhaz4LADeoPF5kweRM3mqtEVoZX5iKRZdAEvbDPq09XgGSqw1iTYWAPV4uO5JYD
+        p4PDO8lNWewp43SwKw+vmcuikGsw93dxpNhgC6AzszBRZW+DAdAG0uQcpsV2H8lIAmd+KtUubgP6
+        B78knMaxKZ6eCuyWQ0lyscc2ULyWltvEOlGiNkJWJ6u7AwFUqoxV4oG9CQqIBosUPVkxuxgQvoIz
+        n0xxq9vAhmuyIbMpnnCxwnm8jbyHAdhsasou9yML0ikJwyOWlpQUbK54PEP0vjJ2DiSglG8PfzKr
+        kL8oItRym5CeDWxr3ENBekAQUV+w/9E4BDBgsMqSb7wxidUG+NvFW4LEwGKpGJK4NyE70DYYfyWn
+        MpyV3mRZGKC5lP4sb2GACq0bfpTvH3+qlqmDPtiqpoxdJj0mxI4X42jYA9NaZBXn3iy+BbZBfwnE
+        ilVJ7k9Ez2sD98l6Dcu8bYFYQMaFjL0xcaEHFtgGOmfuajSRT61JAvF2BCg+97oF4m0FGOXRb6z6
+        BNzicVsbuJA3/Xte0HYnULAqa1jmT8IWSJcVSpWMPbxYoR0fswMReCpNlYgbv4l5YNIOXFGE/OPv
+        CAbkIMBWXc+XdK8w0qiSs2YqS/FSzXM8vcPthJhnERQH+2Lo+8ul2+u2Qbw2GO4Xd5l1knydRneb
+        9fqP5XVvK2+u1fOC9peamZwyLMTWTHFfm+lwQRvjqft4cXHR5pzZZ0nJlccs4mjAMpXkKK996d/2
+        PFSOJTP2+TMn9VM8hwrJUm9nsQUC7lzA1x4cbexHNep1b4pb2JheigJdC1n5uyMG4lhOJY2Yi+SY
+        t+LxYb4DbT9rUSX8jOF5g6gwIhGIEzzZyQNQ5HN/VnQ0bA89IvdMLDhCxtspKe54beC6AimvC7nx
+        miFHSEokiqNBlUbM4FEaTsPp+fT6fBp+u7yahVezD+FPzGlq9MCennNNc+pG509PuaEpSP9drOAT
+        ulLPN4L235jUcQJE63yA/DogZgd6SU8gkgJOvxe1p+my2r/bX4fBdnJZ8hp1Wv841+IBn6c7NVYi
+        mwqng8E1M3hsoGYZhvq6rAfkTEcuk0xmRjXoOdJIreSCJ0aPx4ZMNpq4Fkuxs5BqyG23wD3yB+Gl
+        UEp2zUbXXOjyMNqGXcczFZrFBR8GZM2rTsPxNkTCK701g2sA0JZH03dMYL+kfM6awkTurUTtVPRk
+        0WCFO3JVwgzU86J2a9dZcQYhV+33SFnRfUbDxfCyjpx3GLnk1J8FCllFriP9T8PgevYC6xe7X+wQ
+        tkLV2O4vitN1ursmRYCj1eM0jlAcdsS+QTxuC733iZv4vU/83id+7xO7Tjtdfwf6xBU3azRMR9l0
+        /Lzts/Xjfyd1lh8VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:38 GMT
+      etag:
+      - W/"a2a44fd20d905c023e373fd0fa702e2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CE94:4EDBA1B:5ED66125
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3052'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset/git/refs/tags/version-1.0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3JMQ6AIBAF0auYtVW3sPMAll7BIHzRRFgDi43x7tLNy7wUkLPxoIkW0WaWEh11
+        5MSWgKhGT4lrSVf9h+qdJ2aHB5fcSIM/9SjbYCXwM3IVJ+yZWw/tTV8bCdGCvh8u9SX+ZwAAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:38 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 404 Not Found
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CEE0:4EDBA7B:5ED66126
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-poll-interval:
+      - '300'
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3051'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/orgs/metastore-lib-tests
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VUy27bMBD8F55t65HEiQUE7SFtT0YuPbS5ECtpJdGmSJYPua6Rf+/qkUR5AAVc
+        nUSKM7s7M9SJSV0LxTLWogfntcWlFPnSo/OOLZgoWbZex9dpepMsmNIl8n6Lbe++HO/3m+ND+jXA
+        D9OU32SX736m27viuN3VvwkarKSDjffGZVEERqxq4ZuQrwrdRtrWLvq4pEWjHT8LHQ1Yqo0dKn8u
+        yQgmlkbr/bkkA7YX0LmA55KMYGJpsc3RnkszoU8keE/zSIQm5FIU/P94X5PM6aEDD/aticOmu5hy
+        EBzaQitPTg2RCNFT0D51t5fUY4musMJ4oSmfKkjZq8k7tKISSCGsQDokl8BxihMo8Qf6s9xYvcOC
+        4pt5G6YDQzAExfv47vM0xRidLH3Wphb9FcjiBau0lPpA+s9WQtXDqvGtfDPnLOYfJ7ywCB5LDp4u
+        SBqn8TK+WqY335OLLEmyOHnob48p/3nGHw0Sw/1seEJ67UHSlILkRj6NRZ3qg6Ka7/efdl7mLYXb
+        8+CgJnYCFjQ+5NoCyTdKkAspSQCOLYj+krsGGrAr7KxWn6lvbQSo3tTBxQqC9GMjkwNoW4r24Csj
+        LcpZwgtQfNTnBSHw2Ut/0LyCgjqhz7+CsNhSfjgqyOUsE0YCcZ+YgrZXqLKIVMMZKGi5uV5frdPL
+        zYasfq1SEtNDftN4JJUjl6gw/femt/jx8S8WCbrxMAUAAA==
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:38 GMT
+      etag:
+      - W/"ed0b36cfde07b6e43789085808853649"
+      last-modified:
+      - Thu, 28 May 2020 13:11:01 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - admin:org, read:org, repo, user, write:org
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CF20:4EDBAC9:5ED66126
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3050'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: GET
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YwW7jNhCG38XXJpGjDZKsgcX2sO2iBdIAxR529yJQEi3RlkSVpOw6Qt69/5CS
+        JbtO4jg85pLYNPnNcDgzHE47EelkFl7f3obh1eXN2aSSKY9obHL35bf1ffFnkXz9+MC+/71KquXm
+        r0V2dbf4Y3r3Lfk0wWRWcsw0XJsoKjcpM0xzgx/mTVFE3a8lx6iRip8XIj6nuTr4/4paiRUzoM1Z
+        ofnZRK4rriazdlLITFQQcgADQaTp9fX0JgxvL/eU39wvP25+hr837Hudp1+LVbz4Ed59STZ3i+xf
+        LGWQx1TUqAL03Jhaz4LADeoPF5kweRM3mqtEVoZX5iKRZdAEvbDPq09XgGSqw1iTYWAPV4uO5JYD
+        p4PDO8lNWewp43SwKw+vmcuikGsw93dxpNhgC6AzszBRZW+DAdAG0uQcpsV2H8lIAmd+KtUubgP6
+        B78knMaxKZ6eCuyWQ0lyscc2ULyWltvEOlGiNkJWJ6u7AwFUqoxV4oG9CQqIBosUPVkxuxgQvoIz
+        n0xxq9vAhmuyIbMpnnCxwnm8jbyHAdhsasou9yML0ikJwyOWlpQUbK54PEP0vjJ2DiSglG8PfzKr
+        kL8oItRym5CeDWxr3ENBekAQUV+w/9E4BDBgsMqSb7wxidUG+NvFW4LEwGKpGJK4NyE70DYYfyWn
+        MpyV3mRZGKC5lP4sb2GACq0bfpTvH3+qlqmDPtiqpoxdJj0mxI4X42jYA9NaZBXn3iy+BbZBfwnE
+        ilVJ7k9Ez2sD98l6Dcu8bYFYQMaFjL0xcaEHFtgGOmfuajSRT61JAvF2BCg+97oF4m0FGOXRb6z6
+        BNzicVsbuJA3/Xte0HYnULAqa1jmT8IWSJcVSpWMPbxYoR0fswMReCpNlYgbv4l5YNIOXFGE/OPv
+        CAbkIMBWXc+XdK8w0qiSs2YqS/FSzXM8vcPthJhnERQH+2Lo+8ul2+u2Qbw2GO4Xd5l1knydRneb
+        9fqP5XVvK2+u1fOC9peamZwyLMTWTHFfm+lwQRvjqft4cXHR5pzZZ0nJlccs4mjAMpXkKK996d/2
+        PFSOJTP2+TMn9VM8hwrJUm9nsQUC7lzA1x4cbexHNep1b4pb2JheigJdC1n5uyMG4lhOJY2Yi+SY
+        t+LxYb4DbT9rUSX8jOF5g6gwIhGIEzzZyQNQ5HN/VnQ0bA89IvdMLDhCxtspKe54beC6AimvC7nx
+        miFHSEokiqNBlUbM4FEaTsPp+fT6fBp+u7yahVezD+FPzGlq9MCennNNc+pG509PuaEpSP9drOAT
+        ulLPN4L235jUcQJE63yA/DogZgd6SU8gkgJOvxe1p+my2r/bX4fBdnJZ8hp1Wv841+IBn6c7NVYi
+        mwqng8E1M3hsoGYZhvq6rAfkTEcuk0xmRjXoOdJIreSCJ0aPx4ZMNpq4Fkuxs5BqyG23wD3yB+Gl
+        UEp2zUbXXOjyMNqGXcczFZrFBR8GZM2rTsPxNkTCK701g2sA0JZH03dMYL+kfM6awkTurUTtVPRk
+        0WCFO3JVwgzU86J2a9dZcQYhV+33SFnRfUbDxfCyjpx3GLnk1J8FCllFriP9T8PgevYC6xe7X+wQ
+        tkLV2O4vitN1ursmRYCj1eM0jlAcdsS+QTxuC733iZv4vU/83id+7xO7Tjtdfwf6xBU3azRMR9l0
+        /Lzts/Xjfyd1lh8VGwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      content-encoding:
+      - gzip
+      content-security-policy:
+      - default-src 'none'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 02 Jun 2020 14:24:38 GMT
+      etag:
+      - W/"a2a44fd20d905c023e373fd0fa702e2a"
+      last-modified:
+      - Tue, 02 Jun 2020 14:24:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 200 OK
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CF6C:4EDBB22:5ED66126
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3049'
+      x-ratelimit-reset:
+      - '1591110419'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - PyGithub/Python
+      authorization:
+      - fake-authz-header
+    method: DELETE
+    uri: https://api.github.com/repos/metastore-lib-tests/test__mydataset
+  response:
+    body:
+      string: !!python/unicode 
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      content-security-policy:
+      - default-src 'none'
+      date:
+      - Tue, 02 Jun 2020 14:24:39 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      server:
+      - GitHub.com
+      status:
+      - 204 No Content
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      - Accept-Encoding
+      x-accepted-oauth-scopes:
+      - delete_repo
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-github-media-type:
+      - github.v3; format=json
+      x-github-request-id:
+      - C98C:3CF32:425CFC2:4EDBB86:5ED66126
+      x-oauth-scopes:
+      - delete_repo, repo
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '3048'
+      x-ratelimit-reset:
+      - '1591110420'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/backend/test_github_backend.py
+++ b/tests/backend/test_github_backend.py
@@ -46,9 +46,27 @@ def backend():
         backend.cleanup__()
 
 
-# @pytest.mark.vcr()
-@pytest.mark.skipif(not (os.environ.get('GITHUB_TOKEN') and os.environ.get('GITHUB_OWNER')),
-                    reason="GITHUB_TOKEN or GITHUB OWNER is not set")
+@pytest.fixture(scope='module')
+def vcr_config():
+    have_github_access = bool(os.environ.get('GITHUB_TOKEN') and os.environ.get('GITHUB_OWNER'))
+    force_record = bool(os.environ.get('DISABLE_VCR'))
+    if have_github_access:
+        if force_record:
+            mode = 'all'
+        else:
+            mode = 'once'
+    else:
+        mode = 'none'
+
+    return {
+        "filter_headers": [
+            ('authorization', 'fake-authz-header')
+        ],
+        "record_mode": mode
+    }
+
+
+@pytest.mark.vcr()
 class TestGitHubBackend(CommonBackendTestSuite):
 
     ID_PREFIX = 'test__'

--- a/tests/backend/test_github_backend.py
+++ b/tests/backend/test_github_backend.py
@@ -22,8 +22,8 @@ class CleaningGitHubStorage(GitHubStorage):
         self._packages = set()
         self._log = logging.getLogger(__name__)
 
-    def create(self, package_id, metadata, change_desc=None):
-        package = super(CleaningGitHubStorage, self).create(package_id, metadata, change_desc)
+    def create(self, package_id, metadata, author=None, message=None):
+        package = super(CleaningGitHubStorage, self).create(package_id, metadata, author, message)
         self._packages.add(package.package_id)
         return package
 


### PR DESCRIPTION
This resolves #4 by allowing users to specify an author when updating or creating a tag. Authors are preserved and returned as part of the revision / tag info. 